### PR TITLE
Update terraform to not change cluster context name

### DIFF
--- a/test/terraform/eks/main.tf
+++ b/test/terraform/eks/main.tf
@@ -47,7 +47,7 @@ provider "kubectl" {
 data "template_file" "kubeconfig_file" {
   template = file("./kubeconfig.tpl")
   vars = {
-    CLUSTER_NAME : data.aws_eks_cluster.testing_cluster.name
+    CLUSTER_NAME : var.eks_cluster_context_name
     CA_DATA : data.aws_eks_cluster.testing_cluster.certificate_authority[0].data
     SERVER_ENDPOINT : data.aws_eks_cluster.testing_cluster.endpoint
     TOKEN = data.aws_eks_cluster_auth.testing_cluster.token

--- a/test/terraform/eks/variables.tf
+++ b/test/terraform/eks/variables.tf
@@ -25,6 +25,10 @@ variable "eks_cluster_name" {
   default = "pulse-canary-cluster"
 }
 
+variable "eks_cluster_context_name" {
+  default = "us-east-1.pulse-cw-agent-operator-test"
+}
+
 variable "test_namespace" {
   default = "sample-app-namespace"
 }


### PR DESCRIPTION
*Issue #, if available:*
Duplicate code change for this PR: https://github.com/aws-observability/aws-apm-java-instrumentation/pull/214/files



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
