### PR TITLE
Open aws proxy port 2000 as a default port on the cloudwatch agent pod

### DIFF
--- a/pkg/collector/common.go
+++ b/pkg/collector/common.go
@@ -16,4 +16,8 @@ var CloudwatchAgentPorts = []corev1.ServicePort{
 		Name: "otlp-http",
 		Port: 4318,
 	},
+	{
+		Name: "aws-proxy",
+		Port: 2000,
+	},
 }


### PR DESCRIPTION
*Description of changes:*
Open port 2000 in the cloudwatch agent container for aws proxy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
