### PR TITLE
Change fluent bit configmap to use log level error

### DIFF
--- a/helm/templates/fluent-bit-configmap.yaml
+++ b/helm/templates/fluent-bit-configmap.yaml
@@ -10,7 +10,7 @@ data:
     [SERVICE]
         Flush                     5
         Grace                     30
-        Log_Level                 info
+        Log_Level                 error
         Daemon                    off
         Parsers_File              parsers.conf
         storage.path              /var/fluent-bit/state/flb-storage/


### PR DESCRIPTION
*Issue #, if available:*
Fluent Bit log level info can create large volume of logs causing high cost to CW Logs. Error should be sufficient.

*Description of changes:*
Change fluent bit config map to use log level error instead of info.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
