### PR TITLE
Add integration test for Helm charts

### DIFF
--- a/.github/workflows/helm-integ-test.yml
+++ b/.github/workflows/helm-integ-test.yml
@@ -1,0 +1,98 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Run Helm Charts Integration Tests
+on:
+  workflow_dispatch:
+    inputs:
+      cluster_name:
+        required: true
+        type: string
+        default: "cwagent-operator-helm-integ"
+        description: "EKS cluster name"
+      cluster_namespace:
+        required: true
+        type: string
+        default: "amazon-cloudwatch"
+        description: "EKS cluster namespace"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  TERRAFORM_AWS_ASSUME_ROLE: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
+  AWS_DEFAULT_REGION: us-west-2
+
+jobs:
+  HelmChartsIntegrationTest:
+    name: HelmChartsIntegrationTest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      
+      #  local directory to store the kubernetes config
+      - name: Create kubeconfig directory
+        run: mkdir -p ${{ github.workspace }}/.kube
+
+      - name: Set KUBECONFIG environment variable
+        run: echo KUBECONFIG="${{ github.workspace }}/.kube/config" >> $GITHUB_ENV
+
+      # - name: Set up kubeconfig
+      #   run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Install eksctl
+        run: |
+          mkdir ${{ github.workspace }}/eksctl
+          curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"
+          tar -xzf eksctl_Linux_amd64.tar.gz -C ${{ github.workspace }}/eksctl && rm eksctl_Linux_amd64.tar.gz
+          echo "${{ github.workspace }}/eksctl" >> $GITHUB_PATH
+
+      - name: Verify Terraform version
+        run: terraform --version
+
+      - name: Terraform apply
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 1
+          timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
+          retry_wait_seconds: 5
+          command: |
+            cd integration-tests/terraform/helm
+            terraform init
+            if terraform apply -auto-approve \
+                -var="cluster_name=${{ github.event.inputs.cluster_name }}" \
+                -var="cluster_namespace=${{ github.event.inputs.cluster_namespace }}" \
+                -var="kube_dir=${{ github.workspace }}/.kube"; then
+              terraform destroy -auto-approve
+            else
+              terraform destroy -auto-approve && exit 1
+            fi
+
+      - name: Terraform destroy
+        if: ${{ cancelled() || failure() }}
+        uses: nick-fields/retry@v2
+        with:
+          max_attempts: 3
+          timeout_minutes: 8
+          retry_wait_seconds: 5
+          command: |
+            cd integration-tests/terraform/helm
+            terraform destroy --auto-approve

--- a/.github/workflows/helm-integ-test.yml
+++ b/.github/workflows/helm-integ-test.yml
@@ -50,13 +50,10 @@ jobs:
       
       #  local directory to store the kubernetes config
       - name: Create kubeconfig directory
-        run: mkdir -p ${{ github.workspace }}/.kube
+        run: mkdir -p ${{ github.workspace }}/../../../.kube
 
       - name: Set KUBECONFIG environment variable
-        run: echo KUBECONFIG="${{ github.workspace }}/.kube/config" >> $GITHUB_ENV
-
-      # - name: Set up kubeconfig
-      #   run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ env.AWS_DEFAULT_REGION }}
+        run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
 
       - name: Install eksctl
         run: |
@@ -80,7 +77,7 @@ jobs:
             if terraform apply -auto-approve \
                 -var="cluster_name=${{ github.event.inputs.cluster_name }}" \
                 -var="cluster_namespace=${{ github.event.inputs.cluster_namespace }}" \
-                -var="kube_dir=${{ github.workspace }}/.kube"; then
+                -var="kube_dir=${{ github.workspace }}/../../../.kube"; then
               terraform destroy -auto-approve
             else
               terraform destroy -auto-approve && exit 1

--- a/.github/workflows/helm-integ-test.yml
+++ b/.github/workflows/helm-integ-test.yml
@@ -7,17 +7,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-    inputs:
-      cluster_name:
-        required: true
-        type: string
-        default: "cwagent-operator-helm-integ"
-        description: "EKS cluster name"
-      cluster_namespace:
-        required: true
-        type: string
-        default: "amazon-cloudwatch"
-        description: "EKS cluster namespace"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
@@ -71,8 +60,6 @@ jobs:
             cd integration-tests/terraform/helm
             terraform init
             if terraform apply -auto-approve \
-                -var="cluster_name=${{ github.event.inputs.cluster_name }}" \
-                -var="cluster_namespace=${{ github.event.inputs.cluster_namespace }}" \
                 -var="kube_dir=${{ github.workspace }}/../../../.kube"; then
               terraform destroy -auto-approve
             else

--- a/.github/workflows/helm-integ-test.yml
+++ b/.github/workflows/helm-integ-test.yml
@@ -3,6 +3,9 @@
 
 name: Run Helm Charts Integration Tests
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       cluster_name:

--- a/.github/workflows/helm-integ-test.yml
+++ b/.github/workflows/helm-integ-test.yml
@@ -58,13 +58,6 @@ jobs:
       - name: Set KUBECONFIG environment variable
         run: echo KUBECONFIG="${{ github.workspace }}/../../../.kube/config" >> $GITHUB_ENV
 
-      - name: Install eksctl
-        run: |
-          mkdir ${{ github.workspace }}/eksctl
-          curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"
-          tar -xzf eksctl_Linux_amd64.tar.gz -C ${{ github.workspace }}/eksctl && rm eksctl_Linux_amd64.tar.gz
-          echo "${{ github.workspace }}/eksctl" >> $GITHUB_PATH
-
       - name: Verify Terraform version
         run: terraform --version
 

--- a/integration-tests/eks/validateResources_test.go
+++ b/integration-tests/eks/validateResources_test.go
@@ -66,7 +66,7 @@ func TestOperatorOnEKs(t *testing.T) {
 		// - amazon-cloudwatch-observability-controller-manager-*
 		// - fluent-bit-*
 		if match, _ := regexp.MatchString(podNameRegex, pod.Name); !match {
-			assert.Fail(t, "Cluster Pods are not created correctly by Helm Charts")
+			assert.Fail(t, "Cluster Pods are not created correctly")
 		}
 	}
 
@@ -82,7 +82,7 @@ func TestOperatorOnEKs(t *testing.T) {
 		// - cloudwatch-agent-headless
 		// - cloudwatch-agent-monitoring
 		if match, _ := regexp.MatchString(serviceNameRegex, service.Name); !match {
-			assert.Fail(t, "Cluster Service is not created correctly by Helm Charts")
+			assert.Fail(t, "Cluster Service is not created correctly")
 		}
 	}
 
@@ -111,7 +111,7 @@ func TestOperatorOnEKs(t *testing.T) {
 		// - cloudwatch-agent
 		// - fluent-bit
 		if match, _ := regexp.MatchString(agentName+"|fluent-bit", daemonSet.Name); !match {
-			assert.Fail(t, "DaemonSet is created correctly by Helm Charts")
+			assert.Fail(t, "DaemonSet is created correctly")
 		}
 	}
 

--- a/integration-tests/eks/validateResources_test.go
+++ b/integration-tests/eks/validateResources_test.go
@@ -9,10 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"testing"
 
 	arv1 "k8s.io/api/admissionregistration/v1"
 	appsV1 "k8s.io/api/apps/v1"
@@ -23,9 +22,15 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const nameSpace = "amazon-cloudwatch"
+const (
+	nameSpace        = "amazon-cloudwatch"
+	addOnName        = "amazon-cloudwatch-observability"
+	agentName        = "cloudwatch-agent"
+	podNameRegex     = "(" + agentName + "|" + addOnName + "-controller-manager|fluent-bit)-*"
+	serviceNameRegex = agentName + "(-headless|-monitoring)?|" + addOnName + "-webhook-service"
+)
 
-func TestK8s(t *testing.T) {
+func TestOperatorOnEKs(t *testing.T) {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
 		t.Fatalf("error getting user home dir: %v\n", err)
@@ -52,29 +57,34 @@ func TestK8s(t *testing.T) {
 	//Validating the number of pods and status
 	pods, err := ListPods(nameSpace, clientSet)
 	assert.NoError(t, err)
+	assert.Len(t, pods.Items, 3)
 	for _, pod := range pods.Items {
 		fmt.Println("pod name: " + pod.Name + " namespace:" + pod.Namespace)
+		assert.Equal(t, v1.PodRunning, pod.Status.Phase)
+		// matches
+		// - cloudwatch-agent-*
+		// - amazon-cloudwatch-observability-controller-manager-*
+		// - fluent-bit-*
+		if match, _ := regexp.MatchString(podNameRegex, pod.Name); !match {
+			assert.Fail(t, "Cluster Pods are not created correctly by Helm Charts")
+		}
 	}
-	assert.Len(t, pods.Items, 3)
-	assert.Equal(t, v1.PodRunning, pods.Items[0].Status.Phase)
-	assert.Equal(t, v1.PodRunning, pods.Items[1].Status.Phase)
-	assert.Equal(t, v1.PodRunning, pods.Items[2].Status.Phase)
-
-	assert.True(t, validateOperatorPodRegexMatch(pods.Items[0].Name))
-	assert.True(t, validateAgentPodRegexMatch(pods.Items[1].Name))
-	assert.True(t, validateFluentBitPodRegexMatch(pods.Items[2].Name))
 
 	//Validating the services
 	services, err := ListServices(nameSpace, clientSet)
 	assert.NoError(t, err)
+	assert.Len(t, services.Items, 4)
 	for _, service := range services.Items {
 		fmt.Println("service name: " + service.Name + " namespace:" + service.Namespace)
+		// matches
+		// - amazon-cloudwatch-observability-webhook-service
+		// - cloudwatch-agent
+		// - cloudwatch-agent-headless
+		// - cloudwatch-agent-monitoring
+		if match, _ := regexp.MatchString(serviceNameRegex, service.Name); !match {
+			assert.Fail(t, "Cluster Service is not created correctly by Helm Charts")
+		}
 	}
-	assert.Len(t, services.Items, 4)
-	assert.Equal(t, "amazon-cloudwatch-observability-webhook-service", services.Items[0].Name)
-	assert.Equal(t, "cloudwatch-agent", services.Items[1].Name)
-	assert.Equal(t, "cloudwatch-agent-headless", services.Items[2].Name)
-	assert.Equal(t, "cloudwatch-agent-monitoring", services.Items[3].Name)
 
 	//Validating the Deployment
 	deployments, err := ListDeployments(nameSpace, clientSet)
@@ -83,7 +93,9 @@ func TestK8s(t *testing.T) {
 		fmt.Println("deployment name: " + deployment.Name + " namespace:" + deployment.Namespace)
 	}
 	assert.Len(t, deployments.Items, 1)
-	assert.Equal(t, "amazon-cloudwatch-observability-controller-manager", deployments.Items[0].Name)
+	// matches
+	// - amazon-cloudwatch-observability-controller-manager
+	assert.Equal(t, addOnName+"-controller-manager", deployments.Items[0].Name)
 	for _, deploymentCondition := range deployments.Items[0].Status.Conditions {
 		fmt.Println("deployment condition type: " + deploymentCondition.Type)
 	}
@@ -92,61 +104,64 @@ func TestK8s(t *testing.T) {
 	//Validating the Daemon Sets
 	daemonSets, err := ListDaemonSets(nameSpace, clientSet)
 	assert.NoError(t, err)
+	assert.Len(t, daemonSets.Items, 2)
 	for _, daemonSet := range daemonSets.Items {
 		fmt.Println("daemonSet name: " + daemonSet.Name + " namespace:" + daemonSet.Namespace)
+		// matches
+		// - cloudwatch-agent
+		// - fluent-bit
+		if match, _ := regexp.MatchString(agentName+"|fluent-bit", daemonSet.Name); !match {
+			assert.Fail(t, "DaemonSet is created correctly by Helm Charts")
+		}
 	}
-	assert.Len(t, daemonSets.Items, 2)
-	assert.Equal(t, "cloudwatch-agent", daemonSets.Items[0].Name)
-	assert.Equal(t, "fluent-bit", daemonSets.Items[1].Name)
 
 	// Validating Service Accounts
 	serviceAccounts, err := ListServiceAccounts(nameSpace, clientSet)
 	assert.NoError(t, err)
-	for _, serviceAcc := range serviceAccounts.Items {
-		fmt.Println("serviceAccount name: " + serviceAcc.Name + " namespace:" + serviceAcc.Namespace)
+	for _, sa := range serviceAccounts.Items {
+		fmt.Println("serviceAccounts name: " + sa.Name + " namespace:" + sa.Namespace)
 	}
-	assert.True(t, validateServiceAccount(serviceAccounts, "amazon-cloudwatch-observability-controller-manager"))
-	assert.True(t, validateServiceAccount(serviceAccounts, "cloudwatch-agent"))
+	// searches
+	// - amazon-cloudwatch-observability-controller-manager
+	// - cloudwatch-agent
+	assert.True(t, validateServiceAccount(serviceAccounts, addOnName+"-controller-manager"))
+	assert.True(t, validateServiceAccount(serviceAccounts, agentName))
 
 	//Validating ClusterRoles
 	clusterRoles, err := ListClusterRoles(clientSet)
 	assert.NoError(t, err)
-	assert.True(t, validateClusterRoles(clusterRoles, "amazon-cloudwatch-observability-manager-role"))
-	assert.True(t, validateClusterRoles(clusterRoles, "cloudwatch-agent-role"))
+	// searches
+	// - amazon-cloudwatch-observability-manager-role
+	// - cloudwatch-agent-role
+	assert.True(t, validateClusterRoles(clusterRoles, addOnName+"-manager-role"))
+	assert.True(t, validateClusterRoles(clusterRoles, agentName+"-role"))
 
 	//Validating ClusterRoleBinding
 	clusterRoleBindings, err := ListClusterRoleBindings(clientSet)
 	assert.NoError(t, err)
-	assert.True(t, validateClusterRoleBindings(clusterRoleBindings, "amazon-cloudwatch-observability-manager-rolebinding"))
-	assert.True(t, validateClusterRoleBindings(clusterRoleBindings, "cloudwatch-agent-role-binding"))
+	// searches
+	// - amazon-cloudwatch-observability-manager-rolebinding
+	// - cloudwatch-agent-role-binding
+	assert.True(t, validateClusterRoleBindings(clusterRoleBindings, addOnName+"-manager-rolebinding"))
+	assert.True(t, validateClusterRoleBindings(clusterRoleBindings, agentName+"-role-binding"))
 
 	//Validating MutatingWebhookConfiguration
 	mutatingWebhookConfigurations, err := ListMutatingWebhookConfigurations(clientSet)
 	assert.NoError(t, err)
-	assert.Equal(t, "amazon-cloudwatch-observability-mutating-webhook-configuration", mutatingWebhookConfigurations.Items[0].Name)
 	assert.Len(t, mutatingWebhookConfigurations.Items[0].Webhooks, 3)
+	// searches
+	// - amazon-cloudwatch-observability-mutating-webhook-configuration
+	assert.Equal(t, addOnName+"-mutating-webhook-configuration", mutatingWebhookConfigurations.Items[0].Name)
 
 	//Validating ValidatingWebhookConfiguration
 	validatingWebhookConfigurations, err := ListValidatingWebhookConfigurations(clientSet)
 	assert.NoError(t, err)
-	assert.Equal(t, "amazon-cloudwatch-observability-validating-webhook-configuration", validatingWebhookConfigurations.Items[0].Name)
 	assert.Len(t, validatingWebhookConfigurations.Items[0].Webhooks, 4)
+	// searches
+	// - amazon-cloudwatch-observability-validating-webhook-configuration
+	assert.Equal(t, addOnName+"-validating-webhook-configuration", validatingWebhookConfigurations.Items[0].Name)
 }
 
-func validateAgentPodRegexMatch(podName string) bool {
-	agentPodMatch, _ := regexp.MatchString("cloudwatch-agent-*", podName)
-	return agentPodMatch
-}
-
-func validateOperatorPodRegexMatch(podName string) bool {
-	operatorPodMatch, _ := regexp.MatchString("amazon-cloudwatch-observability-controller-manager-*", podName)
-	return operatorPodMatch
-}
-
-func validateFluentBitPodRegexMatch(podName string) bool {
-	fluentBitPodMatch, _ := regexp.MatchString("fluent-bit-*", podName)
-	return fluentBitPodMatch
-}
 func validateServiceAccount(serviceAccounts *v1.ServiceAccountList, serviceAccountName string) bool {
 	for _, serviceAccount := range serviceAccounts.Items {
 		if serviceAccount.Name == serviceAccountName {

--- a/integration-tests/terraform/eks/variables.tf
+++ b/integration-tests/terraform/eks/variables.tf
@@ -13,7 +13,7 @@ variable "k8s_version" {
 
 variable "test_dir" {
   type    = string
-  default = "../../eks-addon"
+  default = "../../eks"
 }
 
 variable "addon_name" {

--- a/integration-tests/terraform/helm/main.tf
+++ b/integration-tests/terraform/helm/main.tf
@@ -1,0 +1,126 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+module "common" {
+  source = "../common"
+}
+
+module "basic_components" {
+  source = "../basic_components"
+}
+
+locals {
+  aws_eks  = "aws eks --region ${var.region}"
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = aws_eks_cluster.this.name
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "${var.cluster_name}-${module.common.testing_id}"
+  role_arn = module.basic_components.role_arn
+  version  = var.k8s_version
+  vpc_config {
+    subnet_ids         = module.basic_components.public_subnet_ids
+    security_group_ids = [module.basic_components.security_group]
+  }
+}
+
+# EKS Node Groups
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${var.cluster_name}-node"
+  node_role_arn   = aws_iam_role.node_role.arn
+  subnet_ids      = module.basic_components.public_subnet_ids
+
+  scaling_config {
+    desired_size = 1
+    max_size     = 1
+    min_size     = 1
+  }
+
+  ami_type       = "AL2_x86_64"
+  capacity_type  = "ON_DEMAND"
+  disk_size      = 20
+  instance_types = ["t3a.medium"]
+
+  depends_on = [
+    aws_iam_role_policy_attachment.node_AmazonEC2ContainerRegistryReadOnly,
+    aws_iam_role_policy_attachment.node_AmazonEKS_CNI_Policy,
+    aws_iam_role_policy_attachment.node_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.node_CloudWatchAgentServerPolicy
+  ]
+}
+
+# EKS Node IAM Role
+resource "aws_iam_role" "node_role" {
+  name = "${var.cluster_name}-Worker-Role-${module.common.testing_id}"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "node_CloudWatchAgentServerPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.node_role.name
+}
+
+resource "null_resource" "kubectl" {
+  depends_on = [
+    aws_eks_cluster.this,
+    aws_eks_node_group.this
+  ]
+  provisioner "local-exec" {
+    command = <<-EOT
+      ${local.aws_eks} update-kubeconfig --name ${aws_eks_cluster.this.name}
+      ${local.aws_eks} list-clusters --output text
+      ${local.aws_eks} describe-cluster --name ${aws_eks_cluster.this.name} --output text
+    EOT
+  }
+}
+
+resource "helm_release" "this" {
+  depends_on = [
+    null_resource.kubectl
+  ]
+  name = "amazon-cloudwatch-observability"
+  namespace = "${var.cluster_namespace}"
+  chart      = "${var.test_dir}" 
+}
+
+resource "null_resource" "validator" {
+  depends_on = [
+    helm_release.this
+  ]
+  provisioner "local-exec" {
+    command = "go test ${var.test_dir} -v"
+  }
+}

--- a/integration-tests/terraform/helm/main.tf
+++ b/integration-tests/terraform/helm/main.tf
@@ -12,7 +12,6 @@ module "basic_components" {
 locals {
   aws_eks  = "aws eks --region ${var.region}"
   cluster_name = var.cluster_name != "" ? var.cluster_name : "cwagent-operator-helm-integ"
-  cluster_namespace = var.cluster_namespace != "" ? var.cluster_namespace : "amazon-cloudwatch"
 }
 
 data "aws_eks_cluster_auth" "this" {
@@ -114,7 +113,7 @@ resource "helm_release" "this" {
     null_resource.kubectl
   ]
   name = "amazon-cloudwatch-observability"
-  namespace = "${local.cluster_namespace}"
+  namespace = "amazon-cloudwatch"
   create_namespace = true
   chart      = "${var.helm_dir}" 
 }

--- a/integration-tests/terraform/helm/providers.tf
+++ b/integration-tests/terraform/helm/providers.tf
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+provider "aws" {
+  region = var.region
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "${var.kube_dir}/config"
+  }
+}

--- a/integration-tests/terraform/helm/variables.tf
+++ b/integration-tests/terraform/helm/variables.tf
@@ -31,8 +31,3 @@ variable "cluster_name" {
   type    = string
   default = "cwagent-operator-helm-integ"
 }
-
-variable "cluster_namespace" {
-  type = string
-  default = "amazon-cloudwatch"
-}

--- a/integration-tests/terraform/helm/variables.tf
+++ b/integration-tests/terraform/helm/variables.tf
@@ -14,7 +14,7 @@ variable "k8s_version" {
 # eks addon and helm tests are similar
 variable "test_dir" {
   type    = string
-  default = "../../eks-addon"
+  default = "../../eks"
 }
 
 variable "helm_dir" {

--- a/integration-tests/terraform/helm/variables.tf
+++ b/integration-tests/terraform/helm/variables.tf
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "k8s_version" {
+  type    = string
+  default = "1.25"
+}
+
+# eks addon and helm tests are similar
+variable "test_dir" {
+  type    = string
+  default = "../../eks-addon"
+}
+
+variable "helm_dir" {
+  type    = string
+  default = "../../../helm"
+}
+
+variable "kube_dir" {
+  type    = string
+  default = "~/.kube"
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "cwagent-operator-helm-integ"
+}
+
+variable "cluster_namespace" {
+  type = string
+  default = "amazon-cloudwatch"
+}


### PR DESCRIPTION
*Description of changes:*
Add integration tests that are similar to ESK add-on for Helm charts. This PR also consolidates add-on and helm charts tests into single test function since they validates the same attributes and components. 

Changes:
- add terraform integ test for Helm
- deletes EKS add-on test function then use consolidated EKS test function for both addon and helm

Test run: 
- https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/6850938986

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
