### PR TITLE
Change container ports on the cloudwatch agent to use non-default ports

### DIFF
--- a/pkg/collector/common.go
+++ b/pkg/collector/common.go
@@ -10,11 +10,11 @@ import (
 var CloudwatchAgentPorts = []corev1.ServicePort{
 	{
 		Name: "otlp-grpc",
-		Port: 4317,
+		Port: 4315,
 	},
 	{
 		Name: "otlp-http",
-		Port: 4318,
+		Port: 4316,
 	},
 	{
 		Name: "aws-proxy",


### PR DESCRIPTION
*Description of changes:*
Update otlp ports according to change in the cloudwatch agent: https://github.com/aws/private-amazon-cloudwatch-agent-staging/commit/84cdc3a8b014a48ddf109813857b5423d2d0e084

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
