### PR TITLE
Add repositoryDomainMap to all images for cn and us-gov regions

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -13,6 +13,42 @@ Name for cloudwatch-agent
 {{- end }}
 
 {{/*
+Get the current recommended cloudwatch agent image for a region
+*/}}
+{{- define "cloudwatch-agent.image" -}}
+{{- $imageDomain := "" -}}
+{{- $imageDomain = index .Values.agent.image.repositoryDomainMap .Values.region -}}
+{{- if not $imageDomain -}}
+{{- $imageDomain = .Values.agent.image.repositoryDomainMap.public -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $imageDomain .Values.agent.image.repository .Values.agent.image.tag -}}
+{{- end -}}
+
+{{/*
+Get the current recommended cloudwatch agent operator image for a region
+*/}}
+{{- define "cloudwatch-agent-operator.image" -}}
+{{- $imageDomain := "" -}}
+{{- $imageDomain = index .Values.manager.image.repositoryDomainMap .Values.region -}}
+{{- if not $imageDomain -}}
+{{- $imageDomain = .Values.manager.image.repositoryDomainMap.public -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $imageDomain .Values.manager.image.repository .Values.manager.image.tag -}}
+{{- end -}}
+
+{{/*
+Get the current recommended fluent-bit image for a region
+*/}}
+{{- define "fluent-bit.image" -}}
+{{- $imageDomain := "" -}}
+{{- $imageDomain = index .Values.containerLogs.fluentBit.image.repositoryDomainMap .Values.region -}}
+{{- if not $imageDomain -}}
+{{- $imageDomain = .Values.containerLogs.fluentBit.image.repositoryDomainMap.public -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $imageDomain .Values.containerLogs.fluentBit.image.repository .Values.containerLogs.fluentBit.image.tag -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "amazon-cloudwatch-observability.labels" -}}

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "cloudwatch-agent.name" . }}
   namespace: {{ .Release.Namespace }}
 spec:
-  image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag }}"
+  image: {{ template "cloudwatch-agent.image" . }}
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   {{- if .Values.agent.config }}

--- a/helm/templates/fluent-bit-daemonset.yaml
+++ b/helm/templates/fluent-bit-daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: {{ .Values.containerLogs.fluentBit.image.repository }}:{{ .Values.containerLogs.fluentBit.image.tag }}
+        image: {{ template "fluent-bit.image" . }}
         imagePullPolicy: Always
         env:
         - name: AWS_REGION

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- include "amazon-cloudwatch-observability.podLabels" . | nindent 8 }}
     spec:
       containers:
-      - image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"
+      - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
         - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
         command:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,20 +21,32 @@ containerLogs:
   enabled: true
   fluentBit:
     image:
-      repository: public.ecr.aws/aws-observability/aws-for-fluent-bit
+      repository: aws-for-fluent-bit
       tag: 2.31.12.20230911
+      repositoryDomainMap:
+        public: public.ecr.aws/aws-observability
+        cn-north-1: 128054284489.dkr.ecr.cn-north-1.amazonaws.com.cn
+        cn-northwest-1: 128054284489.dkr.ecr.cn-northwest-1.amazonaws.com.cn
+        us-gov-east-1: 161423150738.dkr.ecr.us-gov-east-1.amazonaws.com
+        us-gov-west-1: 161423150738.dkr.ecr.us-gov-west-1.amazonaws.com
 
 ## Provide CloudWatchAgent Operator manager container image and resources.
 ##
 manager:
   name:
   image:
-    repository: public.ecr.aws/cloudwatch-agent/cloudwatch-agent-operator
+    repository: cloudwatch-agent-operator
     tag: 1.0.0
+    repositoryDomainMap:
+      public: public.ecr.aws/cloudwatch-agent
+      cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
+      cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
+      us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
+      us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   autoInstrumentationImage:
     java:
       repository: public.ecr.aws/aws-observability/adot-autoinstrumentation-java
-      tag: v1.32.0
+      tag: v1.31.0
   ports:
     containerPort: 9443
     metricsPort: 8080
@@ -111,27 +123,22 @@ admissionWebhooks:
 agent:
   name:
   image:
-    repository: public.ecr.aws/cloudwatch-agent/cloudwatch-agent
-    tag: 1.300028.1b210
+    repository: cloudwatch-agent
+    tag: 1.300030.1b305
+    repositoryDomainMap:
+      public: public.ecr.aws/cloudwatch-agent
+      cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
+      cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
+      us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
+      us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   enabled: true
   serviceAccount:
     name: # override agent service account name 
   config: # optional config that can be provided to override the defaultConfig
   defaultConfig:
     {
-      "agent": {
-        "debug": true
-      },
-      "traces": {
-        "traces_collected": {
-          "app_signals": {
-          }
-        }
-      },
       "logs": {
         "metrics_collected": {
-          "app_signals": {
-          },
           "kubernetes": {
             "enhanced_container_insights": true
           }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,7 +36,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.0.0
+    tag: 1.0.1
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,8 @@
 # Represents the latest stable release of the CloudWatch Agent
-cloudwatch-agent=1.300028.1b210
+cloudwatch-agent=1.300030.1b305
 
 # Represents the current release of the CloudWatch Agent Operator.
-operator=1.0.0
+operator=1.0.1
 
 # Represents the current release of ADOT Java instrumentation.
-aws-otel-java-instrumentation=v1.30.0
+aws-otel-java-instrumentation=v1.31.0


### PR DESCRIPTION
- Add repositoryDomainMap to all images for cn and us-gov regions
- Remove unnecessary parameters in cloudwatch agent config
- Use adot instrumentation version v1.31.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
