### PR TITLE
E2E Testing: Fix reference to enablement script file

### DIFF
--- a/.github/workflows/apm-e2e-test.yml
+++ b/.github/workflows/apm-e2e-test.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Set the CW Agent Operator image to the staging image in the manifest
         if: inputs.caller-workflow-name == 'build-and-upload-staging'
-        run: "sed -i 's#${{ env.ECR_OPERATOR_RELEASE_IMAGE }}#${{ env.ECR_OPERATOR_STAGING_IMAGE }}#g' apm.yaml"
+        run: "sed -i 's#${{ env.ECR_OPERATOR_RELEASE_IMAGE }}#${{ env.ECR_OPERATOR_STAGING_IMAGE }}#g' app-signals.yaml"
 
       - name: Enable APM
         run: |


### PR DESCRIPTION
File is now `app-signals.yaml`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
