### PR TITLE
E2E Testing: Add Fluent Bit image ID logging

### DIFF
--- a/.github/workflows/appsignals-e2e-test.yml
+++ b/.github/workflows/appsignals-e2e-test.yml
@@ -154,6 +154,11 @@ jobs:
           kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=cloudwatch-agent -o json | \
           jq '.items[0].status.containerStatuses[0].imageID'
 
+      - name: Log pod Fluent Bit image ID
+        run: |
+          kubectl get pods -n amazon-cloudwatch -l k8s-app=fluent-bit -o json | \
+          jq '.items[0].status.containerStatuses[0].imageID'
+
       - name: Log pod CWAgent Operator image ID and save image to the environment
         run: |
           kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-observability -o json | \


### PR DESCRIPTION
Quick PR to add logging of Fluent Bit image ID. This will allow testers to check the exact version of Fluent Bit being used in app signals enablement, the same way we do for ADOT and CW Agent.

Workflow run showing it works as expected: [link](https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/7269050885/job/19806040067#step:21:24)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
