### PR TITLE
add helm charts

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: amazon-cloudwatch-agent-operator
+version: 0.1.0
+description: CloudWatch Agent Operator Helm chart for Kubernetes
+type: application
+home: https://cloudwatch.aws.amazon.com/
+sources:
+  - https://github.com/aws/amazon-cloudwatch-agent-operator
+maintainers:
+  - name: jacksondaw
+  - name: lisguo
+icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
+appVersion: 0.1.0

--- a/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -1,0 +1,2508 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-agent-operator
+  name: amazoncloudwatchagents.cloudwatch.aws.amazon.com
+spec:
+  group: cloudwatch.aws.amazon.com
+  names:
+    kind: AmazonCloudWatchAgent
+    listKind: AmazonCloudWatchAgentList
+    plural: amazoncloudwatchagents
+    shortNames:
+    - otelcol
+    - otelcols
+    singular: amazoncloudwatchagent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Deployment Mode
+      jsonPath: .spec.mode
+      name: Mode
+      type: string
+    - description: CloudWatch Agent Version
+      jsonPath: .status.version
+      name: Version
+      type: string
+    - jsonPath: .status.scale.statusReplicas
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.image
+      name: Image
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AmazonCloudWatchAgent is the Schema for the AmazonCloudWatchAgents
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AmazonCloudWatchAgentSpec defines the desired state of AmazonCloudWatchAgent.
+            properties:
+              args:
+                additionalProperties:
+                  type: string
+                description: Args is the set of arguments to pass to the CloudWatch
+                  Agent binary
+                type: object
+              config:
+                description: Config is the raw JSON to be used as the collector's
+                  configuration. Refer to the CloudWatch Agent documentation for details.
+                type: string
+              env:
+                description: ENV vars to set on the CloudWatch Agent's Pods. These
+                  can then in certain cases be consumed in the config file for the
+                  Collector.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              envFrom:
+                description: List of sources to populate environment variables on
+                  the CloudWatch Agent's Pods. These can then in certain cases be
+                  consumed in the config file for the Collector.
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              hostNetwork:
+                description: HostNetwork indicates if the pod should run in the host
+                  networking namespace.
+                type: boolean
+              image:
+                description: Image indicates the container image to use for the CloudWatch
+                  Agent.
+                type: string
+              imagePullPolicy:
+                description: ImagePullPolicy indicates the pull policy to be used
+                  for retrieving the container image (Always, Never, IfNotPresent)
+                type: string
+              ingress:
+                description: 'Ingress is used to specify how CloudWatch Agent is exposed.
+                  This functionality is only available if one of the valid modes is
+                  set. Valid modes are: deployment, daemonset and statefulset.'
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: 'Annotations to add to ingress. e.g. ''cert-manager.io/cluster-issuer:
+                      "letsencrypt"'''
+                    type: object
+                  hostname:
+                    description: Hostname by which the ingress proxy can be reached.
+                    type: string
+                  ingressClassName:
+                    description: IngressClassName is the name of an IngressClass cluster
+                      resource. Ingress controller implementations use this field
+                      to know whether they should be serving this Ingress resource.
+                    type: string
+                  route:
+                    description: Route is an OpenShift specific section that is only
+                      considered when type "route" is used.
+                    properties:
+                      termination:
+                        description: Termination indicates termination type. By default
+                          "edge" is used.
+                        enum:
+                        - insecure
+                        - edge
+                        - passthrough
+                        - reencrypt
+                        type: string
+                    type: object
+                  tls:
+                    description: TLS configuration.
+                    items:
+                      description: IngressTLS describes the transport layer security
+                        associated with an ingress.
+                      properties:
+                        hosts:
+                          description: hosts is a list of hosts included in the TLS
+                            certificate. The values in this list must match the name/s
+                            used in the tlsSecret. Defaults to the wildcard host setting
+                            for the loadbalancer controller fulfilling this Ingress,
+                            if left unspecified.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        secretName:
+                          description: secretName is the name of the secret used to
+                            terminate TLS traffic on port 443. Field is left optional
+                            to allow TLS routing based on SNI hostname alone. If the
+                            SNI host in a listener conflicts with the "Host" header
+                            field used by an IngressRule, the SNI host is used for
+                            termination and value of the "Host" header is used for
+                            routing.
+                          type: string
+                      type: object
+                    type: array
+                  type:
+                    description: 'Type default value is: "" Supported types are: ingress'
+                    enum:
+                    - ingress
+                    - route
+                    type: string
+                type: object
+              mode:
+                description: Mode represents how the collector should be deployed
+                  (deployment, daemonset, statefulset or sidecar)
+                enum:
+                - daemonset
+                - deployment
+                - sidecar
+                - statefulset
+                type: string
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector to schedule CloudWatch Agent pods. This
+                  is only relevant to daemonset, statefulset, and deployment mode
+                type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: PodAnnotations is the set of annotations that will be
+                  attached to Collector and Target Allocator pods.
+                type: object
+              ports:
+                description: Ports allows a set of ports to be exposed by the underlying
+                  v1.Service. By default, the operator will attempt to infer the required
+                  ports by parsing the .Spec.Config property but this property can
+                  be used to open additional ports that can't be inferred by the operator,
+                  like for custom receivers.
+                items:
+                  description: ServicePort contains information on service's port.
+                  properties:
+                    appProtocol:
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and https://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                      type: string
+                    name:
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort. Optional
+                        if only one ServicePort is defined on this service.
+                      type: string
+                    nodePort:
+                      description: 'The port on each node on which this service is
+                        exposed when type is NodePort or LoadBalancer.  Usually assigned
+                        by the system. If a value is specified, in-range, and not
+                        in use it will be used, otherwise the operation will fail.  If
+                        not specified, a port will be allocated if this Service requires
+                        one.  If this field is specified when creating a Service which
+                        does not need it, creation will fail. This field will be wiped
+                        when updating a Service to no longer need it (e.g. changing
+                        type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                      format: int32
+                      type: integer
+                    port:
+                      description: The port that will be exposed by this service.
+                      format: int32
+                      type: integer
+                    protocol:
+                      default: TCP
+                      description: The IP protocol for this port. Supports "TCP",
+                        "UDP", and "SCTP". Default is TCP.
+                      type: string
+                    targetPort:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: 'Number or name of the port to access on the pods
+                        targeted by the service. Number must be in the range 1 to
+                        65535. Name must be an IANA_SVC_NAME. If this is a string,
+                        it will be looked up as a named port in the target Pod''s
+                        container ports. If this is not specified, the value of the
+                        ''port'' field is used (an identity map). This field is ignored
+                        for services with clusterIP=None, and should be omitted or
+                        set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - port
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              priorityClassName:
+                description: If specified, indicates the pod's priority. If not specified,
+                  the pod priority will be default or zero if there is no default.
+                type: string
+              replicas:
+                description: Replicas is the number of pod instances for the underlying
+                  CloudWatch Agent. Set this if your are not using autoscaling
+                format: int32
+                type: integer
+              resources:
+                description: Resources to set on the CloudWatch Agent pods.
+                properties:
+                  claims:
+                    description: "Claims lists the names of resources, defined in
+                      spec.resourceClaims, that are used by this container. \n This
+                      is an alpha field and requires enabling the DynamicResourceAllocation
+                      feature gate. \n This field is immutable. It can only be set
+                      for containers."
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: Name must match the name of one entry in pod.spec.resourceClaims
+                            of the Pod where this field is used. It makes that resource
+                            available inside a container.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              serviceAccount:
+                description: ServiceAccount indicates the name of an existing service
+                  account to use with this instance. When set, the operator will not
+                  automatically create a ServiceAccount for the collector.
+                type: string
+              tolerations:
+                description: Toleration to schedule CloudWatch Agent pods. This is
+                  only relevant to daemonset, statefulset, and deployment mode
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              upgradeStrategy:
+                description: UpgradeStrategy represents how the operator will handle
+                  upgrades to the CR when a newer version of the operator is deployed
+                enum:
+                - automatic
+                - none
+                type: string
+              volumeClaimTemplates:
+                description: VolumeClaimTemplates will provide stable storage using
+                  PersistentVolumes. Only available when the mode=statefulset.
+                items:
+                  description: PersistentVolumeClaim is a user's request for and claim
+                    to a persistent volume
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                      type: string
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    metadata:
+                      description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      type: object
+                    spec:
+                      description: 'spec defines the desired characteristics of a
+                        volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        accessModes:
+                          description: 'accessModes contains the desired access modes
+                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        dataSource:
+                          description: 'dataSource field can be used to specify either:
+                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                            * An existing PVC (PersistentVolumeClaim) If the provisioner
+                            or an external controller can support the specified data
+                            source, it will create a new volume based on the contents
+                            of the specified data source. When the AnyVolumeDataSource
+                            feature gate is enabled, dataSource contents will be copied
+                            to dataSourceRef, and dataSourceRef contents will be copied
+                            to dataSource when dataSourceRef.namespace is not specified.
+                            If the namespace is specified, then dataSourceRef will
+                            not be copied to dataSource.'
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        dataSourceRef:
+                          description: 'dataSourceRef specifies the object from which
+                            to populate the volume with data, if a non-empty volume
+                            is desired. This may be any object from a non-empty API
+                            group (non core object) or a PersistentVolumeClaim object.
+                            When this field is specified, volume binding will only
+                            succeed if the type of the specified object matches some
+                            installed volume populator or dynamic provisioner. This
+                            field will replace the functionality of the dataSource
+                            field and as such if both fields are non-empty, they must
+                            have the same value. For backwards compatibility, when
+                            namespace isn''t specified in dataSourceRef, both fields
+                            (dataSource and dataSourceRef) will be set to the same
+                            value automatically if one of them is empty and the other
+                            is non-empty. When namespace is specified in dataSourceRef,
+                            dataSource isn''t set to the same value and must be empty.
+                            There are three important differences between dataSource
+                            and dataSourceRef: * While dataSource only allows two
+                            specific types of objects, dataSourceRef allows any non-core
+                            object, as well as PersistentVolumeClaim objects. * While
+                            dataSource ignores disallowed values (dropping them),
+                            dataSourceRef preserves all values, and generates an error
+                            if a disallowed value is specified. * While dataSource
+                            only allows local objects, dataSourceRef allows objects
+                            in any namespaces. (Beta) Using this field requires the
+                            AnyVolumeDataSource feature gate to be enabled. (Alpha)
+                            Using the namespace field of dataSourceRef requires the
+                            CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                          properties:
+                            apiGroup:
+                              description: APIGroup is the group for the resource
+                                being referenced. If APIGroup is not specified, the
+                                specified Kind must be in the core API group. For
+                                any other third-party types, APIGroup is required.
+                              type: string
+                            kind:
+                              description: Kind is the type of resource being referenced
+                              type: string
+                            name:
+                              description: Name is the name of resource being referenced
+                              type: string
+                            namespace:
+                              description: Namespace is the namespace of resource
+                                being referenced Note that when a namespace is specified,
+                                a gateway.networking.k8s.io/ReferenceGrant object
+                                is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the
+                                ReferenceGrant documentation for details. (Alpha)
+                                This field requires the CrossNamespaceVolumeDataSource
+                                feature gate to be enabled.
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                        resources:
+                          description: 'resources represents the minimum resources
+                            the volume should have. If RecoverVolumeExpansionFailure
+                            feature is enabled users are allowed to specify resource
+                            requirements that are lower than previous value but must
+                            still be higher than capacity recorded in the status field
+                            of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                          properties:
+                            claims:
+                              description: "Claims lists the names of resources, defined
+                                in spec.resourceClaims, that are used by this container.
+                                \n This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate. \n This field
+                                is immutable. It can only be set for containers."
+                              items:
+                                description: ResourceClaim references one entry in
+                                  PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry
+                                      in pod.spec.resourceClaims of the Pod where
+                                      this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        selector:
+                          description: selector is a label query over volumes to consider
+                            for binding.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        storageClassName:
+                          description: 'storageClassName is the name of the StorageClass
+                            required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          type: string
+                        volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not
+                            included in claim spec.
+                          type: string
+                        volumeName:
+                          description: volumeName is the binding reference to the
+                            PersistentVolume backing this claim.
+                          type: string
+                      type: object
+                    status:
+                      description: 'status represents the current information/status
+                        of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        accessModes:
+                          description: 'accessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                          items:
+                            type: string
+                          type: array
+                        allocatedResources:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: allocatedResources is the storage resource
+                            within AllocatedResources tracks the capacity allocated
+                            to a PVC. It may be larger than the actual capacity when
+                            a volume expansion operation is requested. For storage
+                            quota, the larger value from allocatedResources and PVC.spec.resources
+                            is used. If allocatedResources is not set, PVC.spec.resources
+                            alone is used for quota calculation. If a volume expansion
+                            capacity request is lowered, allocatedResources is only
+                            lowered if there are no expansion operations in progress
+                            and if the actual volume capacity is equal or lower than
+                            the requested capacity. This is an alpha field and requires
+                            enabling RecoverVolumeExpansionFailure feature.
+                          type: object
+                        capacity:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: capacity represents the actual resources of
+                            the underlying volume.
+                          type: object
+                        conditions:
+                          description: conditions is the current Condition of persistent
+                            volume claim. If underlying persistent volume is being
+                            resized then the Condition will be set to 'ResizeStarted'.
+                          items:
+                            description: PersistentVolumeClaimCondition contains details
+                              about state of pvc
+                            properties:
+                              lastProbeTime:
+                                description: lastProbeTime is the time we probed the
+                                  condition.
+                                format: date-time
+                                type: string
+                              lastTransitionTime:
+                                description: lastTransitionTime is the time the condition
+                                  transitioned from one status to another.
+                                format: date-time
+                                type: string
+                              message:
+                                description: message is the human-readable message
+                                  indicating details about last transition.
+                                type: string
+                              reason:
+                                description: reason is a unique, this should be a
+                                  short, machine understandable string that gives
+                                  the reason for condition's last transition. If it
+                                  reports "ResizeStarted" that means the underlying
+                                  persistent volume is being resized.
+                                type: string
+                              status:
+                                type: string
+                              type:
+                                description: PersistentVolumeClaimConditionType is
+                                  a valid value of PersistentVolumeClaimCondition.Type
+                                type: string
+                            required:
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        phase:
+                          description: phase represents the current phase of PersistentVolumeClaim.
+                          type: string
+                        resizeStatus:
+                          description: resizeStatus stores status of resize operation.
+                            ResizeStatus is not set by default but when expansion
+                            is complete resizeStatus is set to empty string by resize
+                            controller or kubelet. This is an alpha field and requires
+                            enabling RecoverVolumeExpansionFailure feature.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              volumeMounts:
+                description: VolumeMounts represents the mount points to use in the
+                  underlying collector deployment(s)
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: Path within the container at which the volume should
+                        be mounted.  Must not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: mountPropagation determines how mounts are propagated
+                        from the host to container and the other way around. When
+                        not set, MountPropagationNone is used. This field is beta
+                        in 1.10.
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: Mounted read-only if true, read-write otherwise
+                        (false or unspecified). Defaults to false.
+                      type: boolean
+                    subPath:
+                      description: Path within the volume from which the container's
+                        volume should be mounted. Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: Expanded path within the volume from which the
+                        container's volume should be mounted. Behaves similarly to
+                        SubPath but environment variable references $(VAR_NAME) are
+                        expanded using the container's environment. Defaults to ""
+                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              volumes:
+                description: Volumes represents which volumes to use in the underlying
+                  collector deployment(s).
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: 'awsElasticBlockStore represents an AWS Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'readOnly value true will force the readOnly
+                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: boolean
+                        volumeID:
+                          description: 'volumeID is unique ID of the persistent disk
+                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: azureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
+                          type: string
+                        diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
+                          type: string
+                        fsType:
+                          description: fsType is Filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: azureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
+                          type: string
+                        shareName:
+                          description: shareName is the azure share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: 'monitors is Required: Monitors is a collection
+                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: boolean
+                        secretFile:
+                          description: 'secretFile is Optional: SecretFile is the
+                            path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                        secretRef:
+                          description: 'secretRef is Optional: SecretRef is reference
+                            to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: 'user is optional: User is the rados user name,
+                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: 'cinder represents a cinder volume attached and
+                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
+                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                        readOnly:
+                          description: 'readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is optional: points to a secret
+                            object containing parameters used to connect to OpenStack.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeID:
+                          description: 'volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: 'defaultMode is optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: items if unspecified, each key-value pair in
+                            the Data field of the referenced ConfigMap will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the ConfigMap, the volume setup will error unless it is
+                            marked optional. Paths must be relative and may not contain
+                            the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. If not
+                                  specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers (Beta
+                        feature).
+                      properties:
+                        driver:
+                          description: driver is the name of the CSI driver that handles
+                            this volume. Consult with your admin for the correct name
+                            as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated
+                            CSI driver which will determine the default filesystem
+                            to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: nodePublishSecretRef is a reference to the
+                            secret object containing sensitive information to pass
+                            to the CSI driver to complete the CSI NodePublishVolume
+                            and NodeUnpublishVolume calls. This field is optional,
+                            and  may be empty if no secret is required. If the secret
+                            object contains more than one secret, all secret references
+                            are passed.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        readOnly:
+                          description: readOnly specifies a read-only configuration
+                            for the volume. Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: volumeAttributes stores driver-specific properties
+                            that are passed to the CSI driver. Consult your driver's
+                            documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: 'Optional: mode bits to use on created files
+                            by default. Must be a Optional: mode bits used to set
+                            permissions on created files by default. Must be an octal
+                            value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name and namespace are
+                                  supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mode:
+                                description: 'Optional: mode bits used to set permissions
+                                  on this file, must be an octal value between 0000
+                                  and 0777 or a decimal value between 0 and 511. YAML
+                                  accepts both octal and decimal values, JSON requires
+                                  decimal values for mode bits. If not specified,
+                                  the volume defaultMode will be used. This might
+                                  be in conflict with other options that affect the
+                                  file mode, like fsGroup, and the result can be other
+                                  mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, requests.cpu and requests.memory)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - path
+                            type: object
+                          type: array
+                      type: object
+                    emptyDir:
+                      description: 'emptyDir represents a temporary directory that
+                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                      properties:
+                        medium:
+                          description: 'medium represents what type of storage medium
+                            should back this directory. The default is "" which means
+                            to use the node''s default medium. Must be an empty string
+                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: 'sizeLimit is the total amount of local storage
+                            required for this EmptyDir volume. The size limit is also
+                            applicable for memory medium. The maximum usage on memory
+                            medium EmptyDir would be the minimum value between the
+                            SizeLimit specified here and the sum of memory limits
+                            of all containers in a pod. The default is nil which means
+                            that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      description: "ephemeral represents a volume that is handled
+                        by a cluster storage driver. The volume's lifecycle is tied
+                        to the pod that defines it - it will be created before the
+                        pod starts, and deleted when the pod is removed. \n Use this
+                        if: a) the volume is only needed while the pod runs, b) features
+                        of normal volumes like restoring from snapshot or capacity
+                        tracking are needed, c) the storage driver is specified through
+                        a storage class, and d) the storage driver supports dynamic
+                        volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
+                        for more information on the connection between this volume
+                        type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
+                        or one of the vendor-specific APIs for volumes that persist
+                        for longer than the lifecycle of an individual pod. \n Use
+                        CSI for light-weight local ephemeral volumes if the CSI driver
+                        is meant to be used that way - see the documentation of the
+                        driver for more information. \n A pod can use both types of
+                        ephemeral volumes and persistent volumes at the same time."
+                      properties:
+                        volumeClaimTemplate:
+                          description: "Will be used to create a stand-alone PVC to
+                            provision the volume. The pod in which this EphemeralVolumeSource
+                            is embedded will be the owner of the PVC, i.e. the PVC
+                            will be deleted together with the pod.  The name of the
+                            PVC will be `<pod name>-<volume name>` where `<volume
+                            name>` is the name from the `PodSpec.Volumes` array entry.
+                            Pod validation will reject the pod if the concatenated
+                            name is not valid for a PVC (for example, too long). \n
+                            An existing PVC with that name that is not owned by the
+                            pod will *not* be used for the pod to avoid using an unrelated
+                            volume by mistake. Starting the pod is then blocked until
+                            the unrelated PVC is removed. If such a pre-created PVC
+                            is meant to be used by the pod, the PVC has to updated
+                            with an owner reference to the pod once the pod exists.
+                            Normally this should not be necessary, but it may be useful
+                            when manually reconstructing a broken cluster. \n This
+                            field is read-only and no changes will be made by Kubernetes
+                            to the PVC after it has been created. \n Required, must
+                            not be nil."
+                          properties:
+                            metadata:
+                              description: May contain labels and annotations that
+                                will be copied into the PVC when creating it. No other
+                                fields are allowed and will be rejected during validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              type: object
+                            spec:
+                              description: The specification for the PersistentVolumeClaim.
+                                The entire content is copied unchanged into the PVC
+                                that gets created from this template. The same fields
+                                as in a PersistentVolumeClaim are also valid here.
+                              properties:
+                                accessModes:
+                                  description: 'accessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  description: 'dataSource field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim) If the
+                                    provisioner or an external controller can support
+                                    the specified data source, it will create a new
+                                    volume based on the contents of the specified
+                                    data source. When the AnyVolumeDataSource feature
+                                    gate is enabled, dataSource contents will be copied
+                                    to dataSourceRef, and dataSourceRef contents will
+                                    be copied to dataSource when dataSourceRef.namespace
+                                    is not specified. If the namespace is specified,
+                                    then dataSourceRef will not be copied to dataSource.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                dataSourceRef:
+                                  description: 'dataSourceRef specifies the object
+                                    from which to populate the volume with data, if
+                                    a non-empty volume is desired. This may be any
+                                    object from a non-empty API group (non core object)
+                                    or a PersistentVolumeClaim object. When this field
+                                    is specified, volume binding will only succeed
+                                    if the type of the specified object matches some
+                                    installed volume populator or dynamic provisioner.
+                                    This field will replace the functionality of the
+                                    dataSource field and as such if both fields are
+                                    non-empty, they must have the same value. For
+                                    backwards compatibility, when namespace isn''t
+                                    specified in dataSourceRef, both fields (dataSource
+                                    and dataSourceRef) will be set to the same value
+                                    automatically if one of them is empty and the
+                                    other is non-empty. When namespace is specified
+                                    in dataSourceRef, dataSource isn''t set to the
+                                    same value and must be empty. There are three
+                                    important differences between dataSource and dataSourceRef:
+                                    * While dataSource only allows two specific types
+                                    of objects, dataSourceRef allows any non-core
+                                    object, as well as PersistentVolumeClaim objects.
+                                    * While dataSource ignores disallowed values (dropping
+                                    them), dataSourceRef preserves all values, and
+                                    generates an error if a disallowed value is specified.
+                                    * While dataSource only allows local objects,
+                                    dataSourceRef allows objects in any namespaces.
+                                    (Beta) Using this field requires the AnyVolumeDataSource
+                                    feature gate to be enabled. (Alpha) Using the
+                                    namespace field of dataSourceRef requires the
+                                    CrossNamespaceVolumeDataSource feature gate to
+                                    be enabled.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API
+                                        group. For any other third-party types, APIGroup
+                                        is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                    namespace:
+                                      description: Namespace is the namespace of resource
+                                        being referenced Note that when a namespace
+                                        is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                        object is required in the referent namespace
+                                        to allow that namespace's owner to accept
+                                        the reference. See the ReferenceGrant documentation
+                                        for details. (Alpha) This field requires the
+                                        CrossNamespaceVolumeDataSource feature gate
+                                        to be enabled.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  description: 'resources represents the minimum resources
+                                    the volume should have. If RecoverVolumeExpansionFailure
+                                    feature is enabled users are allowed to specify
+                                    resource requirements that are lower than previous
+                                    value but must still be higher than capacity recorded
+                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  properties:
+                                    claims:
+                                      description: "Claims lists the names of resources,
+                                        defined in spec.resourceClaims, that are used
+                                        by this container. \n This is an alpha field
+                                        and requires enabling the DynamicResourceAllocation
+                                        feature gate. \n This field is immutable.
+                                        It can only be set for containers."
+                                      items:
+                                        description: ResourceClaim references one
+                                          entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: Name must match the name
+                                              of one entry in pod.spec.resourceClaims
+                                              of the Pod where this field is used.
+                                              It makes that resource available inside
+                                              a container.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. Requests
+                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                storageClassName:
+                                  description: 'storageClassName is the name of the
+                                    StorageClass required by the claim. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem
+                                    is implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. TODO: how do we prevent errors in the
+                            filesystem from compromising the machine'
+                          type: string
+                        lun:
+                          description: 'lun is Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                        wwids:
+                          description: 'wwids Optional: FC volume world wide identifiers
+                            (wwids) Either wwids or combination of targetWWNs and
+                            lun must be set, but not both simultaneously.'
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    flexVolume:
+                      description: flexVolume represents a generic volume resource
+                        that is provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                            on FlexVolume script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
+                          type: object
+                        readOnly:
+                          description: 'readOnly is Optional: defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is Optional: secretRef is reference
+                            to the secret object containing sensitive information
+                            to pass to the plugin scripts. This may be empty if no
+                            secret object is specified. If the secret object contains
+                            more than one secret, all secrets are passed to the plugin
+                            scripts.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: datasetName is Name of the dataset stored as
+                            metadata -> name on the dataset for Flocker should be
+                            considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: 'gcePersistentDisk represents a GCE Disk resource
+                        that is attached to a kubelet''s host machine and then exposed
+                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                      properties:
+                        fsType:
+                          description: 'fsType is filesystem type of the volume that
+                            you want to mount. Tip: Ensure that the filesystem type
+                            is supported by the host operating system. Examples: "ext4",
+                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        partition:
+                          description: 'partition is the partition in the volume that
+                            you want to mount. If omitted, the default is to mount
+                            by volume name. Examples: For volume /dev/sda1, you specify
+                            the partition as "1". Similarly, the volume partition
+                            for /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: 'pdName is unique name of the PD resource in
+                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: 'gitRepo represents a git repository at a particular
+                        revision. DEPRECATED: GitRepo is deprecated. To provision
+                        a container with a git repo, mount an EmptyDir into an InitContainer
+                        that clones the repo using git, then mount the EmptyDir into
+                        the Pod''s container.'
+                      properties:
+                        directory:
+                          description: directory is the target directory name. Must
+                            not contain or start with '..'.  If '.' is supplied, the
+                            volume directory will be the git repository.  Otherwise,
+                            if specified, the volume will contain the git repository
+                            in the subdirectory with the given name.
+                          type: string
+                        repository:
+                          description: repository is the URL
+                          type: string
+                        revision:
+                          description: revision is the commit hash for the specified
+                            revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: 'glusterfs represents a Glusterfs mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                      properties:
+                        endpoints:
+                          description: 'endpoints is the endpoint name that details
+                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        path:
+                          description: 'path is the Glusterfs volume path. More info:
+                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the Glusterfs volume
+                            to be mounted with read-only permissions. Defaults to
+                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: 'hostPath represents a pre-existing file or directory
+                        on the host machine that is directly exposed to the container.
+                        This is generally used for system agents or other privileged
+                        things that are allowed to see the host machine. Most containers
+                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                        --- TODO(jonesdl) We need to restrict who can use host directory
+                        mounts and who can/can not mount host directories as read/write.'
+                      properties:
+                        path:
+                          description: 'path of the directory on the host. If the
+                            path is a symlink, it will follow the link to the real
+                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                        type:
+                          description: 'type for HostPath Volume Defaults to "" More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    iscsi:
+                      description: 'iscsi represents an ISCSI Disk resource that is
+                        attached to a kubelet''s host machine and then exposed to
+                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                      properties:
+                        chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        initiatorName:
+                          description: initiatorName is the custom iSCSI Initiator
+                            Name. If initiatorName is specified with iscsiInterface
+                            simultaneously, new iSCSI interface <target portal>:<volume
+                            name> will be created for the connection.
+                          type: string
+                        iqn:
+                          description: iqn is the target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          description: iscsiInterface is the interface Name that uses
+                            an iSCSI transport. Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: lun represents iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: portals is the iSCSI Target Portal List. The
+                            portal is either an IP or ip_addr:port if the port is
+                            other than default (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                        readOnly:
+                          description: readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPortal:
+                          description: targetPortal is iSCSI Target Portal. The Portal
+                            is either an IP or ip_addr:port if the port is other than
+                            default (typically TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: 'name of the volume. Must be a DNS_LABEL and unique
+                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    nfs:
+                      description: 'nfs represents an NFS mount on the host that shares
+                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                      properties:
+                        path:
+                          description: 'path that is exported by the NFS server. More
+                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the NFS export to
+                            be mounted with read-only permissions. Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: boolean
+                        server:
+                          description: 'server is the hostname or IP address of the
+                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: 'persistentVolumeClaimVolumeSource represents a
+                        reference to a PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      properties:
+                        claimName:
+                          description: 'claimName is the name of a PersistentVolumeClaim
+                            in the same namespace as the pod using this volume. More
+                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: string
+                        readOnly:
+                          description: readOnly Will force the ReadOnly setting in
+                            VolumeMounts. Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating
+                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
+                      properties:
+                        defaultMode:
+                          description: defaultMode are the mode bits used to set permissions
+                            on created files by default. Must be an octal value between
+                            0000 and 0777 or a decimal value between 0 and 511. YAML
+                            accepts both octal and decimal values, JSON requires decimal
+                            values for mode bits. Directories within the path are
+                            not affected by this setting. This might be in conflict
+                            with other options that affect the file mode, like fsGroup,
+                            and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: sources is the list of volume projections
+                          items:
+                            description: Projection that may be projected along with
+                              other supported volume types
+                            properties:
+                              configMap:
+                                description: configMap information about the configMap
+                                  data to project
+                                properties:
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the ConfigMap, the volume
+                                      setup will error unless it is marked optional.
+                                      Paths must be relative and may not contain the
+                                      '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name and namespace are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: 'Optional: mode bits used to
+                                            set permissions on this file, must be
+                                            an octal value between 0000 and 0777 or
+                                            a decimal value between 0 and 511. YAML
+                                            accepts both octal and decimal values,
+                                            JSON requires decimal values for mode
+                                            bits. If not specified, the volume defaultMode
+                                            will be used. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: 'Selects a resource of the
+                                            container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu
+                                            and requests.memory) are currently supported.'
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              secret:
+                                description: secret information about the secret data
+                                  to project
+                                properties:
+                                  items:
+                                    description: items if unspecified, each key-value
+                                      pair in the Data field of the referenced Secret
+                                      will be projected into the volume as a file
+                                      whose name is the key and content is the value.
+                                      If specified, the listed keys will be projected
+                                      into the specified paths, and unlisted keys
+                                      will not be present. If a key is specified which
+                                      is not present in the Secret, the volume setup
+                                      will error unless it is marked optional. Paths
+                                      must be relative and may not contain the '..'
+                                      path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: 'mode is Optional: mode bits
+                                            used to set permissions on this file.
+                                            Must be an octal value between 0000 and
+                                            0777 or a decimal value between 0 and
+                                            511. YAML accepts both octal and decimal
+                                            values, JSON requires decimal values for
+                                            mode bits. If not specified, the volume
+                                            defaultMode will be used. This might be
+                                            in conflict with other options that affect
+                                            the file mode, like fsGroup, and the result
+                                            can be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: path is the relative path of
+                                            the file to map the key to. May not be
+                                            an absolute path. May not contain the
+                                            path element '..'. May not start with
+                                            the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
+                                properties:
+                                  audience:
+                                    description: audience is the intended audience
+                                      of the token. A recipient of a token must identify
+                                      itself with an identifier specified in the audience
+                                      of the token, and otherwise should reject the
+                                      token. The audience defaults to the identifier
+                                      of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: expirationSeconds is the requested
+                                      duration of validity of the service account
+                                      token. As the token approaches expiration, the
+                                      kubelet volume plugin will proactively rotate
+                                      the service account token. The kubelet will
+                                      start trying to rotate the token if the token
+                                      is older than 80 percent of its time to live
+                                      or if the token is older than 24 hours.Defaults
+                                      to 1 hour and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: path is the path relative to the
+                                      mount point of the file to project the token
+                                      into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                    quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
+                      properties:
+                        group:
+                          description: group to map volume access to Default is no
+                            group
+                          type: string
+                        readOnly:
+                          description: readOnly here will force the Quobyte volume
+                            to be mounted with read-only permissions. Defaults to
+                            false.
+                          type: boolean
+                        registry:
+                          description: registry represents a single or multiple Quobyte
+                            Registry services specified as a string as host:port pair
+                            (multiple entries are separated with commas) which acts
+                            as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: tenant owning the given Quobyte volume in the
+                            Backend Used with dynamically provisioned Quobyte volumes,
+                            value is set by the plugin
+                          type: string
+                        user:
+                          description: user to map volume access to Defaults to serivceaccount
+                            user
+                          type: string
+                        volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      description: 'rbd represents a Rados Block Device mount on the
+                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                      properties:
+                        fsType:
+                          description: 'fsType is the filesystem type of the volume
+                            that you want to mount. Tip: Ensure that the filesystem
+                            type is supported by the host operating system. Examples:
+                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                            TODO: how do we prevent errors in the filesystem from
+                            compromising the machine'
+                          type: string
+                        image:
+                          description: 'image is the rados image name. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        keyring:
+                          description: 'keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        monitors:
+                          description: 'monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          items:
+                            type: string
+                          type: array
+                        pool:
+                          description: 'pool is the rados pool name. Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                        readOnly:
+                          description: 'readOnly here will force the ReadOnly setting
+                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: boolean
+                        secretRef:
+                          description: 'secretRef is name of the authentication secret
+                            for RBDUser. If provided overrides keyring. Default is
+                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: 'user is the rados user name. Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                          type: string
+                        gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
+                          type: string
+                        readOnly:
+                          description: readOnly Defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: secretRef references to the secret for ScaleIO
+                            user and other sensitive information. If this is not provided,
+                            Login operation will fail.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
+                          type: boolean
+                        storageMode:
+                          description: storageMode indicates whether the storage for
+                            a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
+                          type: string
+                        system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: volumeName is the name of a volume already
+                            created in the ScaleIO system that is associated with
+                            this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: 'secret represents a secret that should populate
+                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                      properties:
+                        defaultMode:
+                          description: 'defaultMode is Optional: mode bits used to
+                            set permissions on created files by default. Must be an
+                            octal value between 0000 and 0777 or a decimal value between
+                            0 and 511. YAML accepts both octal and decimal values,
+                            JSON requires decimal values for mode bits. Defaults to
+                            0644. Directories within the path are not affected by
+                            this setting. This might be in conflict with other options
+                            that affect the file mode, like fsGroup, and the result
+                            can be other mode bits set.'
+                          format: int32
+                          type: integer
+                        items:
+                          description: items If unspecified, each key-value pair in
+                            the Data field of the referenced Secret will be projected
+                            into the volume as a file whose name is the key and content
+                            is the value. If specified, the listed keys will be projected
+                            into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in
+                            the Secret, the volume setup will error unless it is marked
+                            optional. Paths must be relative and may not contain the
+                            '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: 'mode is Optional: mode bits used to
+                                  set permissions on this file. Must be an octal value
+                                  between 0000 and 0777 or a decimal value between
+                                  0 and 511. YAML accepts both octal and decimal values,
+                                  JSON requires decimal values for mode bits. If not
+                                  specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that
+                                  affect the file mode, like fsGroup, and the result
+                                  can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              path:
+                                description: path is the relative path of the file
+                                  to map the key to. May not be an absolute path.
+                                  May not contain the path element '..'. May not start
+                                  with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                        optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
+                          type: boolean
+                        secretName:
+                          description: 'secretName is the name of the secret in the
+                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          type: string
+                      type: object
+                    storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: fsType is the filesystem type to mount. Must
+                            be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        readOnly:
+                          description: readOnly defaults to false (read/write). ReadOnly
+                            here will force the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: secretRef specifies the secret to use for obtaining
+                            the StorageOS API credentials.  If not specified, default
+                            values will be attempted.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeName:
+                          description: volumeName is the human-readable name of the
+                            StorageOS volume.  Volume names are only unique within
+                            a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: volumeNamespace specifies the scope of the
+                            volume within StorageOS.  If no namespace is specified
+                            then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS
+                            for tighter integration. Set VolumeName to any name to
+                            override the default behaviour. Set to "default" if you
+                            are not using namespaces within StorageOS. Namespaces
+                            that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: fsType is filesystem type to mount. Must be
+                            a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                            if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
+                          type: string
+                        volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+          status:
+            description: AmazonCloudWatchAgentStatus defines the observed state of
+              AmazonCloudWatchAgent.
+            properties:
+              image:
+                description: Image indicates the container image to use for the CloudWatch
+                  Agent.
+                type: string
+              messages:
+                description: 'Messages about actions performed by the operator on
+                  this resource. Deprecated: use Kubernetes events instead.'
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              replicas:
+                description: 'Replicas is currently not being set and might be removed
+                  in the next version. Deprecated: use "AmazonCloudWatchAgent.Status.Scale.Replicas"
+                  instead.'
+                format: int32
+                type: integer
+              scale:
+                description: Scale is the AmazonCloudWatchAgent's scale subresource
+                  status.
+                properties:
+                  replicas:
+                    description: The total number non-terminated pods targeted by
+                      this AmazonCloudWatchAgent's deployment or statefulSet.
+                    format: int32
+                    type: integer
+                  selector:
+                    description: The selector used to match the AmazonCloudWatchAgent's
+                      deployment or statefulSet pods.
+                    type: string
+                  statusReplicas:
+                    description: StatusReplicas is the number of pods targeted by
+                      this AmazonCloudWatchAgent's with a Ready Condition / Total
+                      number of non-terminated pods targeted by this AmazonCloudWatchAgent's
+                      (their labels match the selector). Deployment, Daemonset, StatefulSet.
+                    type: string
+                type: object
+              version:
+                description: Version of the managed CloudWatch Agent (operand)
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.scale.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.scale.replicas
+      status: {}

--- a/helm/crds/cloudwatch.aws.amazon.com_instrumentations.yaml
+++ b/helm/crds/cloudwatch.aws.amazon.com_instrumentations.yaml
@@ -1,0 +1,415 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.12.0
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-agent-operator
+  name: instrumentations.cloudwatch.aws.amazon.com
+spec:
+  group: cloudwatch.aws.amazon.com
+  names:
+    kind: Instrumentation
+    listKind: InstrumentationList
+    plural: instrumentations
+    shortNames:
+    - otelinst
+    - otelinsts
+    singular: instrumentation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.exporter.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .spec.sampler.type
+      name: Sampler
+      type: string
+    - jsonPath: .spec.sampler.argument
+      name: Sampler Arg
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Instrumentation is the spec for OpenTelemetry instrumentation.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InstrumentationSpec defines the desired state of OpenTelemetry
+              SDK and instrumentation.
+            properties:
+              env:
+                description: 'Env defines common env vars. There are four layers for
+                  env vars'' definitions and the precedence order is: `original container
+                  env vars` > `language specific env vars` > `common env vars` > `instrument
+                  spec configs'' vars`. If the former var had been defined, then the
+                  other vars would be ignored.'
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              exporter:
+                description: Exporter defines exporter configuration.
+                properties:
+                  endpoint:
+                    description: Endpoint is address of the collector with OTLP endpoint.
+                    type: string
+                type: object
+              java:
+                description: Java defines configuration for java auto-instrumentation.
+                properties:
+                  env:
+                    description: 'Env defines java specific env vars. There are four
+                      layers for env vars'' definitions and the precedence order is:
+                      `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image is a container image with javaagent auto-instrumentation
+                      JAR.
+                    type: string
+                  resources:
+                    description: Resources describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: Name must match the name of one entry in
+                                pod.spec.resourceClaims of the Pod where this field
+                                is used. It makes that resource available inside a
+                                container.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        type: object
+                    type: object
+                type: object
+              propagators:
+                description: Propagators defines inter-process context propagation
+                  configuration. Values in this list will be set in the OTEL_PROPAGATORS
+                  env var. Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
+                items:
+                  description: Propagator represents the propagation type.
+                  enum:
+                  - tracecontext
+                  - baggage
+                  - b3
+                  - b3multi
+                  - jaeger
+                  - xray
+                  - ottrace
+                  - none
+                  type: string
+                type: array
+              resource:
+                description: Resource defines the configuration for the resource attributes,
+                  as defined by the OpenTelemetry specification.
+                properties:
+                  addK8sUIDAttributes:
+                    description: AddK8sUIDAttributes defines whether K8s UID attributes
+                      should be collected (e.g. k8s.deployment.uid).
+                    type: boolean
+                  resourceAttributes:
+                    additionalProperties:
+                      type: string
+                    description: 'Attributes defines attributes that are added to
+                      the resource. For example environment: dev'
+                    type: object
+                type: object
+              sampler:
+                description: Sampler defines sampling configuration.
+                properties:
+                  argument:
+                    description: Argument defines sampler argument. The value depends
+                      on the sampler type. For instance for parentbased_traceidratio
+                      sampler type it is a number in range [0..1] e.g. 0.25. The value
+                      will be set in the OTEL_TRACES_SAMPLER_ARG env var.
+                    type: string
+                  type:
+                    description: Type defines sampler type. The value will be set
+                      in the OTEL_TRACES_SAMPLER env var. The value can be for instance
+                      parentbased_always_on, parentbased_always_off, parentbased_traceidratio...
+                    enum:
+                    - always_on
+                    - always_off
+                    - traceidratio
+                    - parentbased_always_on
+                    - parentbased_always_off
+                    - parentbased_traceidratio
+                    - jaeger_remote
+                    - xray
+                    type: string
+                type: object
+            type: object
+          status:
+            description: InstrumentationStatus defines status of the instrumentation.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,116 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cloudwatchagent-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cloudwatchagent-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cloudwatchagent-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cloudwatchagent-operator.labels" -}}
+{{ include "cloudwatchagent-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: EKS
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cloudwatchagent-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cloudwatchagent-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cloudwatchagent-operator.managerServiceAccountName" -}}
+{{- if .Values.manager.serviceAccount.create }}
+{{- default (printf "%s-controller-manager" (include "cloudwatchagent-operator.name" .)) .Values.manager.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.manager.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cloudwatchagent-operator.agentServiceAccountName" -}}
+{{- if .Values.agent.enabled }}
+{{- default (printf "%s-agent" (include "cloudwatchagent-operator.name" .)) .Values.agent.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.agent.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+{{- define "cloudwatchagent-operator.podAnnotations" -}}
+{{- if .Values.manager.podAnnotations }}
+{{- .Values.manager.podAnnotations | toYaml }}
+{{- end }}
+{{- end }}
+
+{{- define "cloudwatchagent-operator.podLabels" -}}
+{{- if .Values.manager.podLabels }}
+{{- .Values.manager.podLabels | toYaml }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define the namespace where the resources in the chart will be installed.
+*/}}
+{{- define "cloudwatchagent-operator.namespace" -}}
+amazon-cloudwatch-agent-operator-system
+{{- end -}}
+
+{{/*
+Define the default certificate name
+*/}}
+{{- define "cloudwatchagent-operator.certificateName" -}}
+{{- default (printf "%s-serving-cert" (include "cloudwatchagent-operator.name" .)) .Values.manager.certificate.name }}
+{{- end -}}
+
+{{/*
+Define the default certificate secret name
+*/}}
+{{- define "cloudwatchagent-operator.certificateSecretName" -}}
+{{- default (printf "%s-controller-manager-service-cert" (include "cloudwatchagent-operator.name" .)) .Values.manager.certificate.secretName }}
+{{- end -}}
+
+{{/*
+Define the default service name
+*/}}
+{{- define "cloudwatchagent-operator.webhookServiceName" -}}
+{{- default (printf "%s-webhook-service" (include "cloudwatchagent-operator.name" .)) .Values.manager.service.name }}
+{{- end -}}
+
+
+

--- a/helm/templates/clusterrolebinding.yaml
+++ b/helm/templates/clusterrolebinding.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4 }}
+  name: {{ template "cloudwatchagent-operator.name" . }}-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "cloudwatchagent-operator.name" . }}-manager-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "cloudwatchagent-operator.managerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+
+{{ if .Values.agent.enabled }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "cloudwatchagent-operator.name" . }}-agent-role-binding
+roleRef:
+  kind: ClusterRole
+  name: {{ template "cloudwatchagent-operator.name" . }}-agent-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cloudwatchagent-operator.agentServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,41 @@
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4 }}
+    control-plane: controller-manager
+  name: {{ template "cloudwatchagent-operator.name" . }}-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "cloudwatchagent-operator.name" . }}
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "cloudwatchagent-operator.name" . }}
+        control-plane: controller-manager
+        {{- include "cloudwatchagent-operator.podLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+        name: manager
+        ports:
+        - containerPort: {{ .Values.manager.ports.containerPort }}
+          name: webhook-server
+          protocol: TCP
+        resources: {{ toYaml .Values.manager.resources | nindent 12 }}   
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: {{ template "cloudwatchagent-operator.managerServiceAccountName" . }}
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ template "cloudwatchagent-operator.certificateSecretName" . }}

--- a/helm/templates/role.yaml
+++ b/helm/templates/role.yaml
@@ -1,0 +1,189 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "cloudwatchagent-operator.name" . }}-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloudwatch.aws.amazon.com
+  resources:
+  - amazoncloudwatchagents
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cloudwatch.aws.amazon.com
+  resources:
+  - amazoncloudwatchagents/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cloudwatch.aws.amazon.com
+  resources:
+  - amazoncloudwatchagents/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cloudwatch.aws.amazon.com
+  resources:
+  - instrumentations
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{ if .Values.agent.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4}}
+  name: {{ template "cloudwatchagent-operator.name" . }}-agent-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "namespaces", "endpoints"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/stats", "configmaps", "events"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update"]
+{{- end }}

--- a/helm/templates/role.yaml
+++ b/helm/templates/role.yaml
@@ -172,7 +172,7 @@ rules:
     resources: ["services"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]
     verbs: ["list", "watch", "get"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -186,4 +186,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 {{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,17 @@
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4}}
+  name: {{ template "cloudwatchagent-operator.webhookServiceName" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: {{ .Values.manager.ports.containerPort }}
+  selector:
+    app.kubernetes.io/name: {{ template "cloudwatchagent-operator.name" . }}
+    control-plane: controller-manager

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4}}
+  name: {{ template "cloudwatchagent-operator.managerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+
+{{- if .Values.agent.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cloudwatchagent-operator.agentServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -1,0 +1,174 @@
+{{- $altNames := list ( printf "%s-webhook-service.%s" (include "cloudwatchagent-operator.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc" (include "cloudwatchagent-operator.name" .) .Release.Namespace ) -}}
+{{- $ca := genCA "cloudwatchagent-operator-operator-ca" 365 -}}
+{{- $cert := genSignedCert (include "cloudwatchagent-operator.name" .) nil $altNames 365 $ca -}}
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ template "cloudwatchagent-operator.certificateSecretName" . }}
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4}}
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4}}
+  name: {{ template "cloudwatchagent-operator.name" . }}-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "cloudwatchagent-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: Fail
+  name: mamazoncloudwatchagent.kb.io
+  rules:
+  - apiGroups:
+    - cloudwatch.aws.amazon.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - amazoncloudwatchagents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "cloudwatchagent-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: Fail
+  name: minstrumentation.kb.io
+  rules:
+  - apiGroups:
+    - cloudwatch.aws.amazon.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - instrumentations
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "cloudwatchagent-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-pod
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: Ignore
+  name: mpod.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    {{- include "cloudwatchagent-operator.labels" . | nindent 4}}
+  name: {{ template "cloudwatchagent-operator.name" . }}-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "cloudwatchagent-operator.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: Fail
+  name: vamazoncloudwatchagentcreateupdate.kb.io
+  rules:
+  - apiGroups:
+    - cloudwatch.aws.amazon.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - amazoncloudwatchagents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "cloudwatchagent-operator.name" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: Ignore
+  name: vamazoncloudwatchagentdelete.kb.io
+  rules:
+  - apiGroups:
+    - cloudwatch.aws.amazon.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - DELETE
+    resources:
+    - amazoncloudwatchagents
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "cloudwatchagent-operator.name" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: Fail
+  name: vinstrumentationcreateupdate.kb.io
+  rules:
+  - apiGroups:
+    - cloudwatch.aws.amazon.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - instrumentations
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "cloudwatchagent-operator.name" . }}-webhook-service
+      namespace: {{ .Release.Namespace }}
+      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: Ignore
+  name: vinstrumentationdelete.kb.io
+  rules:
+  - apiGroups:
+    - cloudwatch.aws.amazon.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - DELETE
+    resources:
+    - instrumentations
+  sideEffects: None

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -1,6 +1,6 @@
 {{- $altNames := list ( printf "%s-webhook-service.%s" (include "cloudwatchagent-operator.name" .) .Release.Namespace ) ( printf "%s-webhook-service.%s.svc" (include "cloudwatchagent-operator.name" .) .Release.Namespace ) -}}
-{{- $ca := genCA "cloudwatchagent-operator-operator-ca" 365 -}}
-{{- $cert := genSignedCert (include "cloudwatchagent-operator.name" .) nil $altNames 365 $ca -}}
+{{- $ca := genCA "cloudwatchagent-operator-operator-ca" 1827 -}}
+{{- $cert := genSignedCert (include "cloudwatchagent-operator.name" .) nil $altNames 1827 $ca -}}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,4 +50,26 @@ agent:
   enabled: true
   serviceAccount:
     name: # override agent service account name 
-
+  config: |
+    {
+      "agent": {
+        "debug": true
+      },
+      "traces": {
+        "traces_collected": {
+          "apm": {
+            "enabled": true
+          }
+        }
+      },
+      "logs": {
+        "metrics_collected": {
+          "apm": {
+            "enabled": true
+          },
+          "kubernetes": {
+            "metric_granularity": 3
+          }
+        }
+      }
+    }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,53 @@
+# Default values for cloudwatchagent-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+
+## Provide a name in place of cloudwatchagent-operator.
+##
+nameOverride: ""
+
+## Reference one or more secrets to be used when pulling images from authenticated repositories.
+imagePullSecrets: []
+
+## Provide CloudWatchAgent Operator manager container image and resources.
+##
+manager:
+  name:
+  image:
+    repository: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-operator-release
+    tag: latest
+  ports:
+    containerPort: 9443
+    metricsPort: 8080
+    webhookPort: 9443
+    healthzPort: 8081
+  resources:
+    requests:
+      cpu: 100m
+      memory: 64Mi
+  ## Adds additional environment variables
+  ## e.g ENV_VAR: env_value
+  env:
+    ENABLE_WEBHOOKS: "true"
+
+  # -- Create the manager ServiceAccount
+  serviceAccount:
+    create: true
+    annotations: {}
+
+  podAnnotations: {}
+  podLabels: {}
+
+  certificate:
+    name:
+    secretName:
+
+  service:
+    name:
+
+agent:
+  enabled: true
+  serviceAccount:
+    name: # override agent service account name 
+


### PR DESCRIPTION
Add Helm charts to align with the standards of AWS Controllers for Kubernetes (ACK). Ideally, we will migrate CWA Operator to ACK CloudWatch https://github.com/aws-controllers-k8s/cloudwatch-controller/tree/main. 





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
