### PR TITLE
Run CW agent daemonset as host process container

### DIFF
--- a/helm/templates/cloudwatch-agent-daemonset-windows.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset-windows.yaml
@@ -5,7 +5,13 @@ metadata:
   name: {{ template "cloudwatch-agent.name" . }}-windows
   namespace: {{ .Release.Namespace }}
 spec:
+  securityContext:
+    windowsOptions:
+      hostProcess: true
+      runAsUserName: "NT AUTHORITY\\System"
+  hostNetwork: true
   image: {{ template "cloudwatch-agent-windows.image" . }}
+  command: ["%CONTAINER_SANDBOX_MOUNT_POINT%/Program Files/Amazon/AmazonCloudWatchAgent/start-amazon-cloudwatch-agent.exe"]
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   nodeSelector:
@@ -39,4 +45,6 @@ spec:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
+  - name: RUN_AS_HOST_PROCESS_CONTAINER
+    value: "True"
 {{- end }}


### PR DESCRIPTION
*Description of changes:*
Add security context to run CW agent as system process. Add env variable to run CW agent as host process container. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
