### PR TITLE
Update configmap and service names for cloudwatch-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ metadata:
   namespace: default # use a namespace with pods you'd like to inject
 spec:
   exporter:
-    endpoint: http://amazon-cloudwatch-agent.amazon-cloudwatch:4317
+    endpoint: http://cloudwatch-agent.amazon-cloudwatch:4317
   propagators:
     - tracecontext
     - baggage

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	defaultExporterEndpoint                = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4315"
+	defaultExporterEndpoint                = "http://cloudwatch-agent.amazon-cloudwatch:4315"
 	defaultAPIVersion                      = "cloudwatch.aws.amazon.com/v1alpha1"
 	defaultInstrumenation                  = "java-instrumentation"
 	defaultNamespace                       = "default"
@@ -20,11 +20,11 @@ const (
 	otelSampleEnabledKey                   = "OTEL_SMP_ENABLED"
 	otelSampleEnabledDefaultValue          = "true"
 	otelTracesSamplerArgKey                = "OTEL_TRACES_SAMPLER_ARG"
-	otelTracesSamplerArgDefaultValue       = "endpoint=http://amazon-cloudwatch-agent.amazon-cloudwatch:2000"
+	otelTracesSamplerArgDefaultValue       = "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"
 	otelTracesSamplerKey                   = "OTEL_TRACES_SAMPLER"
 	otelTracesSamplerDefaultValue          = "xray"
 	otelExporterTracesEndpointKey          = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
-	otelExporterTracesEndpointDefaultValue = "http://amazon-cloudwatch-agent.amazon-cloudwatch:4315"
+	otelExporterTracesEndpointDefaultValue = "http://cloudwatch-agent.amazon-cloudwatch:4315"
 )
 
 func getDefaultInstrumentation() (*v1alpha1.Instrumentation, error) {

--- a/pkg/naming/main.go
+++ b/pkg/naming/main.go
@@ -9,8 +9,8 @@ import (
 )
 
 // ConfigMap builds the name for the config map used in the AmazonCloudWatchAgent containers.
-func ConfigMap(agent v1alpha1.AmazonCloudWatchAgent) string {
-	return DNSName(Truncate("%s", 63, agent.Name))
+func ConfigMap(_ v1alpha1.AmazonCloudWatchAgent) string {
+	return "cwaagentconfig"
 }
 
 // ConfigMapVolume returns the name to use for the config map's volume in the pod.
@@ -20,7 +20,7 @@ func ConfigMapVolume() string {
 
 // Container returns the name to use for the container in the pod.
 func Container() string {
-	return "cwa-container"
+	return "cloudwatch-agent"
 }
 
 // Agent builds the agent (deployment/daemonset) name based on the instance.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We are trying to be consistent in our naming of our components to what our existing getting started docs refer to them as.
Accordingly, updating the default config map name and the agent service name used for default instrumentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
