### PR TITLE
Use default instrumentation image passed as command argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 	)
 
 	// set java instrumentation java image in environment variable to be used for default instrumentation
-	os.Setenv("auto-instrumentation-java", autoInstrumentationJava)
+	os.Setenv("AUTO_INSTRUMENTATION_JAVA", autoInstrumentationJava)
 
 	cfg := config.New(
 		config.WithLogger(ctrl.Log.WithName("config")),

--- a/main.go
+++ b/main.go
@@ -92,10 +92,14 @@ func main() {
 		"go-os", runtime.GOOS,
 	)
 
+	// set java instrumentation java image in environment variable to be used for default instrumentation
+	os.Setenv("auto-instrumentation-java", autoInstrumentationJava)
+
 	cfg := config.New(
 		config.WithLogger(ctrl.Log.WithName("config")),
 		config.WithVersion(v),
 		config.WithCollectorImage(agentImage),
+		config.WithAutoInstrumentationJavaImage(autoInstrumentationJava),
 	)
 
 	watchNamespace, found := os.LookupEnv("WATCH_NAMESPACE")

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -28,7 +28,7 @@ const (
 )
 
 func getDefaultInstrumentation() (*v1alpha1.Instrumentation, error) {
-	instrumentationImage, ok := os.LookupEnv("auto-instrumentation-java")
+	instrumentationImage, ok := os.LookupEnv("AUTO_INSTRUMENTATION_JAVA")
 	if !ok {
 		return nil, errors.New("unable to determine instrumentation image")
 	}

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+import (
+	"errors"
+	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+)
+
+const (
+	defaultExporterEndpoint                = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4315"
+	defaultAPIVersion                      = "cloudwatch.aws.amazon.com/v1alpha1"
+	defaultInstrumenation                  = "java-instrumentation"
+	defaultNamespace                       = "default"
+	defaultKind                            = "Instrumentation"
+	otelSampleEnabledKey                   = "OTEL_SMP_ENABLED"
+	otelSampleEnabledDefaultValue          = "true"
+	otelTracesSamplerArgKey                = "OTEL_TRACES_SAMPLER_ARG"
+	otelTracesSamplerArgDefaultValue       = "endpoint=http://amazon-cloudwatch-agent.amazon-cloudwatch:2000"
+	otelTracesSamplerKey                   = "OTEL_TRACES_SAMPLER"
+	otelTracesSamplerDefaultValue          = "xray"
+	otelExporterTracesEndpointKey          = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	otelExporterTracesEndpointDefaultValue = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4315"
+)
+
+func getDefaultInstrumentation() (*v1alpha1.Instrumentation, error) {
+	instrumentationImage, ok := os.LookupEnv("auto-instrumentation-java")
+	if !ok {
+		return nil, errors.New("unable to determine instrumentation image")
+	}
+	return &v1alpha1.Instrumentation{
+		Status: v1alpha1.InstrumentationStatus{},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: defaultAPIVersion,
+			Kind:       defaultKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultInstrumenation,
+			Namespace: defaultNamespace,
+		},
+		Spec: v1alpha1.InstrumentationSpec{
+			Exporter: v1alpha1.Exporter{Endpoint: defaultExporterEndpoint},
+			Propagators: []v1alpha1.Propagator{
+				v1alpha1.TraceContext,
+				v1alpha1.Baggage,
+				v1alpha1.B3,
+				v1alpha1.XRay,
+			},
+			Java: v1alpha1.Java{
+				Image: instrumentationImage,
+				Env: []corev1.EnvVar{
+					{Name: otelSampleEnabledKey, Value: otelSampleEnabledDefaultValue},
+					{Name: otelTracesSamplerArgKey, Value: otelTracesSamplerArgDefaultValue},
+					{Name: otelTracesSamplerKey, Value: otelTracesSamplerDefaultValue},
+					{Name: otelExporterTracesEndpointKey, Value: otelExporterTracesEndpointDefaultValue},
+				},
+			},
+		},
+	}, nil
+}


### PR DESCRIPTION
*Issue #, if available:*
The default instrumentation was hardcoded. This should be parameterized so that the helm chart can dictate which image to use.

*Description of changes:*
Takes the java agent from the command line argument. Helm chart will be updated to inject the image this way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
