### PR TITLE
Temporarily disable default instrumentation

### DIFF
--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	errMultipleInstancesPossible = errors.New("multiple OpenTelemetry Instrumentation instances available, cannot determine which one to select")
+	errNoInstancesAvailable      = errors.New("no OpenTelemetry Instrumentation instances available")
 )
 
 type instPodMutator struct {
@@ -136,8 +137,9 @@ func (pm *instPodMutator) selectInstrumentationInstanceFromNamespace(ctx context
 	}
 	switch items := len(otelInsts.Items); {
 	case items == 0:
-		pm.Logger.Info("no OpenTelemetry Instrumentation instances available. Using default Instrumentation instance")
-		return getDefaultInstrumentation()
+		//pm.Logger.Info("no OpenTelemetry Instrumentation instances available. Using default Instrumentation instance")
+		//return getDefaultInstrumentation()
+		return nil, errNoInstancesAvailable
 	case items > 1:
 		return nil, errMultipleInstancesPossible
 	default:

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -40,6 +40,6 @@ func TestGetInstrumentationInstanceFromNameSpaceDefault(t *testing.T) {
 	instrumentation, err := podMutator.selectInstrumentationInstanceFromNamespace(context.Background(), namespace)
 
 	assert.Nil(t, err)
+	defaultInst, _ := getDefaultInstrumentation()
 	assert.Equal(t, defaultInst, instrumentation)
-
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Temporarily disable default instrumentation that was introduced as part of https://github.com/aws/amazon-cloudwatch-agent-operator/pull/12


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
