### PR TITLE
Updated the integration tests with resources name changes in addon

### DIFF
--- a/.github/workflows/eks-add-on-integ-test.yml
+++ b/.github/workflows/eks-add-on-integ-test.yml
@@ -11,12 +11,12 @@ on:
       addon_name:
         required: true
         type: string
-        default: "amazon-cloudwatch"
+        default: "amazon-cloudwatch-observability"
         description: "EKS addon name"
       addon_version:
         required: true
         type: string
-        default: "v0.1.0-eksbuild.4"
+        default: "v1.1.0-eksbuild.1"
         description: "EKS addon version"
 
 concurrency:

--- a/.github/workflows/eks-beta-add-on-integ-test.yml
+++ b/.github/workflows/eks-beta-add-on-integ-test.yml
@@ -11,12 +11,12 @@ on:
       addon_name:
         required: true
         type: string
-        default: "amazon-cloudwatch"
+        default: "amazon-cloudwatch-observability"
         description: "EKS addon name"
       addon_version:
         required: true
         type: string
-        default: "v0.1.0-eksbuild.4"
+        default: "v1.1.0-eksbuild.1"
         description: "EKS addon version"
 
 concurrency:

--- a/integration-tests/terraform/eks/variables.tf
+++ b/integration-tests/terraform/eks/variables.tf
@@ -18,12 +18,12 @@ variable "test_dir" {
 
 variable "addon_name" {
   type    = string
-  default = "amazon-cloudwatch"
+  default = "amazon-cloudwatch-observability"
 }
 
 variable "addon_version" {
   type = string
-  default = "v0.1.0-eksbuild.4"
+  default = "v1.1.0-eksbuild.1"
 }
 
 variable "beta" {


### PR DESCRIPTION
*Description of changes:*
Updated integration tests with eks addon resources name change and changed the default addon name and version to amazon-cloudwatch-observability

Testing on Beta cluster: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/6736118187

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
