### PR TITLE
E2E Test: Add test running to main

### DIFF
--- a/.github/workflows/apm-e2e-test.yml
+++ b/.github/workflows/apm-e2e-test.yml
@@ -23,8 +23,8 @@ env:
   SAMPLE_APP_FRONTEND_SERVICE_IMAGE: ${{ secrets.APM_E2E_SAMPLE_APP_FRONTEND_SERVICE_IMAGE }}
   SAMPLE_APP_REMOTE_SERVICE_IMAGE: ${{ secrets.APM_E2E_SAMPLE_APP_REMOTE_SERVICE_IMAGE }}
   APM_E2E_ONBOARDING_ZIP_S3_URI: ${{ secrets.APM_E2E_ONBOARDING_ZIP_S3_URI }}
-  METRIC_NAMESPACE: AWS/APM
-  APM_LOG_GROUP: /aws/apm/eks
+  METRIC_NAMESPACE: AppSignals
+  APM_LOG_GROUP: /aws/appsignals/eks
   ECR_OPERATOR_STAGING_IMAGE: ${{ secrets.ECR_OPERATOR_STAGING_IMAGE }}
   ECR_OPERATOR_RELEASE_IMAGE: ${{ secrets.ECR_OPERATOR_RELEASE_IMAGE }}
 
@@ -87,7 +87,7 @@ jobs:
 
       - name: Enable APM
         run: |
-          ./enable-apm.sh \
+          ./enable-app-signals.sh \
           ${{ inputs.test-cluster-name }} \
           ${{ env.AWS_DEFAULT_REGION }} \
           ${{ env.SAMPLE_APP_NAMESPACE }}
@@ -160,6 +160,7 @@ jobs:
           --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --cluster ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
@@ -177,6 +178,7 @@ jobs:
           --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --cluster ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
@@ -194,6 +196,7 @@ jobs:
           --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --cluster ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
@@ -207,12 +210,12 @@ jobs:
         if: always()
         run: |
           delete_log_group="aws logs delete-log-group --log-group-name '${{ env.APM_LOG_GROUP }}' --region \$REGION"
-          sed -i "s#$delete_log_group##g" clean-apm.sh
+          sed -i "s#$delete_log_group##g" clean-app-signals.sh
 
       - name: Clean APM
         if: always()
         run: |
-          ./clean-apm.sh \
+          ./clean-app-signals.sh \
           ${{ inputs.test-cluster-name }} \
           ${{ env.AWS_DEFAULT_REGION }} \
           ${{ env.SAMPLE_APP_NAMESPACE }}

--- a/.github/workflows/apm-e2e-test.yml
+++ b/.github/workflows/apm-e2e-test.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          # Checkout apm branch and get only the required resources for testing
+          # Checkout e2e-test branch and get only the required resources for testing
           ref: e2e-test
           sparse-checkout: |
             test

--- a/.github/workflows/apm-e2e-test.yml
+++ b/.github/workflows/apm-e2e-test.yml
@@ -163,6 +163,7 @@ jobs:
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --cluster ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
           --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
           --rollup'
 
@@ -196,6 +197,7 @@ jobs:
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --cluster ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
           --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
           --rollup'
 

--- a/.github/workflows/apm-e2e-test.yml
+++ b/.github/workflows/apm-e2e-test.yml
@@ -1,0 +1,246 @@
+# This is a reusable workflow for running the E2E test for APM.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: APM Enablement E2E Testing
+on:
+  workflow_call:
+    inputs:
+      test-cluster-name:
+        required: true
+        type: string
+      caller-workflow-name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_DEFAULT_REGION: us-east-1
+  TEST_ACCOUNT: ${{ secrets.APM_E2E_TEST_ACCOUNT }}
+  SAMPLE_APP_NAMESPACE: sample-app-namespace
+  SAMPLE_APP_FRONTEND_SERVICE_IMAGE: ${{ secrets.APM_E2E_SAMPLE_APP_FRONTEND_SERVICE_IMAGE }}
+  SAMPLE_APP_REMOTE_SERVICE_IMAGE: ${{ secrets.APM_E2E_SAMPLE_APP_REMOTE_SERVICE_IMAGE }}
+  APM_E2E_ONBOARDING_ZIP_S3_URI: ${{ secrets.APM_E2E_ONBOARDING_ZIP_S3_URI }}
+  METRIC_NAMESPACE: AWS/APM
+  APM_LOG_GROUP: /aws/apm/eks
+  ECR_OPERATOR_STAGING_IMAGE: ${{ secrets.ECR_OPERATOR_STAGING_IMAGE }}
+  ECR_OPERATOR_RELEASE_IMAGE: ${{ secrets.ECR_OPERATOR_RELEASE_IMAGE }}
+
+jobs:
+  apm-e2e-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Checkout apm branch and get only the required resources for testing
+          ref: e2e-test
+          sparse-checkout: |
+            test
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.APM_E2E_TEST_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      # local directory to store the kubernetes config
+      - name: Create kubeconfig directory
+        run: mkdir -p ${{ github.workspace }}/.kube
+
+      - name: Set KUBECONFIG environment variable
+        run: echo KUBECONFIG="${{ github.workspace }}/.kube/config" >> $GITHUB_ENV
+
+      - name: Set up kubeconfig
+        run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Install eksctl
+        run: |
+          mkdir ${{ github.workspace }}/eksctl
+          curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"
+          tar -xzf eksctl_Linux_amd64.tar.gz -C ${{ github.workspace }}/eksctl && rm eksctl_Linux_amd64.tar.gz
+          echo "${{ github.workspace }}/eksctl" >> $GITHUB_PATH
+
+      - name: Create role for AWS access from the sample app
+        id: create_service_account
+        run: |
+          eksctl create iamserviceaccount \
+          --name service-account-${{ env.TESTING_ID }} \
+          --namespace ${{ env.SAMPLE_APP_NAMESPACE }} \
+          --cluster ${{ inputs.test-cluster-name }} \
+          --role-name eks-s3-access-${{ env.TESTING_ID }} \
+          --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess \
+          --region ${{ env.AWS_DEFAULT_REGION }} \
+          --approve
+
+      # Enable APM on the test cluster
+      - name: Pull and unzip enablement script from S3
+        run: aws s3 cp ${{ env.APM_E2E_ONBOARDING_ZIP_S3_URI }} . && unzip -j onboarding.zip
+
+      - name: Set the CW Agent Operator image to the staging image in the manifest
+        if: inputs.caller-workflow-name == 'build-and-upload-staging'
+        run: "sed -i 's#${{ env.ECR_OPERATOR_RELEASE_IMAGE }}#${{ env.ECR_OPERATOR_STAGING_IMAGE }}#g' apm.yaml"
+
+      - name: Enable APM
+        run: |
+          ./enable-apm.sh \
+          ${{ inputs.test-cluster-name }} \
+          ${{ env.AWS_DEFAULT_REGION }} \
+          ${{ env.SAMPLE_APP_NAMESPACE }}
+
+      - name: Set up terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
+
+      - name: Deploy sample app via terraform
+        working-directory: test/terraform/eks
+        run: |
+          terraform init
+          terraform validate
+          terraform apply -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}" \
+            -var="kube_directory_path=${{ github.workspace }}/.kube" \
+            -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
+            -var="test_namespace=${{ env.SAMPLE_APP_NAMESPACE }}" \
+            -var="service_account_aws_access=service-account-${{ env.TESTING_ID }}" \
+            -var="sample_app_image=${{ env.SAMPLE_APP_FRONTEND_SERVICE_IMAGE }}" \
+            -var="sample_remote_app_image=${{ env.SAMPLE_APP_REMOTE_SERVICE_IMAGE }}"
+
+      - name: Wait for sample app pods to come up
+        run: |
+          kubectl wait --for=condition=Ready pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }} \
+
+      - name: Get remote service deployment name and IP
+        run: |
+          echo "REMOTE_SERVICE_DEPLOYMENT_NAME=$(kubectl get deployments -n ${{ env.SAMPLE_APP_NAMESPACE }} --selector=app=remote-app -o jsonpath='{.items[0].metadata.name}')" >> $GITHUB_ENV
+          echo "REMOTE_SERVICE_POD_IP=$(kubectl get pods -n ${{ env.SAMPLE_APP_NAMESPACE }} --selector=app=remote-app -o jsonpath='{.items[0].status.podIP}')" >> $GITHUB_ENV
+
+      - name: Verify pod ADOT image
+        run: |
+          kubectl get pods -n ${{ env.SAMPLE_APP_NAMESPACE }} --output json | \
+          jq '.items[0].status.initContainerStatuses[0].imageID'
+
+      - name: Verify pod CWAgent image
+        run: |
+          kubectl get pods -n amazon-cloudwatch --output json | \
+          jq '.items[0].status.containerStatuses[0].imageID'
+
+      - name: Get the sample app endpoint
+        run: |
+          echo "APP_ENDPOINT=$(terraform output sample_app_endpoint)" >> $GITHUB_ENV
+        working-directory: test/terraform/eks
+
+      - name: Wait for app endpoint to come online
+        run: |
+          attempt_counter=0
+          max_attempts=30
+          until $(curl --output /dev/null --silent --head --fail http://${{ env.APP_ENDPOINT }}); do
+            if [ ${attempt_counter} -eq ${max_attempts} ];then
+              echo "Max attempts reached"
+              exit 1
+            fi
+
+            printf '.'
+            attempt_counter=$(($attempt_counter+1))
+            sleep 10
+          done
+
+      # Validation for pulse telemetry data
+      - name: Call endpoint and validate generated EMF logs
+        id: log-validation
+        working-directory: test/validator
+        run: ./gradlew run --args='-c log-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.APP_ENDPOINT }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
+          --account-id ${{ env.TEST_ACCOUNT }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+          --cluster ${{ inputs.test-cluster-name }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --rollup'
+
+      - name: Call endpoints and validate generated metrics
+        id: metric-validation
+        if: success() || steps.log-validation.outcome == 'failure'
+        working-directory: test/validator
+        run: ./gradlew run --args='-c metric-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.APP_ENDPOINT }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
+          --account-id ${{ env.TEST_ACCOUNT }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+          --cluster ${{ inputs.test-cluster-name }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
+          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --rollup'
+
+      - name: Call endpoints and validate generated traces
+        if: success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure'
+        working-directory: test/validator
+        run: ./gradlew run --args='-c trace-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.APP_ENDPOINT }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
+          --account-id ${{ env.TEST_ACCOUNT }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+          --cluster ${{ inputs.test-cluster-name }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --rollup'
+
+      # Clean up Procedures
+
+      - name: Remove log group deletion command
+        if: always()
+        run: |
+          delete_log_group="aws logs delete-log-group --log-group-name '${{ env.APM_LOG_GROUP }}' --region \$REGION"
+          sed -i "s#$delete_log_group##g" clean-apm.sh
+
+      - name: Clean APM
+        if: always()
+        run: |
+          ./clean-apm.sh \
+          ${{ inputs.test-cluster-name }} \
+          ${{ env.AWS_DEFAULT_REGION }} \
+          ${{ env.SAMPLE_APP_NAMESPACE }}
+
+      # This step also deletes lingering resources from previous test runs
+      - name: Delete all sample app resources
+        if: always()
+        continue-on-error: true
+        timeout-minutes: 10
+        run: kubectl delete namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+
+      - name: Terraform destroy
+        if: always()
+        continue-on-error: true
+        run: |
+          cd test/terraform/eks
+          terraform destroy -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}" \
+            -var="kube_directory_path=${{ github.workspace }}/.kube" \
+            -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
+            -var="test_namespace=${{ env.SAMPLE_APP_NAMESPACE }}" \
+            -var="service_account_aws_access=service-account-${{ env.TESTING_ID }}" \
+            -var="sample_app_image=${{ env.SAMPLE_APP_IMAGE }}"
+
+      - name: Remove aws access service account
+        if: always()
+        continue-on-error: true
+        run: |
+          eksctl delete iamserviceaccount \
+          --name service-account-${{ env.TESTING_ID }} \
+          --namespace ${{ env.SAMPLE_APP_NAMESPACE }} \
+          --cluster ${{ inputs.test-cluster-name }} \
+          --region ${{ env.AWS_DEFAULT_REGION }} \

--- a/.github/workflows/build-and-upload-staging.yml
+++ b/.github/workflows/build-and-upload-staging.yml
@@ -60,3 +60,14 @@ jobs:
           push: true
           tags: ${{ env.ECR_OPERATOR_STAGING_IMAGE }}
           platforms: linux/amd64, linux/arm64
+
+  e2e-test:
+    needs: MakeBinary
+    uses: ./.github/workflows/apm-e2e-test.yml
+    secrets: inherit
+    concurrency:
+      group: 'pulse-cw-agent-operator-test'
+      cancel-in-progress: false
+    with:
+      test-cluster-name: 'pulse-cw-agent-operator-test'
+      caller-workflow-name: 'build-and-upload-staging'


### PR DESCRIPTION
As we don't want the Java validator code and other test resources in the main branch, we are adding a workflow step to call the test from the e2e-test branch. This is a temporary solution while we work to move the tests to a dedicated location.

Copied over from aws-apm-java-instrumentation repo and private-amazon-cloudwatch-agent repo.

Test run showing 5 passed runs:
https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/6593049734
Another test run:
https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/6592292020
Test run with the latest changes:
https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/6750868668

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
