### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/eks-add-on-integ-test.yml
+++ b/.github/workflows/eks-add-on-integ-test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-         echo "::set-output name=eks_addon_matrix::$(echo $(cat integration-tests/generator/k8s_versions_matrix.json))"
+         echo "eks_addon_matrix=$(echo $(cat integration-tests/generator/k8s_versions_matrix.json))" >> $GITHUB_OUTPUT
 
       - name: Echo test plan matrix
         run: |

--- a/.github/workflows/eks-beta-add-on-integ-test.yml
+++ b/.github/workflows/eks-beta-add-on-integ-test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          echo "::set-output name=eks_addon_matrix::$(echo $(cat integration-tests/generator/k8s_versions_matrix.json))"
+          echo "eks_addon_matrix=$(echo $(cat integration-tests/generator/k8s_versions_matrix.json))" >> $GITHUB_OUTPUT
 
       - name: Echo test plan matrix
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter