### PR TITLE
Add auto-annotation mutators on start up

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -34,6 +35,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/podmutation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/featuregate"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/auto"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/sidecar"
 	// +kubebuilder:scaffold:imports
 )
@@ -88,6 +90,7 @@ func main() {
 		pprofAddr               string
 		agentImage              string
 		autoInstrumentationJava string
+		autoAnnotationConfigStr string
 		webhookPort             int
 		tlsOpt                  tlsConfig
 	)
@@ -97,6 +100,7 @@ func main() {
 	pflag.StringVar(&pprofAddr, "pprof-addr", "", "The address to expose the pprof server. Default is empty string which disables the pprof server.")
 	stringFlagOrEnv(&agentImage, "agent-image", "RELATED_IMAGE_COLLECTOR", fmt.Sprintf("%s:%s", cloudwatchAgentImageRepository, v.AmazonCloudWatchAgent), "The default CloudWatch Agent image. This image is used when no image is specified in the CustomResource.")
 	stringFlagOrEnv(&autoInstrumentationJava, "auto-instrumentation-java-image", "RELATED_IMAGE_AUTO_INSTRUMENTATION_JAVA", fmt.Sprintf("%s:%s", autoInstrumentationJavaImageRepository, v.AutoInstrumentationJava), "The default OpenTelemetry Java instrumentation image. This image is used when no image is specified in the CustomResource.")
+	pflag.StringVar(&autoAnnotationConfigStr, "auto-annotation-config", "", "The configuration for auto-annotation.")
 	pflag.Parse()
 
 	// set java instrumentation java image in environment variable to be used for default instrumentation
@@ -205,6 +209,23 @@ func main() {
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
+	}
+
+	var autoAnnotationConfig auto.AnnotationConfig
+	if err := json.Unmarshal([]byte(autoAnnotationConfigStr), &autoAnnotationConfig); err != nil {
+		setupLog.Error(err, "unable to unmarshal auto-annotation config")
+	} else {
+		setupLog.Info("starting auto-annotator")
+		autoAnnotation := auto.NewAnnotationMutators(
+			mgr.GetClient(),
+			logger,
+			autoAnnotationConfig,
+			instrumentation.NewTypeSet(
+				instrumentation.TypeJava,
+				instrumentation.TypePython,
+			),
+		)
+		go autoAnnotation.MutateAll(ctx)
 	}
 
 	setupLog.Info("starting manager")

--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -14,12 +14,11 @@ type AnnotationMutation interface {
 }
 
 type insertAnnotationMutation struct {
-	insert     map[string]string
-	requireAll bool
+	insert map[string]string
 }
 
 func (m *insertAnnotationMutation) Mutate(annotations map[string]string) bool {
-	if m.requireAll && !m.validate(annotations) {
+	if !m.shouldMutate(annotations) {
 		return false
 	}
 	var mutated bool
@@ -32,7 +31,7 @@ func (m *insertAnnotationMutation) Mutate(annotations map[string]string) bool {
 	return mutated
 }
 
-func (m *insertAnnotationMutation) validate(annotations map[string]string) bool {
+func (m *insertAnnotationMutation) shouldMutate(annotations map[string]string) bool {
 	for key := range m.insert {
 		if _, ok := annotations[key]; ok {
 			return false
@@ -41,19 +40,18 @@ func (m *insertAnnotationMutation) validate(annotations map[string]string) bool 
 	return true
 }
 
-// NewInsertAnnotationMutation creates a new mutation that inserts annotations. If requireAll is enabled,
-// all provided annotation keys must be present for it to attempt to insert.
-func NewInsertAnnotationMutation(annotations map[string]string, requireAll bool) AnnotationMutation {
-	return &insertAnnotationMutation{insert: annotations, requireAll: requireAll}
+// NewInsertAnnotationMutation creates a new mutation that inserts annotations. All provided annotation keys
+// must be present for it to attempt to insert.
+func NewInsertAnnotationMutation(annotations map[string]string) AnnotationMutation {
+	return &insertAnnotationMutation{insert: annotations}
 }
 
 type removeAnnotationMutation struct {
-	remove     []string
-	requireAll bool
+	remove []string
 }
 
 func (m *removeAnnotationMutation) Mutate(annotations map[string]string) bool {
-	if m.requireAll && !m.validate(annotations) {
+	if !m.shouldMutate(annotations) {
 		return false
 	}
 	var mutated bool
@@ -66,7 +64,7 @@ func (m *removeAnnotationMutation) Mutate(annotations map[string]string) bool {
 	return mutated
 }
 
-func (m *removeAnnotationMutation) validate(annotations map[string]string) bool {
+func (m *removeAnnotationMutation) shouldMutate(annotations map[string]string) bool {
 	for _, key := range m.remove {
 		if _, ok := annotations[key]; !ok {
 			return false
@@ -75,10 +73,10 @@ func (m *removeAnnotationMutation) validate(annotations map[string]string) bool 
 	return true
 }
 
-// NewRemoveAnnotationMutation creates a new mutation that removes annotations. If requireAll is enabled,
-// all provided annotation keys must be present for it to attempt to remove them.
-func NewRemoveAnnotationMutation(annotations []string, requireAll bool) AnnotationMutation {
-	return &removeAnnotationMutation{remove: annotations, requireAll: requireAll}
+// NewRemoveAnnotationMutation creates a new mutation that removes annotations. All provided annotation keys
+// must be present for it to attempt to remove them.
+func NewRemoveAnnotationMutation(annotations []string) AnnotationMutation {
+	return &removeAnnotationMutation{remove: annotations}
 }
 
 type AnnotationMutator struct {

--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// AnnotationMutation is used to modify an annotation map.
+type AnnotationMutation interface {
+	// Mutate attempts to modify the annotations map. Returns whether the function changed the annotations.
+	Mutate(annotations map[string]string) bool
+}
+
+type insertAnnotationMutation struct {
+	insert     map[string]string
+	requireAll bool
+}
+
+func (m *insertAnnotationMutation) Mutate(annotations map[string]string) bool {
+	if m.requireAll && !m.validate(annotations) {
+		return false
+	}
+	var mutated bool
+	for key, value := range m.insert {
+		if _, ok := annotations[key]; !ok {
+			annotations[key] = value
+			mutated = true
+		}
+	}
+	return mutated
+}
+
+func (m *insertAnnotationMutation) validate(annotations map[string]string) bool {
+	for key := range m.insert {
+		if _, ok := annotations[key]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+// NewInsertAnnotationMutation creates a new mutation that inserts annotations. If requireAll is enabled,
+// all provided annotation keys must be present for it to attempt to insert.
+func NewInsertAnnotationMutation(annotations map[string]string, requireAll bool) AnnotationMutation {
+	return &insertAnnotationMutation{insert: annotations, requireAll: requireAll}
+}
+
+type removeAnnotationMutation struct {
+	remove     []string
+	requireAll bool
+}
+
+func (m *removeAnnotationMutation) Mutate(annotations map[string]string) bool {
+	if m.requireAll && !m.validate(annotations) {
+		return false
+	}
+	var mutated bool
+	for _, key := range m.remove {
+		if _, ok := annotations[key]; ok {
+			delete(annotations, key)
+			mutated = true
+		}
+	}
+	return mutated
+}
+
+func (m *removeAnnotationMutation) validate(annotations map[string]string) bool {
+	for _, key := range m.remove {
+		if _, ok := annotations[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// NewRemoveAnnotationMutation creates a new mutation that removes annotations. If requireAll is enabled,
+// all provided annotation keys must be present for it to attempt to remove them.
+func NewRemoveAnnotationMutation(annotations []string, requireAll bool) AnnotationMutation {
+	return &removeAnnotationMutation{remove: annotations, requireAll: requireAll}
+}
+
+type AnnotationMutator struct {
+	mutations []AnnotationMutation
+}
+
+// NewAnnotationMutator creates a mutator with the provided mutations that can mutate an Object's annotations.
+func NewAnnotationMutator(mutations []AnnotationMutation) AnnotationMutator {
+	return AnnotationMutator{mutations: mutations}
+}
+
+// Mutate modifies the object's annotations based on the mutator's mutations. Returns whether any of the
+// mutations changed the annotations.
+func (m *AnnotationMutator) Mutate(obj metav1.Object) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	var mutated bool
+	for _, mutation := range m.mutations {
+		mutated = mutated || mutation.Mutate(annotations)
+	}
+	obj.SetAnnotations(annotations)
+	return mutated
+}

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -1,0 +1,127 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMutateAnnotations(t *testing.T) {
+	testCases := map[string]struct {
+		annotations     map[string]string
+		mutations       []AnnotationMutation
+		wantAnnotations map[string]string
+		wantMutated     bool
+	}{
+		"TestInsert/Any": {
+			annotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewInsertAnnotationMutation(map[string]string{
+					"keyA": "3",
+					"keyC": "4",
+				}, false),
+			},
+			wantAnnotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+				"keyC": "4",
+			},
+			wantMutated: true,
+		},
+		"TestInsert/All/Conflicts": {
+			annotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewInsertAnnotationMutation(map[string]string{
+					"keyA": "3",
+					"keyC": "4",
+				}, true),
+			},
+			wantAnnotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			wantMutated: false,
+		},
+		"TestInsert/All/NoConflicts": {
+			annotations: nil,
+			mutations: []AnnotationMutation{
+				NewInsertAnnotationMutation(map[string]string{
+					"keyA": "3",
+					"keyC": "4",
+				}, true),
+			},
+			wantAnnotations: map[string]string{
+				"keyA": "3",
+				"keyC": "4",
+			},
+			wantMutated: true,
+		},
+		"TestRemove/Any": {
+			annotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewRemoveAnnotationMutation([]string{
+					"keyA",
+					"keyC",
+				}, false),
+			},
+			wantAnnotations: map[string]string{
+				"keyB": "2",
+			},
+			wantMutated: true,
+		},
+		"TestRemove/All/Conflicts": {
+			annotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewRemoveAnnotationMutation([]string{
+					"keyA",
+					"keyC",
+				}, true),
+			},
+			wantAnnotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			wantMutated: false,
+		},
+		"TestRemove/All/NoConflicts": {
+			annotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewRemoveAnnotationMutation([]string{
+					"keyA",
+					"keyB",
+				}, true),
+			},
+			wantAnnotations: map[string]string{},
+			wantMutated:     true,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			obj := metav1.ObjectMeta{
+				Annotations: testCase.annotations,
+			}
+			m := NewAnnotationMutator(testCase.mutations)
+			assert.Equal(t, testCase.wantMutated, m.Mutate(&obj))
+			assert.Equal(t, testCase.wantAnnotations, obj.GetAnnotations())
+		})
+	}
+}

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -17,7 +17,7 @@ func TestMutateAnnotations(t *testing.T) {
 		wantAnnotations map[string]string
 		wantMutated     bool
 	}{
-		"TestInsert/Any": {
+		"TestInsert/Conflicts": {
 			annotations: map[string]string{
 				"keyA": "1",
 				"keyB": "2",
@@ -26,25 +26,7 @@ func TestMutateAnnotations(t *testing.T) {
 				NewInsertAnnotationMutation(map[string]string{
 					"keyA": "3",
 					"keyC": "4",
-				}, false),
-			},
-			wantAnnotations: map[string]string{
-				"keyA": "1",
-				"keyB": "2",
-				"keyC": "4",
-			},
-			wantMutated: true,
-		},
-		"TestInsert/All/Conflicts": {
-			annotations: map[string]string{
-				"keyA": "1",
-				"keyB": "2",
-			},
-			mutations: []AnnotationMutation{
-				NewInsertAnnotationMutation(map[string]string{
-					"keyA": "3",
-					"keyC": "4",
-				}, true),
+				}),
 			},
 			wantAnnotations: map[string]string{
 				"keyA": "1",
@@ -52,13 +34,13 @@ func TestMutateAnnotations(t *testing.T) {
 			},
 			wantMutated: false,
 		},
-		"TestInsert/All/NoConflicts": {
+		"TestInsert/NoConflicts": {
 			annotations: nil,
 			mutations: []AnnotationMutation{
 				NewInsertAnnotationMutation(map[string]string{
 					"keyA": "3",
 					"keyC": "4",
-				}, true),
+				}),
 			},
 			wantAnnotations: map[string]string{
 				"keyA": "3",
@@ -66,7 +48,7 @@ func TestMutateAnnotations(t *testing.T) {
 			},
 			wantMutated: true,
 		},
-		"TestRemove/Any": {
+		"TestRemove/Conflicts": {
 			annotations: map[string]string{
 				"keyA": "1",
 				"keyB": "2",
@@ -75,23 +57,7 @@ func TestMutateAnnotations(t *testing.T) {
 				NewRemoveAnnotationMutation([]string{
 					"keyA",
 					"keyC",
-				}, false),
-			},
-			wantAnnotations: map[string]string{
-				"keyB": "2",
-			},
-			wantMutated: true,
-		},
-		"TestRemove/All/Conflicts": {
-			annotations: map[string]string{
-				"keyA": "1",
-				"keyB": "2",
-			},
-			mutations: []AnnotationMutation{
-				NewRemoveAnnotationMutation([]string{
-					"keyA",
-					"keyC",
-				}, true),
+				}),
 			},
 			wantAnnotations: map[string]string{
 				"keyA": "1",
@@ -99,7 +65,7 @@ func TestMutateAnnotations(t *testing.T) {
 			},
 			wantMutated: false,
 		},
-		"TestRemove/All/NoConflicts": {
+		"TestRemove/NoConflicts": {
 			annotations: map[string]string{
 				"keyA": "1",
 				"keyB": "2",
@@ -108,7 +74,7 @@ func TestMutateAnnotations(t *testing.T) {
 				NewRemoveAnnotationMutation([]string{
 					"keyA",
 					"keyB",
-				}, true),
+				}),
 			},
 			wantAnnotations: map[string]string{},
 			wantMutated:     true,

--- a/pkg/instrumentation/annotationtype.go
+++ b/pkg/instrumentation/annotationtype.go
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+// Type is an enum for instrumentation types.
+type Type string
+
+// TypeSet is a map with Type keys.
+type TypeSet map[Type]any
+
+// NewTypeSet creates a new set of Type.
+func NewTypeSet(types ...Type) TypeSet {
+	s := make(TypeSet, len(types))
+	for _, t := range types {
+		s[t] = nil
+	}
+	return s
+}
+
+const (
+	TypeJava   Type = "java"
+	TypeNodeJS Type = "nodejs"
+	TypePython Type = "python"
+	TypeDotNet Type = "dotnet"
+	TypeGo     Type = "go"
+)
+
+// InjectAnnotationKey maps the instrumentation type to the inject annotation.
+func InjectAnnotationKey(instType Type) string {
+	switch instType {
+	case TypeJava:
+		return annotationInjectJava
+	case TypeNodeJS:
+		return annotationInjectNodeJS
+	case TypePython:
+		return annotationInjectPython
+	case TypeDotNet:
+		return annotationInjectDotNet
+	case TypeGo:
+		return annotationInjectGo
+	default:
+		return ""
+	}
+}

--- a/pkg/instrumentation/annotationtype_test.go
+++ b/pkg/instrumentation/annotationtype_test.go
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package instrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInjectAnnotationKey(t *testing.T) {
+	testCases := []struct {
+		instType Type
+		want     string
+	}{
+		{instType: TypeJava, want: annotationInjectJava},
+		{instType: TypeNodeJS, want: annotationInjectNodeJS},
+		{instType: TypePython, want: annotationInjectPython},
+		{instType: TypeDotNet, want: annotationInjectDotNet},
+		{instType: TypeGo, want: annotationInjectGo},
+		{instType: "unsupported", want: ""},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, InjectAnnotationKey(testCase.instType))
+	}
+}
+
+func TestTypeSet(t *testing.T) {
+	types := []Type{TypeJava, TypeGo}
+	ts := NewTypeSet(types...)
+	_, ok := ts[TypeJava]
+	assert.True(t, ok)
+	_, ok = ts[TypeGo]
+	assert.True(t, ok)
+	_, ok = ts[TypePython]
+	assert.False(t, ok)
+}

--- a/pkg/instrumentation/auto/annotation.go
+++ b/pkg/instrumentation/auto/annotation.go
@@ -1,0 +1,245 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package auto
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/exp/maps"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
+)
+
+const (
+	autoAnnotatePrefix     = "cloudwatch.aws.amazon.com/auto-annotate-"
+	defaultAnnotationValue = "true"
+)
+
+// AnnotationMutators has an AnnotationMutator resource name
+type AnnotationMutators struct {
+	client              client.Client
+	logger              logr.Logger
+	namespaceMutators   map[string]instrumentation.AnnotationMutator
+	deploymentMutators  map[string]instrumentation.AnnotationMutator
+	daemonSetMutators   map[string]instrumentation.AnnotationMutator
+	statefulSetMutators map[string]instrumentation.AnnotationMutator
+	defaultMutator      instrumentation.AnnotationMutator
+}
+
+// MutateAll runs the mutators for each of the configured resources.
+func (m *AnnotationMutators) MutateAll(ctx context.Context) {
+	m.MutateNamespaces(ctx)
+	m.MutateDeployments(ctx)
+	m.MutateDaemonSets(ctx)
+	m.MutateStatefulSets(ctx)
+}
+
+// MutateNamespaces lists all namespaces and runs MutateNamespace on each.
+func (m *AnnotationMutators) MutateNamespaces(ctx context.Context) {
+	namespaces := &corev1.NamespaceList{}
+	if err := m.client.List(ctx, namespaces); err != nil {
+		m.logger.Error(err, "Unable to list namespaces")
+		return
+	}
+
+	for _, namespace := range namespaces.Items {
+		m.MutateNamespace(ctx, namespace)
+	}
+}
+
+// MutateNamespace modifies a single namespace's annotations using the configured mutators.
+func (m *AnnotationMutators) MutateNamespace(ctx context.Context, namespace corev1.Namespace) {
+	mutator, ok := m.namespaceMutators[namespace.Name]
+	if !ok {
+		mutator = m.defaultMutator
+	}
+	if !mutator.Mutate(namespace.GetObjectMeta()) {
+		return
+	}
+	if err := m.client.Update(ctx, &namespace); err != nil {
+		m.logger.Error(err, "Unable to send update", "kind", namespace.Kind, "name", namespace.Name)
+	}
+}
+
+// MutateDeployments lists all deployments and runs MutateDeployment on each.
+func (m *AnnotationMutators) MutateDeployments(ctx context.Context) {
+	deployments := &appsv1.DeploymentList{}
+	if err := m.client.List(ctx, deployments); err != nil {
+		m.logger.Error(err, "Unable to list deployments")
+		return
+	}
+	for _, deployment := range deployments.Items {
+		m.MutateDeployment(ctx, deployment)
+	}
+}
+
+// MutateDeployment modifies a single deployment's pod template spec annotations using the configured mutators.
+func (m *AnnotationMutators) MutateDeployment(ctx context.Context, deployment appsv1.Deployment) {
+	name := namespacedName(deployment.GetObjectMeta())
+	mutator, ok := m.deploymentMutators[name]
+	if !ok {
+		mutator = m.defaultMutator
+	}
+	if !mutator.Mutate(deployment.Spec.Template.GetObjectMeta()) {
+		return
+	}
+	if err := m.client.Update(ctx, &deployment); err != nil {
+		m.logger.Error(err, "Unable to send update", "kind", deployment.Kind, "name", name)
+	}
+}
+
+// MutateDaemonSets lists all daemonsets and runs MutateDaemonSet on each.
+func (m *AnnotationMutators) MutateDaemonSets(ctx context.Context) {
+	daemonSets := &appsv1.DaemonSetList{}
+	if err := m.client.List(ctx, daemonSets); err != nil {
+		m.logger.Error(err, "Unable to list daemonsets")
+		return
+	}
+	for _, daemonSet := range daemonSets.Items {
+		m.MutateDaemonSet(ctx, daemonSet)
+	}
+}
+
+// MutateDaemonSet modifies a single daemonset's pod template spec annotations using the configured mutators.
+func (m *AnnotationMutators) MutateDaemonSet(ctx context.Context, daemonSet appsv1.DaemonSet) {
+	name := namespacedName(daemonSet.GetObjectMeta())
+	mutator, ok := m.daemonSetMutators[name]
+	if !ok {
+		mutator = m.defaultMutator
+	}
+	if !mutator.Mutate(daemonSet.Spec.Template.GetObjectMeta()) {
+		return
+	}
+	if err := m.client.Update(ctx, &daemonSet); err != nil {
+		m.logger.Error(err, "Unable to send update", "kind", daemonSet.Kind, "name", name)
+	}
+}
+
+// MutateStatefulSets lists all statefulsets and runs MutateStatefulSet on each.
+func (m *AnnotationMutators) MutateStatefulSets(ctx context.Context) {
+	statefulSets := &appsv1.StatefulSetList{}
+	if err := m.client.List(ctx, statefulSets); err != nil {
+		m.logger.Error(err, "Unable to list statefulsets")
+		return
+	}
+	for _, statefulSet := range statefulSets.Items {
+		m.MutateStatefulSet(ctx, statefulSet)
+	}
+}
+
+// MutateStatefulSet modifies a single statefulset's pod template spec annotations using the configured mutators.
+func (m *AnnotationMutators) MutateStatefulSet(ctx context.Context, statefulSet appsv1.StatefulSet) {
+	name := namespacedName(statefulSet.GetObjectMeta())
+	mutator, ok := m.statefulSetMutators[name]
+	if !ok {
+		mutator = m.defaultMutator
+	}
+	if !mutator.Mutate(statefulSet.Spec.Template.GetObjectMeta()) {
+		return
+	}
+	if err := m.client.Update(ctx, &statefulSet); err != nil {
+		m.logger.Error(err, "Unable to send update", "kind", statefulSet.Kind, "name", name)
+	}
+}
+
+func namespacedName(obj metav1.Object) string {
+	return fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+}
+
+// NewAnnotationMutators creates mutators based on the AnnotationConfig provided and enabled instrumentation.TypeSet.
+// The default mutator, which is used for non-configured resources, removes all auto-annotated annotations in the type
+// set.
+func NewAnnotationMutators(client client.Client, logger logr.Logger, cfg AnnotationConfig, typeSet instrumentation.TypeSet) *AnnotationMutators {
+	builder := newMutatorBuilder(typeSet)
+	return &AnnotationMutators{
+		client:              client,
+		logger:              logger,
+		namespaceMutators:   builder.buildMutators(getResources(cfg, typeSet, getNamespaces)),
+		deploymentMutators:  builder.buildMutators(getResources(cfg, typeSet, getDeployments)),
+		daemonSetMutators:   builder.buildMutators(getResources(cfg, typeSet, getDaemonSets)),
+		statefulSetMutators: builder.buildMutators(getResources(cfg, typeSet, getStatefulSets)),
+		defaultMutator:      instrumentation.NewAnnotationMutator(maps.Values(builder.removeMutations)),
+	}
+}
+
+func getResources(cfg AnnotationConfig, typeSet instrumentation.TypeSet, resourceFn func(AnnotationResources) []string) map[instrumentation.Type][]string {
+	resources := map[instrumentation.Type][]string{}
+	for instType := range typeSet {
+		resources[instType] = resourceFn(cfg.getResources(instType))
+	}
+	return resources
+}
+
+type mutatorBuilder struct {
+	typeSet         instrumentation.TypeSet
+	insertMutations map[instrumentation.Type]instrumentation.AnnotationMutation
+	removeMutations map[instrumentation.Type]instrumentation.AnnotationMutation
+}
+
+func (b *mutatorBuilder) buildMutators(resources map[instrumentation.Type][]string) map[string]instrumentation.AnnotationMutator {
+	mutators := map[string]instrumentation.AnnotationMutator{}
+	typeSetByResource := map[string]instrumentation.TypeSet{}
+	for instType, resourceNames := range resources {
+		for _, resourceName := range resourceNames {
+			typeSet, ok := typeSetByResource[resourceName]
+			if !ok {
+				typeSet = instrumentation.NewTypeSet()
+			}
+			typeSet[instType] = nil
+			typeSetByResource[resourceName] = typeSet
+		}
+	}
+	for resourceName, typeSet := range typeSetByResource {
+		var mutations []instrumentation.AnnotationMutation
+		for instType := range b.typeSet {
+			if _, ok := typeSet[instType]; ok {
+				mutations = append(mutations, b.insertMutations[instType])
+			} else {
+				mutations = append(mutations, b.removeMutations[instType])
+			}
+		}
+		mutators[resourceName] = instrumentation.NewAnnotationMutator(mutations)
+	}
+	return mutators
+}
+
+func newMutatorBuilder(typeSet instrumentation.TypeSet) *mutatorBuilder {
+	builder := &mutatorBuilder{
+		typeSet:         typeSet,
+		insertMutations: map[instrumentation.Type]instrumentation.AnnotationMutation{},
+		removeMutations: map[instrumentation.Type]instrumentation.AnnotationMutation{},
+	}
+	for instType := range typeSet {
+		builder.insertMutations[instType], builder.removeMutations[instType] = buildMutations(instType)
+	}
+	return builder
+}
+
+// buildMutations builds insert and remove annotation mutations for the instrumentation.Type.
+// Both are configured to only modify the annotations if all annotation keys are missing or present respectively.
+func buildMutations(instType instrumentation.Type) (instrumentation.AnnotationMutation, instrumentation.AnnotationMutation) {
+	annotations := buildAnnotations(instType)
+	return instrumentation.NewInsertAnnotationMutation(annotations, true),
+		instrumentation.NewRemoveAnnotationMutation(maps.Keys(annotations), true)
+}
+
+// buildAnnotations creates an annotation map of the inject and auto-annotate keys.
+func buildAnnotations(instType instrumentation.Type) map[string]string {
+	return map[string]string{
+		instrumentation.InjectAnnotationKey(instType): defaultAnnotationValue,
+		AnnotateKey(instType):                         defaultAnnotationValue,
+	}
+}
+
+// AnnotateKey joins the auto-annotate annotation prefix with the provided instrumentation.Type.
+func AnnotateKey(instType instrumentation.Type) string {
+	return autoAnnotatePrefix + strings.ToLower(string(instType))
+}

--- a/pkg/instrumentation/auto/annotation_test.go
+++ b/pkg/instrumentation/auto/annotation_test.go
@@ -117,7 +117,7 @@ func TestAnnotationMutators_Namespaces(t *testing.T) {
 			for _, gotNamespace := range gotNamespaces.Items {
 				annotations, ok := testCase.want[gotNamespace.Name]
 				assert.True(t, ok)
-				assert.Equal(t, annotations, gotNamespace.GetAnnotations())
+				assert.Equalf(t, annotations, gotNamespace.GetAnnotations(), "Failed for %s", gotNamespace.Name)
 			}
 		})
 	}
@@ -181,9 +181,10 @@ func TestAnnotationMutators_Deployments(t *testing.T) {
 			gotDeployments := &appv1.DeploymentList{}
 			require.NoError(t, client.List(ctx, gotDeployments))
 			for _, gotDeployment := range gotDeployments.Items {
-				annotations, ok := testCase.want[namespacedName(gotDeployment.GetObjectMeta())]
+				name := namespacedName(gotDeployment.GetObjectMeta())
+				annotations, ok := testCase.want[name]
 				assert.True(t, ok)
-				assert.Equal(t, annotations, gotDeployment.Spec.Template.GetAnnotations())
+				assert.Equalf(t, annotations, gotDeployment.Spec.Template.GetAnnotations(), "Failed for %s", name)
 			}
 		})
 	}
@@ -247,9 +248,10 @@ func TestAnnotationMutators_DaemonSets(t *testing.T) {
 			gotDaemonSets := &appv1.DaemonSetList{}
 			require.NoError(t, client.List(ctx, gotDaemonSets))
 			for _, gotDaemonSet := range gotDaemonSets.Items {
-				annotations, ok := testCase.want[namespacedName(gotDaemonSet.GetObjectMeta())]
+				name := namespacedName(gotDaemonSet.GetObjectMeta())
+				annotations, ok := testCase.want[name]
 				assert.True(t, ok)
-				assert.Equal(t, annotations, gotDaemonSet.Spec.Template.GetAnnotations())
+				assert.Equalf(t, annotations, gotDaemonSet.Spec.Template.GetAnnotations(), "Failed for %s", name)
 			}
 		})
 	}
@@ -313,9 +315,10 @@ func TestAnnotationMutators_StatefulSets(t *testing.T) {
 			gotStatefulSets := &appv1.StatefulSetList{}
 			require.NoError(t, client.List(ctx, gotStatefulSets))
 			for _, gotStatefulSet := range gotStatefulSets.Items {
-				annotations, ok := testCase.want[namespacedName(gotStatefulSet.GetObjectMeta())]
+				name := namespacedName(gotStatefulSet.GetObjectMeta())
+				annotations, ok := testCase.want[name]
 				assert.True(t, ok)
-				assert.Equal(t, annotations, gotStatefulSet.Spec.Template.GetAnnotations())
+				assert.Equalf(t, annotations, gotStatefulSet.Spec.Template.GetAnnotations(), "Failed for %s", name)
 			}
 		})
 	}

--- a/pkg/instrumentation/auto/annotation_test.go
+++ b/pkg/instrumentation/auto/annotation_test.go
@@ -1,0 +1,346 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package auto
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
+)
+
+func TestAnnotationMutators_Namespaces(t *testing.T) {
+	testCases := map[string]struct {
+		typeSet    instrumentation.TypeSet
+		namespaces map[string]map[string]string
+		cfg        AnnotationConfig
+		want       map[string]map[string]string
+	}{
+		"SkipManualAnnotations": {
+			typeSet: instrumentation.NewTypeSet(instrumentation.TypeJava),
+			namespaces: map[string]map[string]string{
+				"manual-inject": {
+					instrumentation.InjectAnnotationKey(instrumentation.TypeJava): defaultAnnotationValue,
+				},
+				"manual-auto": {
+					AnnotateKey(instrumentation.TypeJava): defaultAnnotationValue,
+				},
+			},
+			cfg: AnnotationConfig{
+				Java: AnnotationResources{
+					Namespaces: []string{"manual-inject", "manual-auto"},
+				},
+			},
+			want: map[string]map[string]string{
+				"manual-inject": {
+					instrumentation.InjectAnnotationKey(instrumentation.TypeJava): defaultAnnotationValue,
+				},
+				"manual-auto": {
+					AnnotateKey(instrumentation.TypeJava): defaultAnnotationValue,
+				},
+			},
+		},
+		"RemoveAuto": {
+			typeSet: instrumentation.NewTypeSet(instrumentation.TypeJava, instrumentation.TypePython),
+			namespaces: map[string]map[string]string{
+				"remove-auto-java": buildAnnotations(instrumentation.TypeJava),
+				"remove-auto-python": mergeAnnotations(
+					buildAnnotations(instrumentation.TypePython),
+					map[string]string{"keep-other-field": "remains"},
+				),
+				"keep-auto-java": mergeAnnotations(
+					buildAnnotations(instrumentation.TypeJava),
+					buildAnnotations(instrumentation.TypePython),
+				),
+			},
+			cfg: AnnotationConfig{
+				Java: AnnotationResources{
+					Namespaces: []string{"keep-auto-java"},
+				},
+			},
+			want: map[string]map[string]string{
+				"remove-auto-java":   nil,
+				"remove-auto-python": {"keep-other-field": "remains"},
+				"keep-auto-java":     buildAnnotations(instrumentation.TypeJava),
+			},
+		},
+		"AddAuto": {
+			typeSet: instrumentation.NewTypeSet(instrumentation.TypeJava),
+			namespaces: map[string]map[string]string{
+				"add-auto-java": buildAnnotations(instrumentation.TypePython),
+			},
+			cfg: AnnotationConfig{
+				Java: AnnotationResources{
+					Namespaces: []string{"add-auto-java"},
+				},
+			},
+			want: map[string]map[string]string{
+				"add-auto-java": mergeAnnotations(
+					buildAnnotations(instrumentation.TypeJava),
+					buildAnnotations(instrumentation.TypePython),
+				),
+			},
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			var namespaces []corev1.Namespace
+			for name, annotations := range testCase.namespaces {
+				namespaces = append(namespaces, corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        name,
+						Annotations: annotations,
+					},
+				})
+			}
+			ctx := context.Background()
+			client := fake.NewClientBuilder().WithLists(&corev1.NamespaceList{Items: namespaces}).Build()
+			mutators := NewAnnotationMutators(
+				client,
+				logr.Logger{},
+				testCase.cfg,
+				testCase.typeSet,
+			)
+			mutators.MutateAll(ctx)
+			gotNamespaces := &corev1.NamespaceList{}
+			require.NoError(t, client.List(ctx, gotNamespaces))
+			for _, gotNamespace := range gotNamespaces.Items {
+				annotations, ok := testCase.want[gotNamespace.Name]
+				assert.True(t, ok)
+				assert.Equal(t, annotations, gotNamespace.GetAnnotations())
+			}
+		})
+	}
+}
+
+func TestAnnotationMutators_Deployments(t *testing.T) {
+	testCases := map[string]struct {
+		typeSet     instrumentation.TypeSet
+		deployments map[string]map[string]string
+		cfg         AnnotationConfig
+		want        map[string]map[string]string
+	}{
+		"AddRemoveAuto": {
+			typeSet: instrumentation.NewTypeSet(instrumentation.TypeJava),
+			deployments: map[string]map[string]string{
+				"test/add-auto-java":    nil,
+				"test/keep-auto-java":   buildAnnotations(instrumentation.TypeJava),
+				"test/remove-auto-java": buildAnnotations(instrumentation.TypeJava),
+			},
+			cfg: AnnotationConfig{
+				Java: AnnotationResources{
+					Deployments: []string{"test/add-auto-java", "test/keep-auto-java"},
+				},
+			},
+			want: map[string]map[string]string{
+				"test/add-auto-java":    buildAnnotations(instrumentation.TypeJava),
+				"test/keep-auto-java":   buildAnnotations(instrumentation.TypeJava),
+				"test/remove-auto-java": nil,
+			},
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			var deployments []appv1.Deployment
+			for name, annotations := range testCase.deployments {
+				var namespace string
+				namespace, name, _ = strings.Cut(name, "/")
+				deployments = append(deployments, appv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+					},
+					Spec: appv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: annotations,
+							},
+						},
+					},
+				})
+			}
+			ctx := context.Background()
+			client := fake.NewClientBuilder().WithLists(&appv1.DeploymentList{Items: deployments}).Build()
+			mutators := NewAnnotationMutators(
+				client,
+				logr.Logger{},
+				testCase.cfg,
+				testCase.typeSet,
+			)
+			mutators.MutateAll(ctx)
+			gotDeployments := &appv1.DeploymentList{}
+			require.NoError(t, client.List(ctx, gotDeployments))
+			for _, gotDeployment := range gotDeployments.Items {
+				annotations, ok := testCase.want[namespacedName(gotDeployment.GetObjectMeta())]
+				assert.True(t, ok)
+				assert.Equal(t, annotations, gotDeployment.Spec.Template.GetAnnotations())
+			}
+		})
+	}
+}
+
+func TestAnnotationMutators_DaemonSets(t *testing.T) {
+	testCases := map[string]struct {
+		typeSet    instrumentation.TypeSet
+		daemonSets map[string]map[string]string
+		cfg        AnnotationConfig
+		want       map[string]map[string]string
+	}{
+		"AddKeepRemoveAuto": {
+			typeSet: instrumentation.NewTypeSet(instrumentation.TypeJava),
+			daemonSets: map[string]map[string]string{
+				"test/add-auto-java":    nil,
+				"test/keep-auto-java":   buildAnnotations(instrumentation.TypeJava),
+				"test/remove-auto-java": buildAnnotations(instrumentation.TypeJava),
+			},
+			cfg: AnnotationConfig{
+				Java: AnnotationResources{
+					DaemonSets: []string{"test/add-auto-java", "test/keep-auto-java"},
+				},
+			},
+			want: map[string]map[string]string{
+				"test/add-auto-java":    buildAnnotations(instrumentation.TypeJava),
+				"test/keep-auto-java":   buildAnnotations(instrumentation.TypeJava),
+				"test/remove-auto-java": nil,
+			},
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			var daemonSets []appv1.DaemonSet
+			for name, annotations := range testCase.daemonSets {
+				var namespace string
+				namespace, name, _ = strings.Cut(name, "/")
+				daemonSets = append(daemonSets, appv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+					},
+					Spec: appv1.DaemonSetSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: annotations,
+							},
+						},
+					},
+				})
+			}
+			ctx := context.Background()
+			client := fake.NewClientBuilder().WithLists(&appv1.DaemonSetList{Items: daemonSets}).Build()
+			mutators := NewAnnotationMutators(
+				client,
+				logr.Logger{},
+				testCase.cfg,
+				testCase.typeSet,
+			)
+			mutators.MutateAll(ctx)
+			gotDaemonSets := &appv1.DaemonSetList{}
+			require.NoError(t, client.List(ctx, gotDaemonSets))
+			for _, gotDaemonSet := range gotDaemonSets.Items {
+				annotations, ok := testCase.want[namespacedName(gotDaemonSet.GetObjectMeta())]
+				assert.True(t, ok)
+				assert.Equal(t, annotations, gotDaemonSet.Spec.Template.GetAnnotations())
+			}
+		})
+	}
+}
+
+func TestAnnotationMutators_StatefulSets(t *testing.T) {
+	testCases := map[string]struct {
+		typeSet      instrumentation.TypeSet
+		statefulSets map[string]map[string]string
+		cfg          AnnotationConfig
+		want         map[string]map[string]string
+	}{
+		"AddRemoveAuto": {
+			typeSet: instrumentation.NewTypeSet(instrumentation.TypeJava),
+			statefulSets: map[string]map[string]string{
+				"test/add-auto-java":    nil,
+				"test/keep-auto-java":   buildAnnotations(instrumentation.TypeJava),
+				"test/remove-auto-java": buildAnnotations(instrumentation.TypeJava),
+			},
+			cfg: AnnotationConfig{
+				Java: AnnotationResources{
+					StatefulSets: []string{"test/add-auto-java", "test/keep-auto-java"},
+				},
+			},
+			want: map[string]map[string]string{
+				"test/add-auto-java":    buildAnnotations(instrumentation.TypeJava),
+				"test/keep-auto-java":   buildAnnotations(instrumentation.TypeJava),
+				"test/remove-auto-java": nil,
+			},
+		},
+	}
+	for testName, testCase := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			var statefulSets []appv1.StatefulSet
+			for name, annotations := range testCase.statefulSets {
+				var namespace string
+				namespace, name, _ = strings.Cut(name, "/")
+				statefulSets = append(statefulSets, appv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+					},
+					Spec: appv1.StatefulSetSpec{
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: annotations,
+							},
+						},
+					},
+				})
+			}
+			ctx := context.Background()
+			client := fake.NewClientBuilder().WithLists(&appv1.StatefulSetList{Items: statefulSets}).Build()
+			mutators := NewAnnotationMutators(
+				client,
+				logr.Logger{},
+				testCase.cfg,
+				testCase.typeSet,
+			)
+			mutators.MutateAll(ctx)
+			gotStatefulSets := &appv1.StatefulSetList{}
+			require.NoError(t, client.List(ctx, gotStatefulSets))
+			for _, gotStatefulSet := range gotStatefulSets.Items {
+				annotations, ok := testCase.want[namespacedName(gotStatefulSet.GetObjectMeta())]
+				assert.True(t, ok)
+				assert.Equal(t, annotations, gotStatefulSet.Spec.Template.GetAnnotations())
+			}
+		})
+	}
+}
+
+func TestAnnotateKey(t *testing.T) {
+	testCases := []struct {
+		instType instrumentation.Type
+		want     string
+	}{
+		{instType: instrumentation.TypeJava, want: "cloudwatch.aws.amazon.com/auto-annotate-java"},
+		{instType: instrumentation.TypeGo, want: "cloudwatch.aws.amazon.com/auto-annotate-go"},
+		{instType: "unsupported", want: "cloudwatch.aws.amazon.com/auto-annotate-unsupported"},
+	}
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.want, AnnotateKey(testCase.instType))
+	}
+}
+
+func mergeAnnotations(annotationMaps ...map[string]string) map[string]string {
+	merged := map[string]string{}
+	for _, annotationMap := range annotationMaps {
+		for key, value := range annotationMap {
+			merged[key] = value
+		}
+	}
+	return merged
+}

--- a/pkg/instrumentation/auto/config.go
+++ b/pkg/instrumentation/auto/config.go
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package auto
+
+import "github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
+
+// AnnotationConfig details the resources that have enabled
+// auto-annotation for each instrumentation type.
+type AnnotationConfig struct {
+	Java   AnnotationResources `json:"java"`
+	Python AnnotationResources `json:"python"`
+}
+
+func (c AnnotationConfig) getResources(instType instrumentation.Type) AnnotationResources {
+	switch instType {
+	case instrumentation.TypeJava:
+		return c.Java
+	case instrumentation.TypePython:
+		return c.Python
+	default:
+		return AnnotationResources{}
+	}
+}
+
+// AnnotationResources contains slices of resource names for each
+// of the supported workloads.
+type AnnotationResources struct {
+	Namespaces   []string `json:"namespaces,omitempty"`
+	Deployments  []string `json:"deployments,omitempty"`
+	DaemonSets   []string `json:"daemonsets,omitempty"`
+	StatefulSets []string `json:"statefulsets,omitempty"`
+}
+
+func getNamespaces(r AnnotationResources) []string {
+	return r.Namespaces
+}
+
+func getDeployments(r AnnotationResources) []string {
+	return r.Deployments
+}
+
+func getDaemonSets(r AnnotationResources) []string {
+	return r.DaemonSets
+}
+
+func getStatefulSets(r AnnotationResources) []string {
+	return r.StatefulSets
+}

--- a/pkg/instrumentation/auto/config_test.go
+++ b/pkg/instrumentation/auto/config_test.go
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package auto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
+)
+
+func TestConfig(t *testing.T) {
+	cfg := AnnotationConfig{
+		Java: AnnotationResources{
+			Namespaces:   []string{"n1"},
+			Deployments:  []string{"d1"},
+			DaemonSets:   []string{"ds1"},
+			StatefulSets: []string{"ss1"},
+		},
+		Python: AnnotationResources{
+			Namespaces:   []string{"n2"},
+			Deployments:  []string{"d2"},
+			DaemonSets:   []string{"ds2"},
+			StatefulSets: []string{"ss2"},
+		},
+	}
+	assert.Equal(t, cfg.Java, cfg.getResources(instrumentation.TypeJava))
+	assert.Equal(t, []string{"n1"}, getNamespaces(cfg.Java))
+	assert.Equal(t, []string{"d1"}, getDeployments(cfg.Java))
+	assert.Equal(t, cfg.Python, cfg.getResources(instrumentation.TypePython))
+	assert.Equal(t, []string{"ds2"}, getDaemonSets(cfg.Python))
+	assert.Equal(t, []string{"ss2"}, getStatefulSets(cfg.Python))
+	assert.Equal(t, AnnotationResources{}, cfg.getResources("invalidType"))
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Adds auto-annotation configuration that gets passed in through `auto-annotation-config` flag.
- Adds auto-annotation mutators that get run at start up.
  - `AnnotationMutator` is partially based on `kubectl annotate` implementation (https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/annotate/annotate.go#L457).
  - Has functions for each of the supported resources.
- Adds unit tests for annotation mutators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
