### PR TITLE
Add versioning in versions.txt and build 0.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,16 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 COPY internal/ internal/
 COPY pkg/ pkg/
+COPY versions.txt versions.txt
 
 ARG VERSION_PKG
 ARG VERSION
 ARG VERSION_DATE
-ARG OTELCOL_VERSION
+ARG AGENT_VERSION
 ARG AUTO_INSTRUMENTATION_JAVA_VERSION
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.otelCol=${OTELCOL_VERSION} -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION}" -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.agent=${AGENT_VERSION} -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION}" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/README.md
+++ b/README.md
@@ -4,17 +4,8 @@ The Amazon CloudWatch Agent Operator is software developed to manage the [CloudW
 This repo is based off of the [OpenTelemetry Operator](https://github.com/open-telemetry/opentelemetry-operator)
 
 ## Build and Deployment
-1. Set environment variable to name the build image `export CLOUDWATCH_AGENT_OPERATOR_IMAGE="ACCOUNT_ID.dkr.ecr.us-east-1.amazonaws.com/amazon-cloudwatch-agent-operator:latest"`
-2. Build the image using `make container`
-3. Push the image to your local ecr repo
-
-```
-aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
-
-docker push <AWS_ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/amazon-cloudwatch-agent-operator:latest
-```
-
-4. Deploy kubernetes objects to your cluster `make deploy`
+- Image can be built using `make container`
+- Deploy kubernetes objects to your cluster `make deploy`
 
 ## Pre requisites
 1. Have an existing kubernetes cluster, such as [minikube](https://minikube.sigs.k8s.io/docs/start/)

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -9,7 +9,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1"
+	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/integration-tests/eks-addon/validateResources_test.go
+++ b/integration-tests/eks-addon/validateResources_test.go
@@ -1,12 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package eks_addon
 
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
 	"regexp"
+
+	"github.com/stretchr/testify/assert"
+
+	"testing"
 
 	arv1 "k8s.io/api/admissionregistration/v1"
 	appsV1 "k8s.io/api/apps/v1"
@@ -15,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"testing"
 )
 
 const nameSpace = "amazon-cloudwatch"

--- a/main.go
+++ b/main.go
@@ -36,11 +36,8 @@ import (
 )
 
 const (
-	cloudwatchAgentImageRepository = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent"
-	cloudwatchAgentImageTag        = "latest"
-
-	autoInstrumentationJavaImageRepository = "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java"
-	autoInstrumentationJavaImageTag        = "latest"
+	cloudwatchAgentImageRepository         = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent"
+	autoInstrumentationJavaImageRepository = "public.ecr.aws/aws-observability/adot-autoinstrumentation-java"
 )
 
 var (
@@ -78,8 +75,8 @@ func main() {
 		tlsOpt                  tlsConfig
 	)
 
-	pflag.StringVar(&agentImage, "agent-image", fmt.Sprintf("%s:%s", cloudwatchAgentImageRepository, cloudwatchAgentImageTag), "The default cloudwatch agent image. This image is used when no image is specified in the CustomResource.")
-	pflag.StringVar(&autoInstrumentationJava, "auto-instrumentation-java-image", fmt.Sprintf("%s:%s", autoInstrumentationJavaImageRepository, autoInstrumentationJavaImageTag), "The default OpenTelemetry Java instrumentation image. This image is used when no image is specified in the CustomResource.")
+	pflag.StringVar(&agentImage, "agent-image", fmt.Sprintf("%s:%s", cloudwatchAgentImageRepository, v.AmazonCloudWatchAgent), "The default cloudwatch agent image. This image is used when no image is specified in the CustomResource.")
+	pflag.StringVar(&autoInstrumentationJava, "auto-instrumentation-java-image", fmt.Sprintf("%s:%s", autoInstrumentationJavaImageRepository, v.AutoInstrumentationJava), "The default OpenTelemetry Java instrumentation image. This image is used when no image is specified in the CustomResource.")
 	pflag.Parse()
 
 	logger := zap.New(zap.UseFlagOptions(&opts))

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package instrumentation
 
 import (

--- a/versions.txt
+++ b/versions.txt
@@ -1,0 +1,8 @@
+# Represents the latest stable release of the CloudWatch Agent
+cloudwatch-agent=1.300028.1b210
+
+# Represents the current release of the CloudWatch Agent Operator.
+operator=0.1.0
+
+# Represents the current release of ADOT Java instrumentation.
+aws-otel-java-instrumentation=v1.30.0


### PR DESCRIPTION
*Issue #, if available:*
Use versions.txt to specify versions of the operator, agent, and adot java instrumentation. Set version of the operator to 0.1.0.

*Description of changes:*
Added versions.txt
Added build arguments to use versions in versions.txt
Changed instrumentation repo to the public adot ecr repo
Updated README.md
Run `make fmt`

*Test*
Pushed new image to my local ecr and ran the operator. Checked logs:
```
{"level":"info","ts":"2023-10-13T17:45:32Z","msg":"Starting the Amazon CloudWatch Agent Operator","amazon-cloudwatch-agent-operator":"0.1.0","amazon-cloudwatch-agent":"public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210","auto-instrumentation-java":"public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.30.0","build-date":"2023-10-13T17:23:33Z","go-version":"go1.20.10","go-arch":"amd64","go-os":"linux"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
