### PR TITLE
Update OTLP ports to have less conflict & add aws-proxy port

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ metadata:
   namespace: default # use a namespace with pods you'd like to inject
 spec:
   exporter:
-    endpoint: http://amazon-cloudwatch-agent.amazon-cloudwatch:4317
+    endpoint: http://amazon-cloudwatch-agent.amazon-cloudwatch:4315
   propagators:
     - tracecontext
     - baggage

--- a/pkg/collector/common.go
+++ b/pkg/collector/common.go
@@ -10,10 +10,14 @@ import (
 var CloudwatchAgentPorts = []corev1.ServicePort{
 	{
 		Name: "otlp-grpc",
-		Port: 4317,
+		Port: 4315,
 	},
 	{
 		Name: "otlp-http",
-		Port: 4318,
+		Port: 4316,
+	},
+	{
+		Name: "aws-proxy",
+		Port: 2000,
 	},
 }

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	defaultExporterEndpoint                = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4317"
+	defaultExporterEndpoint                = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4315"
 	defaultJavaImage                       = "160148376629.dkr.ecr.us-west-2.amazonaws.com/aws-apm-preview:latest"
 	defaultAPIVersion                      = "cloudwatch.aws.amazon.com/v1alpha1"
 	defaultInstrumenation                  = "java-instrumentation"
@@ -34,7 +34,7 @@ const (
 	otelTracesSamplerKey                   = "OTEL_TRACES_SAMPLER"
 	otelTracesSamplerDefaultValue          = "parentbased_traceidratio"
 	otelExporterTracesEndpointKey          = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
-	otelExporterTracesEndpointDefaultValue = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4317"
+	otelExporterTracesEndpointDefaultValue = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4315"
 )
 
 var (


### PR DESCRIPTION
This change will update the agent to use 4315 and 4316 ports for OTLP receiver to have less conflict. 

- Change the default OTLP ports 4317->4315 & 4318->4316. 
- Add `aws-proxy` port 2000


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
