### PR TITLE
Fix the issue with cluster name containing only numeric values

### DIFF
--- a/helm/templates/fluent-bit-daemonset.yaml
+++ b/helm/templates/fluent-bit-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         - name: AWS_REGION
           value: {{ .Values.region }}
         - name: CLUSTER_NAME
-          value: {{ .Values.clusterName }}
+          value: {{ .Values.clusterName | quote }}
         - name: READ_FROM_HEAD
           value: "Off"
         - name: READ_FROM_TAIL


### PR DESCRIPTION
*Issue #, if available:*
EKS resource creation fails when cluster name contains only numbers. The error looks similar to:
```
possible invalid configuration values: failed to create typed patch object (amazon-cloudwatch/fluent-bit; apps/v1, Kind=DaemonSet): .spec.template.spec.containers[name="fluent-bit"].env[name="CLUSTER_NAME"].value: expected string, got &value.valueUnstructured{Value:xxxx}
```

*Description of changes:*
Wrap `CLUSTER_NAME` spec value with double quotes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
