### PR TITLE
Creating mutating webhook for daemonsets for auto-annotation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,14 @@ rules:
   - apps
   resources:
   - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
   - deployments
   - statefulsets
   verbs:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -50,6 +50,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-v1-daemonset
+  failurePolicy: Ignore
+  name: mdaemonset.kb.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - daemonsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-v1-pod
   failurePolicy: Ignore
   name: mpod.kb.io

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-cloudwatch-agent-operator
 
-go 1.20
+go 1.21
 
 retract v1.51.0
 
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/collector/featuregate v0.77.0
 	go.opentelemetry.io/otel v1.21.0
 	go.uber.org/zap v1.25.0
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
@@ -131,7 +132,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,11 +14,15 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aov
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1 h1:UPeCRD+XY7QlaGQte2EVI2iOcWvUYA2XY8w5T/8v0NQ=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.2.1/go.mod h1:oGV6NlB0cvi1ZbYRR2UN44QHxWFyGk+iylgD0qaMXjA=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2 h1:mLY+pNLjCUeKhgnAJWAKhEUQM+RJQo2H1fuGSw1Ky1E=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal v1.1.2/go.mod h1:FbdwsQ2EzwvXxOPcMFYO8ogEc9uMMIj3YkmCdXdAFmk=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0 h1:QM6sE5k2ZT/vI5BEe0r7mqjsUSnhVBFbOsVkEuaEfiA=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork v1.1.0/go.mod h1:243D9iHbcQXoFUtgHJwL7gl2zx1aDuDMjvBZVGr2uW0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1 h1:bWh0Z2rOEDfB/ywv/l0iHN1JgyazE6kW/aIA89+CEK0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2 v2.2.1/go.mod h1:Bzf34hhAE9NSxailk8xVeLEZbUjOXcC+GnU1mMKdhLw=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0 h1:ECsQtyERDVz3NP3kvDOTLvbQhqWp/x9EsGKtb4ogUr8=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.0.0/go.mod h1:s1tW/At+xHqjNFvWU4G0c0Qv33KOhvbGNj0RCTQDV8s=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1 h1:WpB/QDNLpMw72xHJc34BNNykqSOeEJDAWkhf0u12/Jk=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -39,6 +43,7 @@ github.com/aws/aws-sdk-go v1.45.25 h1:c4fLlh5sLdK2DCRTY1z0hyuJZU4ygxX8m1FswL6/nF
 github.com/aws/aws-sdk-go v1.45.25/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -63,6 +68,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/digitalocean/godo v1.104.1 h1:SZNxjAsskM/su0YW9P8Wx3gU0W1Z13b6tZlYNpl5BnA=
 github.com/digitalocean/godo v1.104.1/go.mod h1:VAI/L5YDzMuPRU01lEEUSQ/sp5Z//1HnnFv/RBTEdbg=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
+github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v24.0.7+incompatible h1:Wo6l37AuwP3JaMnZa226lzVXGA3F9Ig1seQen0cKYlM=
@@ -91,6 +97,7 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
+github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -119,6 +126,7 @@ github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPr
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
+github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-zookeeper/zk v1.0.3 h1:7M2kwOsc//9VeeFiPtf+uSJlVpU66x9Ba5+8XK7/TDg=
 github.com/go-zookeeper/zk v1.0.3/go.mod h1:nOB03cncLtlp4t+UAkGSV+9beXP/akpekBwL+UX1Qcw=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -146,6 +154,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -165,6 +174,7 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20230926050212-f7f687d19a98 h1:pUa4ghanp6q4IJHwE9RwLgmVFfReJN+KbQ8ExNEUUoQ=
+github.com/google/pprof v0.0.0-20230926050212-f7f687d19a98/go.mod h1:czg5+yv1E0ZGTi6S6vVK1mke0fV+FaUhNGcd6VRS9Ik=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -183,6 +193,7 @@ github.com/grafana/regexp v0.0.0-20221122212121-6b5c0a4cb7fd/go.mod h1:M5qHK+eWf
 github.com/hashicorp/consul/api v1.25.1 h1:CqrdhYzc8XZuPnhIYZWH45toM0LB9ZeYr/gvpLVI3PE=
 github.com/hashicorp/consul/api v1.25.1/go.mod h1:iiLVwR/htV7mas/sy0O+XSuEnrdBUUydemjxcUrAt4g=
 github.com/hashicorp/consul/sdk v0.14.1 h1:ZiwE2bKb+zro68sWzZ1SgHF3kRMBZ94TwOCFRF4ylPs=
+github.com/hashicorp/consul/sdk v0.14.1/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
 github.com/hashicorp/cronexpr v1.1.2 h1:wG/ZYIKT+RT3QkOdgYc+xsKWVRgnxJ1OJtjjy84fJ9A=
 github.com/hashicorp/cronexpr v1.1.2/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -199,6 +210,7 @@ github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJ
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-msgpack v0.5.5 h1:i9R9JSrqIz0QVLz3sz+i3YJdT7TTSLcfLLzJi9aZTuI=
+github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
@@ -210,10 +222,12 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
+github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
+github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -236,6 +250,7 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/ionos-cloud/sdk-go/v6 v6.1.9 h1:Iq3VIXzeEbc8EbButuACgfLMiY5TPVWUPNrF+Vsddo4=
 github.com/ionos-cloud/sdk-go/v6 v6.1.9/go.mod h1:EzEgRIDxBELvfoa/uBN0kOQaqovLjUWEB7iW4/Q+t4k=
 github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
+github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -259,6 +274,7 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -288,6 +304,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/dns v1.1.56 h1:5imZaSeoRNvpM9SzWNhEcP9QliKiz20/dA2QabIGVnE=
@@ -296,10 +313,12 @@ github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXx
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
+github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
+github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -308,13 +327,16 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
+github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+SVif2QVs3tOP0zanoHgBEVAwHxUSIzRqU=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.13.0 h1:0jY9lJquiL8fcf3M4LAXN5aMlS/b2BV86HFFPCPMgE4=
+github.com/onsi/ginkgo/v2 v2.13.0/go.mod h1:TE309ZR8s5FsKKpuB1YAQYBzCaAfUgatB/xlT/ETL/o=
 github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
+github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
@@ -362,6 +384,7 @@ github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/
 github.com/prometheus/prometheus v0.48.1 h1:CTszphSNTXkuCG6O0IfpKdHcJkvvnAAE1GbELKS+NFk=
 github.com/prometheus/prometheus v0.48.1/go.mod h1:SRw624aMAxTfryAcP8rOjg4S/sHHaetx2lyJJ2nM83g=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21 h1:yWfiTPwYxB0l5fGMhl/G+liULugVIHD9AU77iNLrURQ=
@@ -369,6 +392,7 @@ github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21/go.mod h1:fCa7OJZ/9DRTnOKmxvT
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shoenig/test v0.6.6 h1:Oe8TPH9wAbv++YPNDKJWUnI8Q4PPWCx3UbOfH+FxiMU=
+github.com/shoenig/test v0.6.6/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
@@ -408,6 +432,7 @@ go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
@@ -470,6 +495,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -593,6 +619,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.29.0 h1:NiCdQMY1QOp1H8lfRyeEf8eOwV6+0xA6XEE44ohDX2A=

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -15,6 +15,22 @@ const (
 	defaultCollectorConfigMapEntry = "cwagentconfig.json"
 )
 
+// AnnotationConfig details the resources that have enabled
+// auto-annotation for each instrumentation type.
+type AnnotationConfig struct {
+	Java   AnnotationResources `json:"java"`
+	Python AnnotationResources `json:"python"`
+}
+
+// AnnotationResources contains slices of resource names for each
+// of the supported workloads.
+type AnnotationResources struct {
+	Namespaces   []string `json:"namespaces,omitempty"`
+	Deployments  []string `json:"deployments,omitempty"`
+	DaemonSets   []string `json:"daemonsets,omitempty"`
+	StatefulSets []string `json:"statefulsets,omitempty"`
+}
+
 // Config holds the static configuration for this operator.
 type Config struct {
 	logger                              logr.Logger
@@ -28,6 +44,7 @@ type Config struct {
 	autoInstrumentationNodeJSImage      string
 	autoInstrumentationJavaImage        string
 	labelsFilter                        []string
+	annotationConfig                    AnnotationConfig
 }
 
 // New constructs a new configuration based on the given options.
@@ -54,6 +71,7 @@ func New(opts ...Option) Config {
 		autoInstrumentationApacheHttpdImage: o.autoInstrumentationApacheHttpdImage,
 		autoInstrumentationNginxImage:       o.autoInstrumentationNginxImage,
 		labelsFilter:                        o.labelsFilter,
+		annotationConfig:                    o.annotationConfig,
 	}
 }
 
@@ -105,4 +123,9 @@ func (c *Config) AutoInstrumentationNginxImage() string {
 // LabelsFilter Returns the filters converted to regex strings used to filter out unwanted labels from propagations.
 func (c *Config) LabelsFilter() []string {
 	return c.labelsFilter
+}
+
+// AnnotationConfig Returns the details for the resources that have enabled auto-annotation for each instrumentation type..
+func (c *Config) AnnotationConfig() AnnotationConfig {
+	return c.annotationConfig
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -28,6 +28,7 @@ type options struct {
 	collectorImage                      string
 	collectorConfigMapEntry             string
 	labelsFilter                        []string
+	annotationConfig                    AnnotationConfig
 }
 
 func WithCollectorImage(s string) Option {
@@ -115,5 +116,13 @@ func WithLabelFilters(labelFilters []string) Option {
 		}
 
 		o.labelsFilter = filters
+	}
+}
+
+func WithAnnotationConfig(ns string) Option {
+	return func(o *options) {
+		a := AnnotationConfig{}
+		a.Java.Namespaces = []string{ns}
+		o.annotationConfig = a
 	}
 }

--- a/internal/webhook/daemonsetmutation/webhookhandler.go
+++ b/internal/webhook/daemonsetmutation/webhookhandler.go
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package daemonsetmutation contains the webhook that injects annotations into daemon-sets.
+package daemonsetmutation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+)
+
+// +kubebuilder:webhook:path=/mutate-v1-daemonset,mutating=true,failurePolicy=ignore,groups="apps",resources=daemonsets,verbs=create;update,versions=v1,name=mdaemonset.kb.io,sideEffects=none,admissionReviewVersions=v1
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch
+// +kubebuilder:rbac:groups="apps",resources=daemonsets,verbs=get;list;watch
+
+var _ WebhookHandler = (*daemonSetMutationWebhook)(nil)
+
+// WebhookHandler is a webhook handler that analyzes new daemon-sets and injects appropriate annotations into it.
+type WebhookHandler interface {
+	admission.Handler
+}
+
+// the implementation.
+type daemonSetMutationWebhook struct {
+	client            client.Client
+	decoder           *admission.Decoder
+	logger            logr.Logger
+	daemonSetMutators []DaemonSetMutator
+	config            config.Config
+}
+
+// DaemonSetMutator mutates a daemon-set.
+type DaemonSetMutator interface {
+	Mutate(ctx context.Context, ds appsv1.DaemonSet) (appsv1.DaemonSet, error)
+}
+
+// NewWebhookHandler creates a new WebhookHandler.
+func NewWebhookHandler(cfg config.Config, logger logr.Logger, decoder *admission.Decoder, cl client.Client, daemonSetMutators []DaemonSetMutator) WebhookHandler {
+	return &daemonSetMutationWebhook{
+		config:            cfg,
+		decoder:           decoder,
+		logger:            logger,
+		client:            cl,
+		daemonSetMutators: daemonSetMutators,
+	}
+}
+
+func (p *daemonSetMutationWebhook) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ds := appsv1.DaemonSet{}
+	err := p.decoder.Decode(req, &ds)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// we use the req.Namespace here because the pod might have not been created yet
+	ns := corev1.Namespace{}
+	err = p.client.Get(ctx, types.NamespacedName{Name: req.Namespace, Namespace: ""}, &ns)
+	if err != nil {
+		res := admission.Errored(http.StatusInternalServerError, err)
+		// By default, admission.Errored sets Allowed to false which blocks pod creation even though the failurePolicy=ignore.
+		// Allowed set to true makes sure failure does not block pod creation in case of an error.
+		// Using the http.StatusInternalServerError creates a k8s event associated with the replica set.
+		// The admission.Allowed("").WithWarnings(err.Error()) or http.StatusBadRequest does not
+		// create any event. Additionally, an event/log cannot be created explicitly because the pod name is not known.
+		res.Allowed = true
+		return res
+	}
+
+	for _, m := range p.daemonSetMutators {
+		ds, err = m.Mutate(ctx, ds)
+		if err != nil {
+			res := admission.Errored(http.StatusInternalServerError, err)
+			res.Allowed = true
+			return res
+		}
+	}
+
+	marshaledPod, err := json.Marshal(ds)
+	if err != nil {
+		res := admission.Errored(http.StatusInternalServerError, err)
+		res.Allowed = true
+		return res
+	}
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+}

--- a/internal/webhook/daemonsetmutation/webhookhandler_suite_test.go
+++ b/internal/webhook/daemonsetmutation/webhookhandler_suite_test.go
@@ -1,0 +1,143 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package daemonsetmutation
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	testScheme *runtime.Scheme = scheme.Scheme
+	ctx        context.Context
+	cancel     context.CancelFunc
+	err        error
+	cfg        *rest.Config
+)
+
+func TestMain(m *testing.M) {
+	ctx, cancel = context.WithCancel(context.TODO())
+	defer cancel()
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+	cfg, err = testEnv.Start()
+	if err != nil {
+		fmt.Printf("failed to start testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	if err = v1alpha1.AddToScheme(testScheme); err != nil {
+		fmt.Printf("failed to register scheme: %v", err)
+		os.Exit(1)
+	}
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	if err != nil {
+		fmt.Printf("failed to setup a Kubernetes client: %v", err)
+		os.Exit(1)
+	}
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, mgrErr := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:         testScheme,
+		LeaderElection: false,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+	})
+	if mgrErr != nil {
+		fmt.Printf("failed to start webhook server: %v", mgrErr)
+		os.Exit(1)
+	}
+
+	if err = v1alpha1.SetupCollectorWebhook(mgr, config.New()); err != nil {
+		fmt.Printf("failed to SetupWebhookWithManager: %v", err)
+		os.Exit(1)
+	}
+
+	ctx, cancel = context.WithCancel(context.TODO())
+	defer cancel()
+	go func() {
+		if err = mgr.Start(ctx); err != nil {
+			fmt.Printf("failed to start manager: %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	// wait for the webhook server to get ready
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		if err = retry.OnError(wait.Backoff{
+			Steps:    20,
+			Duration: 10 * time.Millisecond,
+			Factor:   1.5,
+			Jitter:   0.1,
+			Cap:      time.Second * 30,
+		}, func(error) bool {
+			return true
+		}, func() error {
+			// #nosec G402
+			conn, tlsErr := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+			if tlsErr != nil {
+				return tlsErr
+			}
+			_ = conn.Close()
+			return nil
+		}); err != nil {
+			fmt.Printf("failed to wait for webhook server to be ready: %v", err)
+			os.Exit(1)
+		}
+	}(wg)
+	wg.Wait()
+
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		fmt.Printf("failed to stop testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}

--- a/internal/webhook/daemonsetmutation/webhookhandler_test.go
+++ b/internal/webhook/daemonsetmutation/webhookhandler_test.go
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package daemonsetmutation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/annotation"
+)
+
+var logger = logf.Log.WithName("unit-tests")
+
+func TestFailOnInvalidRequest(t *testing.T) {
+	// we use a typical Go table-test instad of Ginkgo's DescribeTable because we need to
+	// do an assertion during the declaration of the table params, which isn't supported (yet?)
+	for _, tt := range []struct {
+		req      admission.Request
+		name     string
+		expected int32
+		allowed  bool
+	}{
+		{
+			name:     "empty payload",
+			req:      admission.Request{},
+			expected: http.StatusBadRequest,
+			allowed:  false,
+		},
+		{
+			name: "namespace doesn't exist",
+			req: func() admission.Request {
+				ds := appsv1.DaemonSet{}
+				encoded, err := json.Marshal(ds)
+				require.NoError(t, err)
+
+				return admission.Request{
+					AdmissionRequest: admv1.AdmissionRequest{
+						Namespace: "non-existing",
+						Object: runtime.RawExtension{
+							Raw: encoded,
+						},
+					},
+				}
+			}(),
+			expected: http.StatusInternalServerError,
+			allowed:  true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// prepare
+			cfg := config.New()
+			decoder := admission.NewDecoder(scheme.Scheme)
+			injector := NewWebhookHandler(cfg, logger, decoder, k8sClient, []DaemonSetMutator{annotation.NewMutator(logger, cfg, k8sClient)})
+
+			// test
+			res := injector.Handle(context.Background(), tt.req)
+
+			// verify
+			assert.Equal(t, tt.allowed, res.Allowed)
+			assert.NotNil(t, res.AdmissionResponse.Result)
+			assert.Equal(t, tt.expected, res.AdmissionResponse.Result.Code)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,9 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-operator/controllers"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/version"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/daemonsetmutation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/podmutation"
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/annotation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/featuregate"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/sidecar"
@@ -190,6 +192,12 @@ func main() {
 				[]podmutation.PodMutator{
 					sidecar.NewMutator(logger, cfg, mgr.GetClient()),
 					instrumentation.NewMutator(logger, mgr.GetClient(), mgr.GetEventRecorderFor("amazon-cloudwatch-agent-operator")),
+				}),
+		})
+		mgr.GetWebhookServer().Register("/mutate-v1-daemonset", &webhook.Admission{
+			Handler: daemonsetmutation.NewWebhookHandler(cfg, ctrl.Log.WithName("daemonset-webhook"), decoder, mgr.GetClient(),
+				[]daemonsetmutation.DaemonSetMutator{
+					annotation.NewMutator(logger, cfg, mgr.GetClient()),
 				}),
 		})
 

--- a/pkg/annotation/annotationutil.go
+++ b/pkg/annotation/annotationutil.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotation
+
+import (
+	"golang.org/x/exp/slices"
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+)
+
+const (
+	// annotationInject<Language> indicates whether language auto-instrumentation should be injected or not.
+	// Possible values are "true", "false" or "<Instrumentation>" name.
+	annotationInjectJava   = "instrumentation.opentelemetry.io/inject-java"
+	annotationInjectPython = "instrumentation.opentelemetry.io/inject-python"
+	autoAnnotation         = "auto-annotation"
+)
+
+var languageAnnotationMap = map[string]string{
+	"java":   annotationInjectJava,
+	"python": annotationInjectPython,
+}
+
+// isAllowListed returns the if the kubernetes workload (deployment, daemon-set, stateful-set) is allow-listed in the operator config
+// TODO can this function be made generic for supporting all workloads instead of just daemon-set
+func isAllowListed(cfg config.Config, ds appsv1.DaemonSet) bool {
+	autoAnnotateLang := getAutoAnnotatedLang(cfg, ds)
+	if len(autoAnnotateLang) > 0 {
+		return true
+	}
+	return false
+}
+
+// getAutoAnnotatedLang returns the list of languages to be auto-annotated for the given kubernetes workload (deployment, daemon-set, stateful-set)
+// TODO can this function be made generic for supporting all workloads instead of just daemon-set
+// TODO can this function be made generic for supporting all languages dynamically instead of checking for each one
+func getAutoAnnotatedLang(cfg config.Config, ds appsv1.DaemonSet) []string {
+	var autoAnnotateLang []string
+	annotationConfig := cfg.AnnotationConfig()
+	if slices.Contains(annotationConfig.Java.DaemonSets, ds.Name) || slices.Contains(annotationConfig.Java.Namespaces, ds.Namespace) {
+		autoAnnotateLang = append(autoAnnotateLang, "java")
+	}
+	if slices.Contains(annotationConfig.Python.DaemonSets, ds.Name) || slices.Contains(annotationConfig.Python.Namespaces, ds.Namespace) {
+		autoAnnotateLang = append(autoAnnotateLang, "python")
+	}
+	return autoAnnotateLang
+}

--- a/pkg/annotation/annotationutil_test.go
+++ b/pkg/annotation/annotationutil_test.go
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+)
+
+func TestIsAllowListed(t *testing.T) {
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testing-ds",
+			Namespace: "default",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := config.New(config.WithAnnotationConfig("testing-ds"))
+	assert.True(t, isAllowListed(cfg, ds))
+}
+
+func TestGetAutoAnnotatedLang(t *testing.T) {
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testing-ds",
+			Namespace: "default",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := config.New(config.WithAnnotationConfig("testing-ds"))
+	assert.Equal(t, []string{"java"}, getAutoAnnotatedLang(cfg, ds))
+}

--- a/pkg/annotation/daemonset.go
+++ b/pkg/annotation/daemonset.go
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotation
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+)
+
+// add a new annotation to the given ds
+func add(cfg config.Config, ds appsv1.DaemonSet) (appsv1.DaemonSet, error) {
+	autoAnnotatedLang := getAutoAnnotatedLang(cfg, ds)
+	for _, lang := range autoAnnotatedLang {
+		if ds.Annotations == nil {
+			ds.Annotations = make(map[string]string)
+		}
+		ds.Annotations[autoAnnotation] = "true"
+
+		// inject auto instrumentation into the ds spec template annotation
+		if ds.Spec.Template.Annotations == nil {
+			ds.Spec.Template.Annotations = make(map[string]string)
+		}
+		ds.Spec.Template.Annotations[languageAnnotationMap[lang]] = "true"
+	}
+
+	return ds, nil
+}
+
+// remove the annotation from the given ds.
+func remove(cfg config.Config, ds appsv1.DaemonSet) (appsv1.DaemonSet, error) {
+	if !existsIn(ds) {
+		return ds, nil
+	}
+	if ds.Spec.Template.Annotations == nil {
+		return ds, nil
+	}
+
+	autoAnnotatedLang := getAutoAnnotatedLang(cfg, ds)
+	for _, lang := range autoAnnotatedLang {
+		delete(ds.Spec.Template.Annotations, languageAnnotationMap[lang])
+	}
+	delete(ds.Annotations, autoAnnotation)
+	return ds, nil
+}
+
+// existsIn checks whether annotations exist in the given ds.
+func existsIn(ds appsv1.DaemonSet) bool {
+	if ds.Spec.Template.Annotations != nil {
+		if ds.Spec.Template.Annotations[autoAnnotation] == "true" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/annotation/daemonset_test.go
+++ b/pkg/annotation/daemonset_test.go
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+)
+
+func TestAddAnnotationWhenNoneExist(t *testing.T) {
+	// prepare
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testing-ds",
+			Namespace: "default",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := config.New(config.WithAnnotationConfig("testing-ds"))
+
+	// test
+	changed, err := add(cfg, ds)
+
+	// verify
+	assert.NoError(t, err)
+	require.Len(t, changed.Annotations, 1)
+	require.Len(t, changed.Spec.Template.Annotations, 1)
+}
+
+func TestRemoveSidecar(t *testing.T) {
+	// prepare
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testing-ds",
+			Namespace:   "default",
+			Annotations: map[string]string{},
+		},
+
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "test-container",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfg := config.New(config.WithAnnotationConfig(""))
+
+	// test
+	changed, err := remove(cfg, ds)
+
+	// verify
+	assert.NoError(t, err)
+	require.Len(t, changed.Annotations, 0)
+	require.Len(t, changed.Spec.Template.Annotations, 0)
+}
+
+func TestExistsIn(t *testing.T) {
+	for _, tt := range []struct {
+		desc     string
+		ds       appsv1.DaemonSet
+		expected bool
+	}{
+		{"no-annotation",
+			appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testing-ds",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+			},
+			false},
+
+		{"has-annotation",
+			appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "testing-ds",
+					Namespace:   "default",
+					Annotations: map[string]string{autoAnnotation: "true"},
+				},
+			},
+			true},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			assert.Equal(t, tt.expected, existsIn(tt.ds))
+		})
+	}
+}

--- a/pkg/annotation/daemonsetmutator.go
+++ b/pkg/annotation/daemonsetmutator.go
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package annotation
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/daemonsetmutation"
+)
+
+type annotationDaemonSetMutator struct {
+	client client.Client
+	logger logr.Logger
+	config config.Config
+}
+
+var _ daemonsetmutation.DaemonSetMutator = (*annotationDaemonSetMutator)(nil)
+
+func NewMutator(logger logr.Logger, config config.Config, client client.Client) *annotationDaemonSetMutator {
+	return &annotationDaemonSetMutator{
+		config: config,
+		logger: logger,
+		client: client,
+	}
+}
+
+func (a annotationDaemonSetMutator) Mutate(ctx context.Context, ds appsv1.DaemonSet) (appsv1.DaemonSet, error) {
+	logger := a.logger.WithValues("namespace", ds.Namespace, "name", ds.Name)
+
+	// check if ds and ns exists in the operator config
+	isAnnotate := isAllowListed(a.config, ds)
+	if !isAnnotate {
+		logger.V(1).Info("annotation not present in operator config")
+		// check whether ds is annotated already -- remove the annotation if that's the case
+		if existsIn(ds) {
+			return remove(a.config, ds)
+		} else {
+			return ds, nil
+		}
+	}
+
+	// from this point and on, annotation is wanted
+	// check whether there's annotation already -- return the same ds if that's the case.
+	if existsIn(ds) {
+		logger.V(1).Info("ds already has annotation in it, skipping injection")
+		return ds, nil
+	}
+
+	return add(a.config, ds)
+}


### PR DESCRIPTION
*Description of changes:*
Creating a new mutating webhook for daemonsets that will:
   1. Add annotations to a daemonset if it doesnt already have them and is provided to the operator via the args
   2. Removes annotations from a daemonset if it has them and is no longer provided to the operator via the args

*Testing*
Testing while watching the default namespace
```
{"level":"info","ts":"2024-01-26T22:03:37Z","logger":"controller-runtime.webhook","msg":"Registering webhook","path":"/mutate-v1-daemonset"}

--- Creating DS in default namespace ---
kubectl apply -f ds.yaml 
daemonset.apps/prometheus-daemonset created

kubectl get ds 
NAME                   DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
prometheus-daemonset   2         2         2       2            2           <none>          15s

kubectl describe ds prometheus-daemonset
Name:           prometheus-daemonset
Selector:       name=prometheus-exporter,tier=monitoring
Node-Selector:  <none>
Labels:         <none>
Annotations:    auto-annotation: true
                deprecated.daemonset.template.generation: 1
Desired Number of Nodes Scheduled: 2
Current Number of Nodes Scheduled: 2
Number of Nodes Scheduled with Up-to-date Pods: 2
Number of Nodes Scheduled with Available Pods: 2
Number of Nodes Misscheduled: 0
Pods Status:  2 Running / 0 Waiting / 0 Succeeded / 0 Failed
Pod Template:
  Labels:       name=prometheus-exporter
                tier=monitoring
  Annotations:  instrumentation.opentelemetry.io/inject-java: true
  Containers:
   prometheus:
    Image:        prom/node-exporter
    Port:         80/TCP
    Host Port:    0/TCP
    Environment:  <none>
    Mounts:       <none>
  Volumes:        <none>
Events:
  Type    Reason            Age   From                  Message
  ----    ------            ----  ----                  -------
  Normal  SuccessfulCreate  23s   daemonset-controller  Created pod: prometheus-daemonset-k6t4n
  Normal  SuccessfulCreate  23s   daemonset-controller  Created pod: prometheus-daemonset-86f8s



kubectl describe pod prometheus-daemonset-86f8s
Name:             prometheus-daemonset-86f8s
Namespace:        default
Priority:         0
Service Account:  default
Node:             ip-192-168-63-8.ec2.internal/192.168.63.8
Start Time:       Fri, 26 Jan 2024 22:04:18 +0000
Labels:           controller-revision-hash=7b67f6b656
                  name=prometheus-exporter
                  pod-template-generation=1
                  tier=monitoring
Annotations:      instrumentation.opentelemetry.io/inject-java: true
Status:           Running
IP:               192.168.55.158
IPs:
  IP:           192.168.55.158
Controlled By:  DaemonSet/prometheus-daemonset
Init Containers:
  opentelemetry-auto-instrumentation-java:
    Container ID:  containerd://4f9b922f5160903162b6d8c121cc6d790827bb72511cd4bd7567de3d7542e0dc
    Image:         public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.31.1
    Image ID:      public.ecr.aws/aws-observability/adot-autoinstrumentation-java@sha256:08d05d413361ea2a11e27b4392f6fe856e384136e8d28f995cfc98438aa8a3f2
    Port:          <none>
    Host Port:     <none>
    Command:
      cp
      /javaagent.jar
      /otel-auto-instrumentation-java/javaagent.jar
    State:          Terminated
      Reason:       Completed
      Exit Code:    0
      Started:      Fri, 26 Jan 2024 22:04:19 +0000
      Finished:     Fri, 26 Jan 2024 22:04:19 +0000
    Ready:          True
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /otel-auto-instrumentation-java from opentelemetry-auto-instrumentation-java (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-59nwj (ro)
Containers:
  prometheus:
    Container ID:   containerd://1ca98d078d0dda32f665283536400fa38038c354201dbede8a6b5edf23d444fb
    Image:          prom/node-exporter
    Image ID:       docker.io/prom/node-exporter@sha256:4cb2b9019f1757be8482419002cb7afe028fdba35d47958829e4cfeaf6246d80
    Port:           80/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Fri, 26 Jan 2024 22:04:20 +0000
    Ready:          True
    Restart Count:  0
    Environment:
      OTEL_SMP_ENABLED:                    true
      OTEL_TRACES_SAMPLER_ARG:             endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000
      OTEL_TRACES_SAMPLER:                 xray
      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:  http://cloudwatch-agent.amazon-cloudwatch:4315
      OTEL_AWS_SMP_EXPORTER_ENDPOINT:      http://cloudwatch-agent.amazon-cloudwatch:4315
      OTEL_METRICS_EXPORTER:               none
      JAVA_TOOL_OPTIONS:                    -javaagent:/otel-auto-instrumentation-java/javaagent.jar
      OTEL_SERVICE_NAME:                   prometheus-daemonset
      OTEL_RESOURCE_ATTRIBUTES_POD_NAME:   prometheus-daemonset-86f8s (v1:metadata.name)
      OTEL_RESOURCE_ATTRIBUTES_NODE_NAME:   (v1:spec.nodeName)
      OTEL_PROPAGATORS:                    tracecontext,baggage,b3,xray
      OTEL_RESOURCE_ATTRIBUTES:            k8s.container.name=prometheus,k8s.daemonset.name=prometheus-daemonset,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)
    Mounts:
      /otel-auto-instrumentation-java from opentelemetry-auto-instrumentation-java (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-59nwj (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             True 
  ContainersReady   True 
  PodScheduled      True 
Volumes:
  kube-api-access-59nwj:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
  opentelemetry-auto-instrumentation-java:
    Type:        EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:      
    SizeLimit:   200Mi
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/disk-pressure:NoSchedule op=Exists
                 node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                 node.kubernetes.io/not-ready:NoExecute op=Exists
                 node.kubernetes.io/pid-pressure:NoSchedule op=Exists
                 node.kubernetes.io/unreachable:NoExecute op=Exists
                 node.kubernetes.io/unschedulable:NoSchedule op=Exists
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  57s   default-scheduler  Successfully assigned default/prometheus-daemonset-86f8s to ip-192-168-63-8.ec2.internal
  Normal  Pulled     56s   kubelet            Container image "public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.31.1" already present on machine
  Normal  Created    56s   kubelet            Created container opentelemetry-auto-instrumentation-java
  Normal  Started    56s   kubelet            Started container opentelemetry-auto-instrumentation-java
  Normal  Pulling    55s   kubelet            Pulling image "prom/node-exporter"
  Normal  Pulled     55s   kubelet            Successfully pulled image "prom/node-exporter" in 124.459204ms (124.467572ms including waiting)
  Normal  Created    55s   kubelet            Created container prometheus
  Normal  Started    55s   kubelet            Started container prometheus


```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
