### PR TITLE
Added logic to parse the receiver ports from cw agent config json

### DIFF
--- a/pkg/collector/adapters/config_from.go
+++ b/pkg/collector/adapters/config_from.go
@@ -7,7 +7,6 @@ package adapters
 import (
 	"encoding/json"
 	"errors"
-
 	"gopkg.in/yaml.v2"
 )
 
@@ -30,6 +29,72 @@ func ConfigFromString(configStr string) (map[interface{}]interface{}, error) {
 
 func ConfigFromJSONString(configStr string) (map[string]interface{}, error) {
 	config := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(configStr), &config); err != nil {
+		return nil, ErrInvalidJSON
+	}
+
+	return config, nil
+}
+
+type CwaConfig struct {
+	Metrics *metric `json:"metrics,omitempty"`
+	Logs    *log    `json:"logs,omitempty"`
+	Traces  *trace  `json:"traces,omitempty"`
+}
+
+type metric struct {
+	MetricsCollected *metricCollected `json:"metrics_collected,omitempty"`
+}
+
+type log struct {
+	LogMetricsCollected *logMetricCollected `json:"metrics_collected,omitempty"`
+}
+
+type trace struct {
+	TracesCollected *traceCollected `json:"traces_collected,omitempty"`
+}
+
+type metricCollected struct {
+	StatsD   *statsD   `json:"statsd,omitempty"`
+	CollectD *collectD `json:"collectd,omitempty"`
+}
+
+type logMetricCollected struct {
+	EMF *emf `json:"emf,omitempty"`
+}
+
+type traceCollected struct {
+	XRay *xray `json:"xray,omitempty"`
+	OTLP *otlp `json:"otlp,omitempty"`
+}
+
+type statsD struct {
+	ServiceAddress string `json:"service_address,omitempty"`
+}
+
+type collectD struct {
+	ServiceAddress string `json:"service_address,omitempty"`
+}
+
+type emf struct {
+}
+
+type xray struct {
+	BindAddress string    `json:"bind_address,omitempty"`
+	TCPProxy    *tcpProxy `json:"tcp_proxy,omitempty"`
+}
+
+type tcpProxy struct {
+	BindAddress string `json:"bind_address,omitempty"`
+}
+
+type otlp struct {
+	GRPCEndpoint string `json:"grpc_endpoint,omitempty"`
+	HTTPEndpoint string `json:"http_endpoint,omitempty"`
+}
+
+func ConfigStructFromJSONString(configStr string) (*CwaConfig, error) {
+	var config *CwaConfig
 	if err := json.Unmarshal([]byte(configStr), &config); err != nil {
 		return nil, ErrInvalidJSON
 	}

--- a/pkg/collector/adapters/config_from.go
+++ b/pkg/collector/adapters/config_from.go
@@ -96,7 +96,7 @@ type otlp struct {
 func ConfigStructFromJSONString(configStr string) (*CwaConfig, error) {
 	var config *CwaConfig
 	if err := json.Unmarshal([]byte(configStr), &config); err != nil {
-		return nil, ErrInvalidJSON
+		return nil, err
 	}
 
 	return config, nil

--- a/pkg/collector/common.go
+++ b/pkg/collector/common.go
@@ -7,17 +7,55 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var CloudwatchAgentPorts = []corev1.ServicePort{
+var AppSignalsCloudwatchAgentPorts = []corev1.ServicePort{
 	{
-		Name: "otlp-grpc",
+		Name: AppSignalsGrpc,
 		Port: 4315,
 	},
 	{
-		Name: "otlp-http",
+		Name: AppSignalsHttp,
 		Port: 4316,
 	},
 	{
-		Name: "aws-proxy",
+		Name: AppSignalsProxy,
+		Port: 2000,
+	},
+}
+
+const (
+	StatsD          = "statsd"
+	CollectD        = "collectd"
+	XrayProxy       = "aws-proxy"
+	XrayTraces      = "aws-traces"
+	OtlpGrpc        = "otlp-grpc"
+	OtlpHttp        = "otlp-http"
+	AppSignalsGrpc  = "appsignals-grpc"
+	AppSignalsHttp  = "appsignals-http"
+	AppSignalsProxy = "appsignals-xray"
+	EMF             = "emf"
+	CWA             = "cwa-"
+)
+
+var receiverDefaultPortsMap = map[string]int32{
+	StatsD:     8125,
+	CollectD:   25826,
+	XrayTraces: 2000,
+	OtlpGrpc:   4317,
+	OtlpHttp:   4318,
+	EMF:        25888,
+}
+
+var apmPortToServicePortMap = map[int32]corev1.ServicePort{
+	4315: {
+		Name: AppSignalsGrpc,
+		Port: 4315,
+	},
+	4316: {
+		Name: AppSignalsHttp,
+		Port: 4316,
+	},
+	2000: {
+		Name: AppSignalsProxy,
 		Port: 2000,
 	},
 }

--- a/pkg/collector/common.go
+++ b/pkg/collector/common.go
@@ -5,22 +5,8 @@ package collector
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"sort"
 )
-
-var AppSignalsCloudwatchAgentPorts = []corev1.ServicePort{
-	{
-		Name: AppSignalsGrpc,
-		Port: 4315,
-	},
-	{
-		Name: AppSignalsHttp,
-		Port: 4316,
-	},
-	{
-		Name: AppSignalsProxy,
-		Port: 2000,
-	},
-}
 
 const (
 	StatsD          = "statsd"
@@ -45,7 +31,7 @@ var receiverDefaultPortsMap = map[string]int32{
 	EMF:        25888,
 }
 
-var apmPortToServicePortMap = map[int32]corev1.ServicePort{
+var AppSignalsPortToServicePortMap = map[int32]corev1.ServicePort{
 	4315: {
 		Name: AppSignalsGrpc,
 		Port: 4315,
@@ -58,4 +44,15 @@ var apmPortToServicePortMap = map[int32]corev1.ServicePort{
 		Name: AppSignalsProxy,
 		Port: 2000,
 	},
+}
+
+func PortMapToServicePortList(portMap map[int32]corev1.ServicePort) []corev1.ServicePort {
+	ports := make([]corev1.ServicePort, 0, len(portMap))
+	for _, p := range portMap {
+		ports = append(ports, p)
+	}
+	sort.Slice(ports, func(i, j int) bool {
+		return ports[i].Name < ports[j].Name
+	})
+	return ports
 }

--- a/pkg/collector/container_test.go
+++ b/pkg/collector/container_test.go
@@ -1,0 +1,179 @@
+package collector
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
+	"testing"
+)
+
+var logger = logf.Log.WithName("unit-tests")
+
+func TestStatsDGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/statsDAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(8135), containerPorts[CWA+StatsD].ContainerPort)
+	assert.Equal(t, CWA+StatsD, containerPorts[CWA+StatsD].Name)
+}
+
+func TestDefaultStatsDGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/statsDDefaultAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(8125), containerPorts[StatsD].ContainerPort)
+	assert.Equal(t, StatsD, containerPorts[StatsD].Name)
+}
+
+func TestCollectDGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/collectDAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(25936), containerPorts[CWA+CollectD].ContainerPort)
+	assert.Equal(t, CWA+CollectD, containerPorts[CWA+CollectD].Name)
+}
+
+func TestDefaultCollectDGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/collectDDefaultAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(25826), containerPorts[CollectD].ContainerPort)
+	assert.Equal(t, CollectD, containerPorts[CollectD].Name)
+}
+
+func TestEMFGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/emfAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(25888), containerPorts[EMF].ContainerPort)
+	assert.Equal(t, EMF, containerPorts[EMF].Name)
+}
+
+func TestXrayAndOTLPGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/xrayAndOTLPAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 5, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(4327), containerPorts[CWA+OtlpGrpc].ContainerPort)
+	assert.Equal(t, CWA+OtlpGrpc, containerPorts[CWA+OtlpGrpc].Name)
+	assert.Equal(t, int32(4328), containerPorts[CWA+OtlpHttp].ContainerPort)
+	assert.Equal(t, CWA+OtlpHttp, containerPorts[CWA+OtlpHttp].Name)
+}
+
+func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/xrayAndOTLPDefaultAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 5, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(4317), containerPorts[OtlpGrpc].ContainerPort)
+	assert.Equal(t, OtlpGrpc, containerPorts[OtlpGrpc].Name)
+	assert.Equal(t, int32(4318), containerPorts[OtlpHttp].ContainerPort)
+	assert.Equal(t, OtlpHttp, containerPorts[OtlpHttp].Name)
+}
+
+func TestXRayGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/xrayAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 5, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
+	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
+	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
+	assert.Equal(t, CWA+XrayProxy, containerPorts[CWA+XrayProxy].Name)
+}
+
+func TestXRayWithBindAddressDefaultGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/xrayAgentConfig.json")
+	strings.Replace(cfg, "2800", "2000", 1)
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 5, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
+	assert.Equal(t, CWA+XrayProxy, containerPorts[CWA+XrayProxy].Name)
+}
+
+func TestXRayWithTCPProxyBindAddressDefaultGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/xrayAgentConfig.json")
+	strings.Replace(cfg, "2900", "2000", 1)
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 5, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
+	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
+}
+
+func TestNilMetricsGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/nilMetrics.json")
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+}
+
+func getJSONStringFromFile(path string) string {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(buf)
+}

--- a/pkg/collector/container_test.go
+++ b/pkg/collector/container_test.go
@@ -213,6 +213,19 @@ func TestMultipleReceiversGetContainerPorts(t *testing.T) {
 	assert.Equal(t, CWA+OtlpHttp, containerPorts[CWA+OtlpHttp].Name)
 }
 
+func TestInvalidConfigGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/nilMetrics.json")
+	cfg = cfg + ","
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+}
+
 func getJSONStringFromFile(path string) string {
 	buf, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/collector/container_test.go
+++ b/pkg/collector/container_test.go
@@ -170,6 +170,33 @@ func TestNilMetricsGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 }
 
+func TestMultipleReceiversGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/multipleReceiversAgentConfig.json")
+	strings.Replace(cfg, "2900", "2000", 1)
+	containerPorts := getContainerPorts(logger, cfg)
+	assert.Equal(t, 10, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[AppSignalsHttp].ContainerPort)
+	assert.Equal(t, AppSignalsHttp, containerPorts[AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
+	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
+	assert.Equal(t, int32(8135), containerPorts[CWA+StatsD].ContainerPort)
+	assert.Equal(t, CWA+StatsD, containerPorts[CWA+StatsD].Name)
+	assert.Equal(t, int32(25936), containerPorts[CWA+CollectD].ContainerPort)
+	assert.Equal(t, CWA+CollectD, containerPorts[CWA+CollectD].Name)
+	assert.Equal(t, int32(25888), containerPorts[EMF].ContainerPort)
+	assert.Equal(t, EMF, containerPorts[EMF].Name)
+	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
+	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
+	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
+	assert.Equal(t, CWA+XrayProxy, containerPorts[CWA+XrayProxy].Name)
+	assert.Equal(t, int32(4327), containerPorts[CWA+OtlpGrpc].ContainerPort)
+	assert.Equal(t, CWA+OtlpGrpc, containerPorts[CWA+OtlpGrpc].Name)
+	assert.Equal(t, int32(4328), containerPorts[CWA+OtlpHttp].ContainerPort)
+	assert.Equal(t, CWA+OtlpHttp, containerPorts[CWA+OtlpHttp].Name)
+}
+
 func getJSONStringFromFile(path string) string {
 	buf, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/collector/container_test.go
+++ b/pkg/collector/container_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"strings"
@@ -22,6 +23,7 @@ func TestStatsDGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(8135), containerPorts[CWA+StatsD].ContainerPort)
 	assert.Equal(t, CWA+StatsD, containerPorts[CWA+StatsD].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+StatsD].Protocol)
 }
 
 func TestDefaultStatsDGetContainerPorts(t *testing.T) {
@@ -36,6 +38,7 @@ func TestDefaultStatsDGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(8125), containerPorts[StatsD].ContainerPort)
 	assert.Equal(t, StatsD, containerPorts[StatsD].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[StatsD].Protocol)
 }
 
 func TestCollectDGetContainerPorts(t *testing.T) {
@@ -49,7 +52,7 @@ func TestCollectDGetContainerPorts(t *testing.T) {
 	assert.Equal(t, int32(2000), containerPorts[AppSignalsProxy].ContainerPort)
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(25936), containerPorts[CWA+CollectD].ContainerPort)
-	assert.Equal(t, CWA+CollectD, containerPorts[CWA+CollectD].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+CollectD].Protocol)
 }
 
 func TestDefaultCollectDGetContainerPorts(t *testing.T) {
@@ -64,6 +67,7 @@ func TestDefaultCollectDGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(25826), containerPorts[CollectD].ContainerPort)
 	assert.Equal(t, CollectD, containerPorts[CollectD].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CollectD].Protocol)
 }
 
 func TestEMFGetContainerPorts(t *testing.T) {
@@ -92,8 +96,10 @@ func TestXrayAndOTLPGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(4327), containerPorts[CWA+OtlpGrpc].ContainerPort)
 	assert.Equal(t, CWA+OtlpGrpc, containerPorts[CWA+OtlpGrpc].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+OtlpGrpc].Protocol)
 	assert.Equal(t, int32(4328), containerPorts[CWA+OtlpHttp].ContainerPort)
 	assert.Equal(t, CWA+OtlpHttp, containerPorts[CWA+OtlpHttp].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+OtlpHttp].Protocol)
 }
 
 func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
@@ -108,8 +114,10 @@ func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(4317), containerPorts[OtlpGrpc].ContainerPort)
 	assert.Equal(t, OtlpGrpc, containerPorts[OtlpGrpc].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[OtlpGrpc].Protocol)
 	assert.Equal(t, int32(4318), containerPorts[OtlpHttp].ContainerPort)
 	assert.Equal(t, OtlpHttp, containerPorts[OtlpHttp].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[OtlpHttp].Protocol)
 }
 
 func TestXRayGetContainerPorts(t *testing.T) {
@@ -124,8 +132,10 @@ func TestXRayGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
 	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
 	assert.Equal(t, CWA+XrayProxy, containerPorts[CWA+XrayProxy].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+XrayProxy].Protocol)
 }
 
 func TestXRayWithBindAddressDefaultGetContainerPorts(t *testing.T) {
@@ -141,6 +151,7 @@ func TestXRayWithBindAddressDefaultGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
 	assert.Equal(t, CWA+XrayProxy, containerPorts[CWA+XrayProxy].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+XrayProxy].Protocol)
 }
 
 func TestXRayWithTCPProxyBindAddressDefaultGetContainerPorts(t *testing.T) {
@@ -156,6 +167,7 @@ func TestXRayWithTCPProxyBindAddressDefaultGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
 }
 
 func TestNilMetricsGetContainerPorts(t *testing.T) {
@@ -183,14 +195,18 @@ func TestMultipleReceiversGetContainerPorts(t *testing.T) {
 	assert.Equal(t, AppSignalsProxy, containerPorts[AppSignalsProxy].Name)
 	assert.Equal(t, int32(8135), containerPorts[CWA+StatsD].ContainerPort)
 	assert.Equal(t, CWA+StatsD, containerPorts[CWA+StatsD].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+StatsD].Protocol)
 	assert.Equal(t, int32(25936), containerPorts[CWA+CollectD].ContainerPort)
 	assert.Equal(t, CWA+CollectD, containerPorts[CWA+CollectD].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+CollectD].Protocol)
 	assert.Equal(t, int32(25888), containerPorts[EMF].ContainerPort)
 	assert.Equal(t, EMF, containerPorts[EMF].Name)
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
+	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
 	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
 	assert.Equal(t, CWA+XrayProxy, containerPorts[CWA+XrayProxy].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+XrayProxy].Protocol)
 	assert.Equal(t, int32(4327), containerPorts[CWA+OtlpGrpc].ContainerPort)
 	assert.Equal(t, CWA+OtlpGrpc, containerPorts[CWA+OtlpGrpc].Name)
 	assert.Equal(t, int32(4328), containerPorts[CWA+OtlpHttp].ContainerPort)

--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -59,7 +59,7 @@ func desiredService(ctx context.Context, params Params) *corev1.Service {
 	name := naming.Service(params.Instance)
 	labels := collector.Labels(params.Instance, name, []string{})
 
-	ports := collector.AppSignalsCloudwatchAgentPorts
+	ports := collector.PortMapToServicePortList(collector.AppSignalsPortToServicePortMap)
 
 	if len(params.Instance.Spec.Ports) > 0 {
 		// we should add all the ports from the CR

--- a/pkg/collector/reconcile/service.go
+++ b/pkg/collector/reconcile/service.go
@@ -59,7 +59,7 @@ func desiredService(ctx context.Context, params Params) *corev1.Service {
 	name := naming.Service(params.Instance)
 	labels := collector.Labels(params.Instance, name, []string{})
 
-	ports := collector.CloudwatchAgentPorts
+	ports := collector.AppSignalsCloudwatchAgentPorts
 
 	if len(params.Instance.Spec.Ports) > 0 {
 		// we should add all the ports from the CR

--- a/pkg/collector/test-resources/collectDAgentConfig.json
+++ b/pkg/collector/test-resources/collectDAgentConfig.json
@@ -1,0 +1,19 @@
+{
+  "agent": {
+    "metrics_collection_interval": 1,
+    "run_as_user": "root"
+  },
+  "metrics": {
+    "namespace": "CloudWatchAgentPerformance",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "collectd": {
+        "service_address": ":25936",
+        "name_prefix": "My_collectd_metrics_",
+        "metrics_aggregation_interval": 120
+      }
+    }
+  }
+}

--- a/pkg/collector/test-resources/collectDDefaultAgentConfig.json
+++ b/pkg/collector/test-resources/collectDDefaultAgentConfig.json
@@ -1,0 +1,18 @@
+{
+  "agent": {
+    "metrics_collection_interval": 1,
+    "run_as_user": "root"
+  },
+  "metrics": {
+    "namespace": "CloudWatchAgentPerformance",
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}"
+    },
+    "metrics_collected": {
+      "collectd": {
+        "name_prefix": "My_collectd_metrics_",
+        "metrics_aggregation_interval": 120
+      }
+    }
+  }
+}

--- a/pkg/collector/test-resources/emfAgentConfig.json
+++ b/pkg/collector/test-resources/emfAgentConfig.json
@@ -1,0 +1,7 @@
+{
+  "logs": {
+    "metrics_collected": {
+      "emf": {}
+    }
+  }
+}

--- a/pkg/collector/test-resources/emptyMetrics.json
+++ b/pkg/collector/test-resources/emptyMetrics.json
@@ -1,0 +1,8 @@
+{
+  "agent": {
+    "metrics_collection_interval": 1,
+    "run_as_user": "root"
+  },
+  "metrics": {
+  }
+}

--- a/pkg/collector/test-resources/multipleReceiversAgentConfig.json
+++ b/pkg/collector/test-resources/multipleReceiversAgentConfig.json
@@ -1,0 +1,36 @@
+{
+  "agent": {
+    "omit_hostname": true
+  },
+  "metrics": {
+    "metrics_collected": {
+      "statsd": {
+        "service_address": ":8135"
+      },
+      "collectd": {
+        "service_address": ":25936",
+        "name_prefix": "My_collectd_metrics_",
+        "metrics_aggregation_interval": 120
+      }
+    }
+  },
+  "logs": {
+    "metrics_collected": {
+      "emf": {}
+    }
+  },
+  "traces": {
+    "traces_collected": {
+      "xray": {
+        "bind_address": "127.0.0.1:2800",
+        "tcp_proxy": {
+          "bind_address": "127.0.0.1:2900"
+        }
+      },
+      "otlp": {
+        "grpc_endpoint": "127.0.0.1:4327",
+        "http_endpoint": "127.0.0.1:4328"
+      }
+    }
+  }
+}

--- a/pkg/collector/test-resources/nilMetrics.json
+++ b/pkg/collector/test-resources/nilMetrics.json
@@ -1,0 +1,6 @@
+{
+  "agent": {
+    "metrics_collection_interval": 1,
+    "run_as_user": "root"
+  }
+}

--- a/pkg/collector/test-resources/statsDAgentConfig.json
+++ b/pkg/collector/test-resources/statsDAgentConfig.json
@@ -1,0 +1,12 @@
+{
+  "agent": {
+    "omit_hostname": true
+  },
+  "metrics": {
+    "metrics_collected": {
+      "statsd": {
+        "service_address": ":8135"
+      }
+    }
+  }
+}

--- a/pkg/collector/test-resources/statsDDefaultAgentConfig.json
+++ b/pkg/collector/test-resources/statsDDefaultAgentConfig.json
@@ -1,0 +1,10 @@
+{
+    "agent": {
+        "omit_hostname": true
+    },
+    "metrics": {
+        "metrics_collected": {
+            "statsd": {}
+        }
+    }
+}

--- a/pkg/collector/test-resources/xrayAgentConfig.json
+++ b/pkg/collector/test-resources/xrayAgentConfig.json
@@ -1,0 +1,12 @@
+{
+  "traces": {
+    "traces_collected": {
+      "xray": {
+        "bind_address": "127.0.0.1:2800",
+        "tcp_proxy": {
+          "bind_address": "127.0.0.1:2900"
+        }
+      }
+    }
+  }
+}

--- a/pkg/collector/test-resources/xrayAndOTLPAgentConfig.json
+++ b/pkg/collector/test-resources/xrayAndOTLPAgentConfig.json
@@ -1,0 +1,16 @@
+{
+    "traces": {
+        "traces_collected": {
+            "xray": {
+                "bind_address": "127.0.0.1:2000",
+                "tcp_proxy": {
+                    "bind_address": "127.0.0.1:2000"
+                }
+            },
+            "otlp": {
+                "grpc_endpoint": "127.0.0.1:4327",
+                "http_endpoint": "127.0.0.1:4328"
+            }
+        }
+    }
+}

--- a/pkg/collector/test-resources/xrayAndOTLPDefaultAgentConfig.json
+++ b/pkg/collector/test-resources/xrayAndOTLPDefaultAgentConfig.json
@@ -1,0 +1,10 @@
+{
+  "traces": {
+    "traces_collected": {
+      "xray": {
+      },
+      "otlp": {
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added logic to parse the receiver ports from cw agent config json.

Testing 
Unit Tests
Manual Testing with below Advanced EKS addon Cw agent config:
```
{
    "agent": {
        "config": {
            "agent": {
                "debug": true
            },
            "metrics": {
                "metrics_collected": {
                    "statsd": {
                        "service_address": ":8135"
                    }
                }
            },
            "logs": {
                "metrics_collected": {
                    "kubernetes": {
                        "enhanced_container_insights": true
                    },
                    "app_signals": {},
                    "emf": {}
                }
            },
            "traces": {
                "traces_collected": {
                    "app_signals": {},
                    "xray": {
                        "bind_address": "127.0.0.1:2800",
                        "tcp_proxy": {
                            "bind_address": "127.0.0.1:2900"
                        }
                    },
                    "otlp": {
                        "grpc_endpoint": "127.0.0.1:4327",
                        "http_endpoint": "127.0.0.1:4328"
                    }
                }
            }
        }
    }
}
```

Pod Spec of Cloudwatch agent pod:

```
poojardy@88665a4a5be5 ~ % kubectl describe pod cloudwatch-agent-7z7tp -n amazon-cloudwatch
Containers:
  cloudwatch-agent:
    Container ID:   containerd://9f96aaaee3dbf5d6dcb569a1f5ac415345cb7e3425b91df2e4ca5e701bccd1f8
    Image:          public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300031.1b317
    Image ID:       public.ecr.aws/cloudwatch-agent/cloudwatch-agent@sha256:d660a92f0e97e529235e21d0ee440942f503c4cdd48dadaa80781fdc11427087
    Ports:          4315/TCP, 4316/TCP, 2000/TCP, 2900/TCP, 2800/UDP, 4327/TCP, 4328/TCP, 8135/UDP, 25888/TCP
    Host Ports:     0/TCP, 0/TCP, 0/TCP, 0/TCP, 0/UDP, 0/TCP, 0/TCP, 0/UDP, 0/TCP
    State:          Running
      Started:      Fri, 12 Jan 2024 15:23:27 -0500
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     500m
      memory:  512Mi
    Requests:
      cpu:     250m
      memory:  128Mi
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
