### PR TITLE
Update CRDs in helm folder

### DIFF
--- a/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -4,8 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-agent-operator
   name: amazoncloudwatchagents.cloudwatch.aws.amazon.com
 spec:
   group: cloudwatch.aws.amazon.com
@@ -14,73 +12,2675 @@ spec:
     listKind: AmazonCloudWatchAgentList
     plural: amazoncloudwatchagents
     shortNames:
-    - otelcol
-    - otelcols
+      - otelcol
+      - otelcols
     singular: amazoncloudwatchagent
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Deployment Mode
-      jsonPath: .spec.mode
-      name: Mode
-      type: string
-    - description: CloudWatch Agent Version
-      jsonPath: .status.version
-      name: Version
-      type: string
-    - jsonPath: .status.scale.statusReplicas
-      name: Ready
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.image
-      name: Image
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: AmazonCloudWatchAgent is the Schema for the AmazonCloudWatchAgents
-          API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - additionalPrinterColumns:
+        - description: Deployment Mode
+          jsonPath: .spec.mode
+          name: Mode
+          type: string
+        - description: CloudWatch Agent Version
+          jsonPath: .status.version
+          name: Version
+          type: string
+        - jsonPath: .status.scale.statusReplicas
+          name: Ready
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .status.image
+          name: Image
+          type: string
+        - description: Management State
+          jsonPath: .spec.managementState
+          name: Management
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: AmazonCloudWatchAgent is the Schema for the amazoncloudwatchagents
+            API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AmazonCloudWatchAgentSpec defines the desired state of AmazonCloudWatchAgent.
-            properties:
-              args:
-                additionalProperties:
-                  type: string
-                description: Args is the set of arguments to pass to the CloudWatch
-                  Agent binary
-                type: object
-              config:
-                description: Config is the raw JSON to be used as the collector's
-                  configuration. Refer to the CloudWatch Agent documentation for details.
-                type: string
-              env:
-                description: ENV vars to set on the CloudWatch Agent's Pods. These
-                  can then in certain cases be consumed in the config file for the
-                  Collector.
-                items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AmazonCloudWatchAgentSpec defines the desired state of AmazonCloudWatchAgent.
+              properties:
+                additionalContainers:
+                  description: "AdditionalContainers allows injecting additional containers
+                  into the Collector's pod definition. These sidecar containers can
+                  be used for authentication proxies, log shipping sidecars, agents
+                  for shipping metrics to their cloud, or in general sidecars that
+                  do not support automatic injection. This option only applies to
+                  Deployment, DaemonSet, and StatefulSet deployment modes of the collector.
+                  It does not apply to the sidecar deployment mode. More info about
+                  sidecars: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+                  \n Container names managed by the operator: * `otc-container` \n
+                  Overriding containers managed by the operator is outside the scope
+                  of what the maintainers will support and by doing so, you wil accept
+                  the risk of it breaking things."
+                  items:
+                    description: A single application container that you want to run
+                      within a pod.
+                    properties:
+                      args:
+                        description: 'Arguments to the entrypoint. The container image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. Double $$ are reduced to a single $, which allows
+                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                        produce the string literal "$(VAR_NAME)". Escaped references
+                        will never be expanded, regardless of whether the variable
+                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: 'Entrypoint array. Not executed within a shell.
+                        The container image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
+                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether
+                        the variable exists or not. Cannot be updated. More info:
+                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be
+                                a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      envFrom:
+                        description: List of sources to populate environment variables
+                          in the container. The keys defined within a source must be
+                          a C_IDENTIFIER. All invalid keys will be reported as an event
+                          when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take
+                          precedence. Values defined by an Env with a duplicate key
+                          will take precedence. Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      image:
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
+                        type: string
+                      imagePullPolicy:
+                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        type: string
+                      lifecycle:
+                        description: Actions that the management system should take
+                          in response to container lifecycle events. Cannot be updated.
+                        properties:
+                          postStart:
+                            description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name. This will
+                                            be canonicalized upon output, so case-variant
+                                            names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds to
+                                      sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward compatibility.
+                                  There are no validation of this field and lifecycle
+                                  hooks will fail in runtime when tcp handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The Pod''s termination grace period
+                            countdown begins before the PreStop hook is executed.
+                            Regardless of the outcome of the handler, the container
+                            will eventually terminate within the Pod''s termination
+                            grace period (unless delayed by finalizers). Other management
+                            of the container blocks until the hook completes or until
+                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name. This will
+                                            be canonicalized upon output, so case-variant
+                                            names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds to
+                                      sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward compatibility.
+                                  There are no validation of this field and lifecycle
+                                  hooks will fail in runtime when tcp handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|', etc)
+                                  won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the
+                                  pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Name or number of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Number or name of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and the
+                              time when the processes are forcibly halted with a kill
+                              signal. Set this value longer than the expected cleanup
+                              time for your process. If this value is nil, the pod's
+                              terminationGracePeriodSeconds will be used. Otherwise,
+                              this value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates
+                              stop immediately via the kill signal (no opportunity to
+                              shut down). This is a beta field and requires enabling
+                              ProbeTerminationGracePeriod feature gate. Minimum value
+                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        description: Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
+                        items:
+                          description: ContainerPort represents a network port in a
+                            single container.
+                          properties:
+                            containerPort:
+                              description: Number of port to expose on the pod's IP
+                                address. This must be a valid port number, 0 < x < 65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port to.
+                              type: string
+                            hostPort:
+                              description: Number of port to expose on the host. If
+                                specified, this must be a valid port number, 0 < x <
+                                65536. If HostNetwork is specified, this must match
+                                ContainerPort. Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: If specified, this must be an IANA_SVC_NAME
+                                and unique within the pod. Each named port in a pod
+                                must have a unique name. Name for the port that can
+                                be referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                          required:
+                            - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|', etc)
+                                  won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the
+                                  pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Name or number of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Number or name of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and the
+                              time when the processes are forcibly halted with a kill
+                              signal. Set this value longer than the expected cleanup
+                              time for your process. If this value is nil, the pod's
+                              terminationGracePeriodSeconds will be used. Otherwise,
+                              this value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates
+                              stop immediately via the kill signal (no opportunity to
+                              shut down). This is a beta field and requires enabling
+                              ProbeTerminationGracePeriod feature gate. Minimum value
+                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      resizePolicy:
+                        description: Resources resize policy for the container.
+                        items:
+                          description: ContainerResizePolicy represents resource resize
+                            policy for the container.
+                          properties:
+                            resourceName:
+                              description: 'Name of the resource to which this resource
+                              resize policy applies. Supported values: cpu, memory.'
+                              type: string
+                            restartPolicy:
+                              description: Restart policy to apply when specified resource
+                                is resized. If not specified, it defaults to NotRequired.
+                              type: string
+                          required:
+                            - resourceName
+                            - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      resources:
+                        description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                            in spec.resourceClaims, that are used by this container.
+                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                            feature gate. \n This field is immutable. It can only
+                            be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      restartPolicy:
+                        description: 'RestartPolicy defines the restart behavior of
+                        individual containers in a pod. This field may only be set
+                        for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
+                        the restart behavior is defined by the Pod''s restart policy
+                        and the container type. Setting the RestartPolicy as "Always"
+                        for the init container will have the following effect: this
+                        init container will be continually restarted on exit until
+                        all regular containers have terminated. Once all regular containers
+                        have completed, all init containers with restartPolicy "Always"
+                        will be shut down. This lifecycle differs from normal init
+                        containers and is often referred to as a "sidecar" container.
+                        Although this init container still starts in the init container
+                        sequence, it does not wait for the container to complete before
+                        proceeding to the next init container. Instead, the next init
+                        container starts immediately after this init container is
+                        started, or after any startupProbe has successfully completed.'
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext defines the security options the
+                        container should be run with. If set, the fields of SecurityContext
+                        override the equivalent fields of PodSecurityContext. More
+                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN Note that this field cannot be set
+                            when spec.os.name is windows.'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by
+                              the container runtime. Note that this field cannot be
+                              set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent to
+                              root on the host. Defaults to false. Note that this field
+                              cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to
+                              use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a
+                              non-root user. If true, the Kubelet will validate the
+                              image at runtime to ensure that it does not run as UID
+                              0 (root) and fail to start the container if it does. If
+                              unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both
+                              SecurityContext and PodSecurityContext, the value specified
+                              in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a
+                              random SELinux context for each container.  May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                              Note that this field cannot be set when spec.os.name is
+                              windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile
+                                  must be preconfigured on the node to work. Must be
+                                  a descending path, relative to the kubelet's configured
+                                  seccomp profile location. Must be set if type is "Localhost".
+                                  Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is
+                              linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container should
+                                  be run as a 'Host Process' container. All of a Pod's
+                                  containers must have the same effective HostProcess
+                                  value (it is not allowed to have a mix of HostProcess
+                                  containers and non-HostProcess containers). In addition,
+                                  if HostProcess is true then HostNetwork must also
+                                  be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      startupProbe:
+                        description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|', etc)
+                                  won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the
+                                  pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Name or number of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Number or name of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and the
+                              time when the processes are forcibly halted with a kill
+                              signal. Set this value longer than the expected cleanup
+                              time for your process. If this value is nil, the pod's
+                              terminationGracePeriodSeconds will be used. Otherwise,
+                              this value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates
+                              stop immediately via the kill signal (no opportunity to
+                              shut down). This is a beta field and requires enabling
+                              ProbeTerminationGracePeriod feature gate. Minimum value
+                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      stdin:
+                        description: Whether this container should allocate a buffer
+                          for stdin in the container runtime. If this is not set, reads
+                          from stdin in the container will always result in EOF. Default
+                          is false.
+                        type: boolean
+                      stdinOnce:
+                        description: Whether the container runtime should close the
+                          stdin channel after it has been opened by a single attach.
+                          When stdin is true the stdin stream will remain open across
+                          multiple attach sessions. If stdinOnce is set to true, stdin
+                          is opened on container start, is empty until the first client
+                          attaches to stdin, and then remains open and accepts data
+                          until the client disconnects, at which time stdin is closed
+                          and remains closed until the container is restarted. If this
+                          flag is false, a container processes that reads from stdin
+                          will never receive an EOF. Default is false
+                        type: boolean
+                      terminationMessagePath:
+                        description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        type: string
+                      terminationMessagePolicy:
+                        description: Indicate how the termination message should be
+                          populated. File will use the contents of terminationMessagePath
+                          to populate the container status message on both success and
+                          failure. FallbackToLogsOnError will use the last chunk of
+                          container log output if the termination message file is empty
+                          and the container exited with an error. The log output is
+                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                          to File. Cannot be updated.
+                        type: string
+                      tty:
+                        description: Whether this container should allocate a TTY for
+                          itself, also requires 'stdin' to be true. Default is false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to be
+                          used by the container.
+                        items:
+                          description: volumeDevice describes a mapping of a raw block
+                            device within a container.
+                          properties:
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
+                              type: string
+                            name:
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
+                              type: string
+                          required:
+                            - devicePath
+                            - name
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume
+                                should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are
+                                propagated from the host to container and the other
+                                way around. When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves similarly
+                                to SubPath but environment variable references $(VAR_NAME)
+                                are expanded using the container's environment. Defaults
+                                to "" (volume's root). SubPathExpr and SubPath are mutually
+                                exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                      workingDir:
+                        description: Container's working directory. If not specified,
+                          the container runtime's default will be used, which might
+                          be configured in the container image. Cannot be updated.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                affinity:
+                  description: If specified, indicates the pod's scheduling constraints
                   properties:
-                    name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
-                      type: string
-                    value:
-                      description: 'Variable references $(VAR_NAME) are expanded using
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the
+                        pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the affinity expressions specified by
+                            this field, but it may choose a node that violates one or
+                            more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node matches
+                            the corresponding matchExpressions; the node(s) with the
+                            highest sum are the most preferred.
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects (i.e.
+                              is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with the
+                                  corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - preference
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not be
+                            scheduled onto the node. If the affinity requirements specified
+                            by this field cease to be met at some point during pod execution
+                            (e.g. due to an update), the system may or may not try to
+                            eventually evict the pod from its node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed. The
+                                  TopologySelectorTerm type implements a subset of the
+                                  NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values. If
+                                            the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values array
+                                            must be empty. If the operator is Gt or
+                                            Lt, the values array must have a single
+                                            element, which will be interpreted as an
+                                            integer. This array is replaced during a
+                                            strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                          required:
+                            - nodeSelectorTerms
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
+                        this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the affinity expressions specified by
+                            this field, but it may choose a node that violates one or
+                            more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node has
+                            pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods. If it's null, this PodAffinityTerm
+                                      matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: MatchLabelKeys is a set of pod label
+                                      keys to select which pods will be taken into consideration.
+                                      The keys are used to lookup values from the incoming
+                                      pod labels, those key-value labels are merged
+                                      with `LabelSelector` as `key in (value)` to select
+                                      the group of existing pods which pods will be
+                                      taken into consideration for the incoming pod's
+                                      pod (anti) affinity. Keys that don't exist in
+                                      the incoming pod labels will be ignored. The default
+                                      value is empty. The same key is forbidden to exist
+                                      in both MatchLabelKeys and LabelSelector. Also,
+                                      MatchLabelKeys cannot be set when LabelSelector
+                                      isn't set. This is an alpha field and requires
+                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: MismatchLabelKeys is a set of pod label
+                                      keys to select which pods will be taken into consideration.
+                                      The keys are used to lookup values from the incoming
+                                      pod labels, those key-value labels are merged
+                                      with `LabelSelector` as `key notin (value)` to
+                                      select the group of existing pods which pods will
+                                      be taken into consideration for the incoming pod's
+                                      pod (anti) affinity. Keys that don't exist in
+                                      the incoming pod labels will be ignored. The default
+                                      value is empty. The same key is forbidden to exist
+                                      in both MismatchLabelKeys and LabelSelector. Also,
+                                      MismatchLabelKeys cannot be set when LabelSelector
+                                      isn't set. This is an alpha field and requires
+                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not be
+                            scheduled onto the node. If the affinity requirements specified
+                            by this field cease to be met at some point during pod execution
+                            (e.g. due to a pod label update), the system may or may
+                            not try to eventually evict the pod from its node. When
+                            there are multiple elements, the lists of nodes corresponding
+                            to each podAffinityTerm are intersected, i.e. all terms
+                            must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not co-located
+                              (anti-affinity) with, where co-located is defined as running
+                              on a node whose value of the label with key <topologyKey>
+                              matches that of any node on which a pod of the set of
+                              pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods. If it's null, this PodAffinityTerm
+                                  matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label keys
+                                  to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key in (value)` to select the
+                                  group of existing pods which pods will be taken into
+                                  consideration for the incoming pod's pod (anti) affinity.
+                                  Keys that don't exist in the incoming pod labels will
+                                  be ignored. The default value is empty. The same key
+                                  is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  Also, MatchLabelKeys cannot be set when LabelSelector
+                                  isn't set. This is an alpha field and requires enabling
+                                  MatchLabelKeysInPodAffinity feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: MismatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key notin (value)` to select the
+                                  group of existing pods which pods will be taken into
+                                  consideration for the incoming pod's pod (anti) affinity.
+                                  Keys that don't exist in the incoming pod labels will
+                                  be ignored. The default value is empty. The same key
+                                  is forbidden to exist in both MismatchLabelKeys and
+                                  LabelSelector. Also, MismatchLabelKeys cannot be set
+                                  when LabelSelector isn't set. This is an alpha field
+                                  and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to the
+                                  union of the namespaces selected by this field and
+                                  the ones listed in the namespaces field. null selector
+                                  and null or empty namespaces list means "this pod's
+                                  namespace". An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: namespaces specifies a static list of namespace
+                                  names that the term applies to. The term is applied
+                                  to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector. null or
+                                  empty namespaces list and null namespaceSelector means
+                                  "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where
+                                  co-located is defined as running on a node whose value
+                                  of the label with key topologyKey matches that of
+                                  any node on which any of the selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g.
+                        avoid putting this pod in the same node, zone, etc. as some
+                        other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods to
+                            nodes that satisfy the anti-affinity expressions specified
+                            by this field, but it may choose a node that violates one
+                            or more of the expressions. The node that is most preferred
+                            is the one with the greatest sum of weights, i.e. for each
+                            node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions,
+                            etc.), compute a sum by iterating through the elements of
+                            this field and adding "weight" to the sum if the node has
+                            pods which matches the corresponding podAffinityTerm; the
+                            node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods. If it's null, this PodAffinityTerm
+                                      matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: MatchLabelKeys is a set of pod label
+                                      keys to select which pods will be taken into consideration.
+                                      The keys are used to lookup values from the incoming
+                                      pod labels, those key-value labels are merged
+                                      with `LabelSelector` as `key in (value)` to select
+                                      the group of existing pods which pods will be
+                                      taken into consideration for the incoming pod's
+                                      pod (anti) affinity. Keys that don't exist in
+                                      the incoming pod labels will be ignored. The default
+                                      value is empty. The same key is forbidden to exist
+                                      in both MatchLabelKeys and LabelSelector. Also,
+                                      MatchLabelKeys cannot be set when LabelSelector
+                                      isn't set. This is an alpha field and requires
+                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: MismatchLabelKeys is a set of pod label
+                                      keys to select which pods will be taken into consideration.
+                                      The keys are used to lookup values from the incoming
+                                      pod labels, those key-value labels are merged
+                                      with `LabelSelector` as `key notin (value)` to
+                                      select the group of existing pods which pods will
+                                      be taken into consideration for the incoming pod's
+                                      pod (anti) affinity. Keys that don't exist in
+                                      the incoming pod labels will be ignored. The default
+                                      value is empty. The same key is forbidden to exist
+                                      in both MismatchLabelKeys and LabelSelector. Also,
+                                      MismatchLabelKeys cannot be set when LabelSelector
+                                      isn't set. This is an alpha field and requires
+                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: A label query over the set of namespaces
+                                      that the term applies to. The term is applied
+                                      to the union of the namespaces selected by this
+                                      field and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list
+                                      means "this pod's namespace". An empty selector
+                                      ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: namespaces specifies a static list
+                                      of namespace names that the term applies to. The
+                                      term is applied to the union of the namespaces
+                                      listed in this field and the ones selected by
+                                      namespaceSelector. null or empty namespaces list
+                                      and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                              - podAffinityTerm
+                              - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified by
+                            this field are not met at scheduling time, the pod will
+                            not be scheduled onto the node. If the anti-affinity requirements
+                            specified by this field cease to be met at some point during
+                            pod execution (e.g. due to a pod label update), the system
+                            may or may not try to eventually evict the pod from its
+                            node. When there are multiple elements, the lists of nodes
+                            corresponding to each podAffinityTerm are intersected, i.e.
+                            all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not co-located
+                              (anti-affinity) with, where co-located is defined as running
+                              on a node whose value of the label with key <topologyKey>
+                              matches that of any node on which a pod of the set of
+                              pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods. If it's null, this PodAffinityTerm
+                                  matches with no Pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: MatchLabelKeys is a set of pod label keys
+                                  to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key in (value)` to select the
+                                  group of existing pods which pods will be taken into
+                                  consideration for the incoming pod's pod (anti) affinity.
+                                  Keys that don't exist in the incoming pod labels will
+                                  be ignored. The default value is empty. The same key
+                                  is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  Also, MatchLabelKeys cannot be set when LabelSelector
+                                  isn't set. This is an alpha field and requires enabling
+                                  MatchLabelKeysInPodAffinity feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              mismatchLabelKeys:
+                                description: MismatchLabelKeys is a set of pod label
+                                  keys to select which pods will be taken into consideration.
+                                  The keys are used to lookup values from the incoming
+                                  pod labels, those key-value labels are merged with
+                                  `LabelSelector` as `key notin (value)` to select the
+                                  group of existing pods which pods will be taken into
+                                  consideration for the incoming pod's pod (anti) affinity.
+                                  Keys that don't exist in the incoming pod labels will
+                                  be ignored. The default value is empty. The same key
+                                  is forbidden to exist in both MismatchLabelKeys and
+                                  LabelSelector. Also, MismatchLabelKeys cannot be set
+                                  when LabelSelector isn't set. This is an alpha field
+                                  and requires enabling MatchLabelKeysInPodAffinity
+                                  feature gate.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              namespaceSelector:
+                                description: A label query over the set of namespaces
+                                  that the term applies to. The term is applied to the
+                                  union of the namespaces selected by this field and
+                                  the ones listed in the namespaces field. null selector
+                                  and null or empty namespaces list means "this pod's
+                                  namespace". An empty selector ({}) matches all namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a
+                                        selector that contains values, a key, and an
+                                        operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the
+                                            operator is Exists or DoesNotExist, the
+                                            values array must be empty. This array is
+                                            replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value". The
+                                      requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              namespaces:
+                                description: namespaces specifies a static list of namespace
+                                  names that the term applies to. The term is applied
+                                  to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector. null or
+                                  empty namespaces list and null namespaceSelector means
+                                  "this pod's namespace".
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where
+                                  co-located is defined as running on a node whose value
+                                  of the label with key topologyKey matches that of
+                                  any node on which any of the selected pods is running.
+                                  Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                              - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                args:
+                  additionalProperties:
+                    type: string
+                  description: Args is the set of arguments to pass to the OpenTelemetry
+                    Collector binary
+                  type: object
+                autoscaler:
+                  description: Autoscaler specifies the pod autoscaling configuration
+                    to use for the AmazonCloudWatchAgent workload.
+                  properties:
+                    behavior:
+                      description: HorizontalPodAutoscalerBehavior configures the scaling
+                        behavior of the target in both Up and Down directions (scaleUp
+                        and scaleDown fields respectively).
+                      properties:
+                        scaleDown:
+                          description: scaleDown is scaling policy for scaling Down.
+                            If not set, the default value is to allow to scale down
+                            to minReplicas pods, with a 300 second stabilization window
+                            (i.e., the highest recommendation for the last 300sec is
+                            used).
+                          properties:
+                            policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
+                              items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
+                                properties:
+                                  periodSeconds:
+                                    description: periodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    description: type is used to specify the scaling
+                                      policy.
+                                    type: string
+                                  value:
+                                    description: value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value Max is
+                                used.
+                              type: string
+                            stabilizationWindowSeconds:
+                              description: 'stabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
+                              format: int32
+                              type: integer
+                          type: object
+                        scaleUp:
+                          description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of: * increase
+                          no more than 4 pods per 60 seconds * double the number of
+                          pods per 60 seconds No stabilization is used.'
+                          properties:
+                            policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
+                              items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
+                                properties:
+                                  periodSeconds:
+                                    description: periodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    description: type is used to specify the scaling
+                                      policy.
+                                    type: string
+                                  value:
+                                    description: value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value Max is
+                                used.
+                              type: string
+                            stabilizationWindowSeconds:
+                              description: 'stabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      description: MaxReplicas sets an upper bound to the autoscaling
+                        feature. If MaxReplicas is set autoscaling is enabled.
+                      format: int32
+                      type: integer
+                    metrics:
+                      description: Metrics is meant to provide a customizable way to
+                        configure HPA metrics. currently the only supported custom metrics
+                        is type=Pod. Use TargetCPUUtilization or TargetMemoryUtilization
+                        instead if scaling on these common resource metrics.
+                      items:
+                        description: MetricSpec defines a subset of metrics to be defined
+                          for the HPA's metric array more metric type can be supported
+                          as needed. See https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
+                          for reference.
+                        properties:
+                          pods:
+                            description: PodsMetricSource indicates how to scale on
+                              a metric describing each pod in the current scale target
+                              (for example, transactions-processed-per-second). The
+                              values will be averaged together before being compared
+                              to the target value.
+                            properties:
+                              metric:
+                                description: metric identifies the target metric by
+                                  name and selector
+                                properties:
+                                  name:
+                                    description: name is the name of the given metric
+                                    type: string
+                                  selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                  - name
+                                type: object
+                              target:
+                                description: target specifies the target value for the
+                                  given metric
+                                properties:
+                                  averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - metric
+                              - target
+                            type: object
+                          type:
+                            description: MetricSourceType indicates the type of metric.
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      type: array
+                    minReplicas:
+                      description: MinReplicas sets a lower bound to the autoscaling
+                        feature.  Set this if your are using autoscaling. It must be
+                        at least 1
+                      format: int32
+                      type: integer
+                    targetCPUUtilization:
+                      description: TargetCPUUtilization sets the target average CPU
+                        used across all replicas. If average CPU exceeds this value,
+                        the HPA will scale up. Defaults to 90 percent.
+                      format: int32
+                      type: integer
+                    targetMemoryUtilization:
+                      description: TargetMemoryUtilization sets the target average memory
+                        utilization across all replicas
+                      format: int32
+                      type: integer
+                  type: object
+                config:
+                  description: Config is the raw JSON to be used as the collector's
+                    configuration. Refer to the OpenTelemetry Collector documentation
+                    for details.
+                  type: string
+                configmaps:
+                  description: ConfigMaps is a list of ConfigMaps in the same namespace
+                    as the AmazonCloudWatchAgent object, which shall be mounted into
+                    the Collector Pods. Each ConfigMap will be added to the Collector's
+                    Deployments as a volume named `configmap-<configmap-name>`.
+                  items:
+                    properties:
+                      mountpath:
+                        type: string
+                      name:
+                        description: Configmap defines name and path where the configMaps
+                          should be mounted.
+                        type: string
+                    required:
+                      - mountpath
+                      - name
+                    type: object
+                  type: array
+                env:
+                  description: ENV vars to set on the OpenTelemetry Collector's Pods.
+                    These can then in certain cases be consumed in the config file for
+                    the Collector.
+                  items:
+                    description: EnvVar represents an environment variable present in
+                      a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded using
                         the previously defined environment variables in the container
                         and any service environment variables. If a variable cannot
                         be resolved, the reference in the input string will be unchanged.
@@ -89,258 +2689,2085 @@ spec:
                         string literal "$(VAR_NAME)". Escaped references will never
                         be expanded, regardless of whether the variable exists or
                         not. Defaults to "".'
-                      type: string
-                    valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value. Cannot
+                          be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
                             metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
                             spec.nodeName, spec.serviceAccountName, status.hostIP,
                             status.podIP, status.podIPs.'
-                          properties:
-                            apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
-                              type: string
-                            fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
-                              type: string
-                          required:
-                          - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        resourceFieldRef:
-                          description: 'Selects a resource of the container: only
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
                             resources limits and requests (limits.cpu, limits.memory,
                             limits.ephemeral-storage, requests.cpu, requests.memory
                             and requests.ephemeral-storage) are currently supported.'
-                          properties:
-                            containerName:
-                              description: 'Container name: required for volumes,
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
                                 optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                envFrom:
+                  description: List of sources to populate environment variables on
+                    the OpenTelemetry Collector's Pods. These can then in certain cases
+                    be consumed in the config file for the Collector.
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      prefix:
+                        description: An optional identifier to prepend to each key in
+                          the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  type: array
+                hostNetwork:
+                  description: HostNetwork indicates if the pod should run in the host
+                    networking namespace.
+                  type: boolean
+                image:
+                  description: Image indicates the container image to use for the OpenTelemetry
+                    Collector.
+                  type: string
+                imagePullPolicy:
+                  description: ImagePullPolicy indicates the pull policy to be used
+                    for retrieving the container image (Always, Never, IfNotPresent)
+                  type: string
+                ingress:
+                  description: 'Ingress is used to specify how OpenTelemetry Collector
+                  is exposed. This functionality is only available if one of the valid
+                  modes is set. Valid modes are: deployment, daemonset and statefulset.'
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations to add to ingress. e.g. ''cert-manager.io/cluster-issuer:
+                      "letsencrypt"'''
+                      type: object
+                    hostname:
+                      description: Hostname by which the ingress proxy can be reached.
+                      type: string
+                    ingressClassName:
+                      description: IngressClassName is the name of an IngressClass cluster
+                        resource. Ingress controller implementations use this field
+                        to know whether they should be serving this Ingress resource.
+                      type: string
+                    route:
+                      description: Route is an OpenShift specific section that is only
+                        considered when type "route" is used.
+                      properties:
+                        termination:
+                          description: Termination indicates termination type. By default
+                            "edge" is used.
+                          enum:
+                            - insecure
+                            - edge
+                            - passthrough
+                            - reencrypt
+                          type: string
+                      type: object
+                    ruleType:
+                      description: RuleType defines how Ingress exposes collector receivers.
+                        IngressRuleTypePath ("path") exposes each receiver port on a
+                        unique path on single domain defined in Hostname. IngressRuleTypeSubdomain
+                        ("subdomain") exposes each receiver port on a unique subdomain
+                        of Hostname. Default is IngressRuleTypePath ("path").
+                      enum:
+                        - path
+                        - subdomain
+                      type: string
+                    tls:
+                      description: TLS configuration.
+                      items:
+                        description: IngressTLS describes the transport layer security
+                          associated with an ingress.
+                        properties:
+                          hosts:
+                            description: hosts is a list of hosts included in the TLS
+                              certificate. The values in this list must match the name/s
+                              used in the tlsSecret. Defaults to the wildcard host setting
+                              for the loadbalancer controller fulfilling this Ingress,
+                              if left unspecified.
+                            items:
                               type: string
-                            divisor:
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          secretName:
+                            description: secretName is the name of the secret used to
+                              terminate TLS traffic on port 443. Field is left optional
+                              to allow TLS routing based on SNI hostname alone. If the
+                              SNI host in a listener conflicts with the "Host" header
+                              field used by an IngressRule, the SNI host is used for
+                              termination and value of the "Host" header is used for
+                              routing.
+                            type: string
+                        type: object
+                      type: array
+                    type:
+                      description: 'Type default value is: "" Supported types are: ingress,
+                      route'
+                      enum:
+                        - ingress
+                        - route
+                      type: string
+                  type: object
+                initContainers:
+                  description: 'InitContainers allows injecting initContainers to the
+                  Collector''s pod definition. These init containers can be used to
+                  fetch secrets for injection into the configuration from external
+                  sources, run added checks, etc. Any errors during the execution
+                  of an initContainer will lead to a restart of the Pod. More info:
+                  https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  items:
+                    description: A single application container that you want to run
+                      within a pod.
+                    properties:
+                      args:
+                        description: 'Arguments to the entrypoint. The container image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. Double $$ are reduced to a single $, which allows
+                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                        produce the string literal "$(VAR_NAME)". Escaped references
+                        will never be expanded, regardless of whether the variable
+                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: 'Entrypoint array. Not executed within a shell.
+                        The container image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
+                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether
+                        the variable exists or not. Cannot be updated. More info:
+                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be
+                                a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                    - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                            - name
+                          type: object
+                        type: array
+                      envFrom:
+                        description: List of sources to populate environment variables
+                          in the container. The keys defined within a source must be
+                          a C_IDENTIFIER. All invalid keys will be reported as an event
+                          when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take
+                          precedence. Values defined by an Env with a duplicate key
+                          will take precedence. Cannot be updated.
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must be
+                                    defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
+                      image:
+                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
+                        type: string
+                      imagePullPolicy:
+                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        type: string
+                      lifecycle:
+                        description: Actions that the management system should take
+                          in response to container lifecycle events. Cannot be updated.
+                        properties:
+                          postStart:
+                            description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name. This will
+                                            be canonicalized upon output, so case-variant
+                                            names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds to
+                                      sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward compatibility.
+                                  There are no validation of this field and lifecycle
+                                  hooks will fail in runtime when tcp handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                            type: object
+                          preStop:
+                            description: 'PreStop is called immediately before a container
+                            is terminated due to an API request or management event
+                            such as liveness/startup probe failure, preemption, resource
+                            contention, etc. The handler is not called if the container
+                            crashes or exits. The Pod''s termination grace period
+                            countdown begins before the PreStop hook is executed.
+                            Regardless of the outcome of the handler, the container
+                            will eventually terminate within the Pod''s termination
+                            grace period (unless delayed by finalizers). Other management
+                            of the container blocks until the hook completes or until
+                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            properties:
+                              exec:
+                                description: Exec specifies the action to take.
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              httpGet:
+                                description: HTTPGet specifies the http request to perform.
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      properties:
+                                        name:
+                                          description: The header field name. This will
+                                            be canonicalized upon output, so case-variant
+                                            names will be understood as the same header.
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              sleep:
+                                description: Sleep represents the duration that the
+                                  container should sleep before being terminated.
+                                properties:
+                                  seconds:
+                                    description: Seconds is the number of seconds to
+                                      sleep.
+                                    format: int64
+                                    type: integer
+                                required:
+                                  - seconds
+                                type: object
+                              tcpSocket:
+                                description: Deprecated. TCPSocket is NOT supported
+                                  as a LifecycleHandler and kept for the backward compatibility.
+                                  There are no validation of this field and lifecycle
+                                  hooks will fail in runtime when tcp handler is specified.
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                            type: object
+                        type: object
+                      livenessProbe:
+                        description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|', etc)
+                                  won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the
+                                  pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Name or number of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Number or name of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and the
+                              time when the processes are forcibly halted with a kill
+                              signal. Set this value longer than the expected cleanup
+                              time for your process. If this value is nil, the pod's
+                              terminationGracePeriodSeconds will be used. Otherwise,
+                              this value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates
+                              stop immediately via the kill signal (no opportunity to
+                              shut down). This is a beta field and requires enabling
+                              ProbeTerminationGracePeriod feature gate. Minimum value
+                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      name:
+                        description: Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: List of ports to expose from the container. Not
+                          specifying a port here DOES NOT prevent that port from being
+                          exposed. Any port which is listening on the default "0.0.0.0"
+                          address inside a container will be accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt
+                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                          Cannot be updated.
+                        items:
+                          description: ContainerPort represents a network port in a
+                            single container.
+                          properties:
+                            containerPort:
+                              description: Number of port to expose on the pod's IP
+                                address. This must be a valid port number, 0 < x < 65536.
+                              format: int32
+                              type: integer
+                            hostIP:
+                              description: What host IP to bind the external port to.
+                              type: string
+                            hostPort:
+                              description: Number of port to expose on the host. If
+                                specified, this must be a valid port number, 0 < x <
+                                65536. If HostNetwork is specified, this must match
+                                ContainerPort. Most containers do not need this.
+                              format: int32
+                              type: integer
+                            name:
+                              description: If specified, this must be an IANA_SVC_NAME
+                                and unique within the pod. Each named port in a pod
+                                must have a unique name. Name for the port that can
+                                be referred to by services.
+                              type: string
+                            protocol:
+                              default: TCP
+                              description: Protocol for port. Must be UDP, TCP, or SCTP.
+                                Defaults to "TCP".
+                              type: string
+                          required:
+                            - containerPort
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                        x-kubernetes-list-type: map
+                      readinessProbe:
+                        description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|', etc)
+                                  won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the
+                                  pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Name or number of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Number or name of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and the
+                              time when the processes are forcibly halted with a kill
+                              signal. Set this value longer than the expected cleanup
+                              time for your process. If this value is nil, the pod's
+                              terminationGracePeriodSeconds will be used. Otherwise,
+                              this value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates
+                              stop immediately via the kill signal (no opportunity to
+                              shut down). This is a beta field and requires enabling
+                              ProbeTerminationGracePeriod feature gate. Minimum value
+                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      resizePolicy:
+                        description: Resources resize policy for the container.
+                        items:
+                          description: ContainerResizePolicy represents resource resize
+                            policy for the container.
+                          properties:
+                            resourceName:
+                              description: 'Name of the resource to which this resource
+                              resize policy applies. Supported values: cpu, memory.'
+                              type: string
+                            restartPolicy:
+                              description: Restart policy to apply when specified resource
+                                is resized. If not specified, it defaults to NotRequired.
+                              type: string
+                          required:
+                            - resourceName
+                            - restartPolicy
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      resources:
+                        description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        properties:
+                          claims:
+                            description: "Claims lists the names of resources, defined
+                            in spec.resourceClaims, that are used by this container.
+                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                            feature gate. \n This field is immutable. It can only
+                            be set for containers."
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: Name must match the name of one entry
+                                    in pod.spec.resourceClaims of the Pod where this
+                                    field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
                               anyOf:
-                              - type: integer
-                              - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
+                                - type: integer
+                                - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            resource:
-                              description: 'Required: resource to select'
-                              type: string
-                          required:
-                          - resource
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
+                            description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests
+                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      restartPolicy:
+                        description: 'RestartPolicy defines the restart behavior of
+                        individual containers in a pod. This field may only be set
+                        for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
+                        the restart behavior is defined by the Pod''s restart policy
+                        and the container type. Setting the RestartPolicy as "Always"
+                        for the init container will have the following effect: this
+                        init container will be continually restarted on exit until
+                        all regular containers have terminated. Once all regular containers
+                        have completed, all init containers with restartPolicy "Always"
+                        will be shut down. This lifecycle differs from normal init
+                        containers and is often referred to as a "sidecar" container.
+                        Although this init container still starts in the init container
+                        sequence, it does not wait for the container to complete before
+                        proceeding to the next init container. Instead, the next init
+                        container starts immediately after this init container is
+                        started, or after any startupProbe has successfully completed.'
+                        type: string
+                      securityContext:
+                        description: 'SecurityContext defines the security options the
+                        container should be run with. If set, the fields of SecurityContext
+                        override the equivalent fields of PodSecurityContext. More
+                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN Note that this field cannot be set
+                            when spec.os.name is windows.'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by
+                              the container runtime. Note that this field cannot be
+                              set when spec.os.name is windows.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                            type: object
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent to
+                              root on the host. Defaults to false. Note that this field
+                              cannot be set when spec.os.name is windows.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount to
+                              use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false. Note that this field cannot
+                              be set when spec.os.name is windows.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a
+                              non-root user. If true, the Kubelet will validate the
+                              image at runtime to ensure that it does not run as UID
+                              0 (root) and fail to start the container if it does. If
+                              unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both
+                              SecurityContext and PodSecurityContext, the value specified
+                              in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence. Note
+                              that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a
+                              random SELinux context for each container.  May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence. Note that this field cannot be set when
+                              spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by this container.
+                              If seccomp options are provided at both the pod & container
+                              level, the container options override the pod options.
+                              Note that this field cannot be set when spec.os.name is
+                              windows.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile
+                                  must be preconfigured on the node to work. Must be
+                                  a descending path, relative to the kubelet's configured
+                                  seccomp profile location. Must be set if type is "Localhost".
+                                  Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                will be applied. Valid options are: \n Localhost -
+                                a profile defined in a file on the node should be
+                                used. RuntimeDefault - the container runtime default
+                                profile should be used. Unconfined - no profile should
+                                be applied."
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options from the PodSecurityContext
+                              will be used. If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is
+                              linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: HostProcess determines if a container should
+                                  be run as a 'Host Process' container. All of a Pod's
+                                  containers must have the same effective HostProcess
+                                  value (it is not allowed to have a mix of HostProcess
+                                  containers and non-HostProcess containers). In addition,
+                                  if HostProcess is true then HostNetwork must also
+                                  be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      startupProbe:
+                        description: 'StartupProbe indicates that the Pod has successfully
+                        initialized. If specified, no other probes are executed until
+                        this completes successfully. If this probe fails, the Pod
+                        will be restarted, just as if the livenessProbe failed. This
+                        can be used to provide different probe parameters at the beginning
+                        of a Pod''s lifecycle, when it might take a long time to load
+                        data or warm a cache, than during steady-state operation.
+                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        properties:
+                          exec:
+                            description: Exec specifies the action to take.
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|', etc)
+                                  won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          grpc:
+                            description: GRPC specifies an action involving a GRPC port.
+                            properties:
+                              port:
+                                description: Port number of the gRPC service. Number
+                                  must be in the range 1 to 65535.
+                                format: int32
+                                type: integer
+                              service:
+                                description: "Service is the name of the service to
+                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                \n If this is not specified, the default behavior
+                                is defined by gRPC."
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the
+                                  pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP
+                                  allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will
+                                        be canonicalized upon output, so case-variant
+                                        names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Name or number of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            format: int32
+                            type: integer
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness and startup. Minimum value
+                              is 1.
+                            format: int32
+                            type: integer
+                          tcpSocket:
+                            description: TCPSocket specifies an action involving a TCP
+                              port.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                                type: string
+                              port:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Number or name of the port to access on
+                                  the container. Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                              - port
+                            type: object
+                          terminationGracePeriodSeconds:
+                            description: Optional duration in seconds the pod needs
+                              to terminate gracefully upon probe failure. The grace
+                              period is the duration in seconds after the processes
+                              running in the pod are sent a termination signal and the
+                              time when the processes are forcibly halted with a kill
+                              signal. Set this value longer than the expected cleanup
+                              time for your process. If this value is nil, the pod's
+                              terminationGracePeriodSeconds will be used. Otherwise,
+                              this value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates
+                              stop immediately via the kill signal (no opportunity to
+                              shut down). This is a beta field and requires enabling
+                              ProbeTerminationGracePeriod feature gate. Minimum value
+                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            format: int64
+                            type: integer
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            format: int32
+                            type: integer
+                        type: object
+                      stdin:
+                        description: Whether this container should allocate a buffer
+                          for stdin in the container runtime. If this is not set, reads
+                          from stdin in the container will always result in EOF. Default
+                          is false.
+                        type: boolean
+                      stdinOnce:
+                        description: Whether the container runtime should close the
+                          stdin channel after it has been opened by a single attach.
+                          When stdin is true the stdin stream will remain open across
+                          multiple attach sessions. If stdinOnce is set to true, stdin
+                          is opened on container start, is empty until the first client
+                          attaches to stdin, and then remains open and accepts data
+                          until the client disconnects, at which time stdin is closed
+                          and remains closed until the container is restarted. If this
+                          flag is false, a container processes that reads from stdin
+                          will never receive an EOF. Default is false
+                        type: boolean
+                      terminationMessagePath:
+                        description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        type: string
+                      terminationMessagePolicy:
+                        description: Indicate how the termination message should be
+                          populated. File will use the contents of terminationMessagePath
+                          to populate the container status message on both success and
+                          failure. FallbackToLogsOnError will use the last chunk of
+                          container log output if the termination message file is empty
+                          and the container exited with an error. The log output is
+                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                          to File. Cannot be updated.
+                        type: string
+                      tty:
+                        description: Whether this container should allocate a TTY for
+                          itself, also requires 'stdin' to be true. Default is false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to be
+                          used by the container.
+                        items:
+                          description: volumeDevice describes a mapping of a raw block
+                            device within a container.
                           properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
                               type: string
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
                               type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
                           required:
-                          - key
+                            - devicePath
+                            - name
                           type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              envFrom:
-                description: List of sources to populate environment variables on
-                  the CloudWatch Agent's Pods. These can then in certain cases be
-                  consumed in the config file for the Collector.
-                items:
-                  description: EnvFromSource represents the source of a set of ConfigMaps
-                  properties:
-                    configMapRef:
-                      description: The ConfigMap to select from
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the ConfigMap must be defined
-                          type: boolean
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    prefix:
-                      description: An optional identifier to prepend to each key in
-                        the ConfigMap. Must be a C_IDENTIFIER.
-                      type: string
-                    secretRef:
-                      description: The Secret to select from
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: Specify whether the Secret must be defined
-                          type: boolean
-                      type: object
-                      x-kubernetes-map-type: atomic
-                  type: object
-                type: array
-              hostNetwork:
-                description: HostNetwork indicates if the pod should run in the host
-                  networking namespace.
-                type: boolean
-              image:
-                description: Image indicates the container image to use for the CloudWatch
-                  Agent.
-                type: string
-              imagePullPolicy:
-                description: ImagePullPolicy indicates the pull policy to be used
-                  for retrieving the container image (Always, Never, IfNotPresent)
-                type: string
-              ingress:
-                description: 'Ingress is used to specify how CloudWatch Agent is exposed.
-                  This functionality is only available if one of the valid modes is
-                  set. Valid modes are: deployment, daemonset and statefulset.'
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: 'Annotations to add to ingress. e.g. ''cert-manager.io/cluster-issuer:
-                      "letsencrypt"'''
-                    type: object
-                  hostname:
-                    description: Hostname by which the ingress proxy can be reached.
-                    type: string
-                  ingressClassName:
-                    description: IngressClassName is the name of an IngressClass cluster
-                      resource. Ingress controller implementations use this field
-                      to know whether they should be serving this Ingress resource.
-                    type: string
-                  route:
-                    description: Route is an OpenShift specific section that is only
-                      considered when type "route" is used.
-                    properties:
-                      termination:
-                        description: Termination indicates termination type. By default
-                          "edge" is used.
-                        enum:
-                        - insecure
-                        - edge
-                        - passthrough
-                        - reencrypt
+                        type: array
+                      volumeMounts:
+                        description: Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume
+                                should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are
+                                propagated from the host to container and the other
+                                way around. When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves similarly
+                                to SubPath but environment variable references $(VAR_NAME)
+                                are expanded using the container's environment. Defaults
+                                to "" (volume's root). SubPathExpr and SubPath are mutually
+                                exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                      workingDir:
+                        description: Container's working directory. If not specified,
+                          the container runtime's default will be used, which might
+                          be configured in the container image. Cannot be updated.
                         type: string
+                    required:
+                      - name
                     type: object
-                  tls:
-                    description: TLS configuration.
-                    items:
-                      description: IngressTLS describes the transport layer security
-                        associated with an ingress.
+                  type: array
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                      is created. If the handler fails, the container is terminated
+                      and restarted according to its restart policy. Other management
+                      of the container blocks until the hook completes. More info:
+                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                       properties:
-                        hosts:
-                          description: hosts is a list of hosts included in the TLS
-                            certificate. The values in this list must match the name/s
-                            used in the tlsSecret. Defaults to the wildcard host setting
-                            for the loadbalancer controller fulfilling this Ingress,
-                            if left unspecified.
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        secretName:
-                          description: secretName is the name of the secret used to
-                            terminate TLS traffic on port 443. Field is left optional
-                            to allow TLS routing based on SNI hostname alone. If the
-                            SNI host in a listener conflicts with the "Host" header
-                            field used by an IngressRule, the SNI host is used for
-                            termination and value of the "Host" header is used for
-                            routing.
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute inside
+                                the container, the working directory for the command  is
+                                root ('/') in the container's filesystem. The command
+                                is simply exec'd, it is not run inside a shell, so traditional
+                                shell instructions ('|', etc) won't work. To use a shell,
+                                you need to explicitly call out to that shell. Exit
+                                status of 0 is treated as live/healthy and non-zero
+                                is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header to
+                                  be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name. This will be
+                                      canonicalized upon output, so case-variant names
+                                      will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Name or number of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                            - port
+                          type: object
+                        sleep:
+                          description: Sleep represents the duration that the container
+                            should sleep before being terminated.
+                          properties:
+                            seconds:
+                              description: Seconds is the number of seconds to sleep.
+                              format: int64
+                              type: integer
+                          required:
+                            - seconds
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
+                            and kept for the backward compatibility. There are no validation
+                            of this field and lifecycle hooks will fail in runtime when
+                            tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Number or name of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                            - port
+                          type: object
+                      type: object
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                      is terminated due to an API request or management event such
+                      as liveness/startup probe failure, preemption, resource contention,
+                      etc. The handler is not called if the container crashes or exits.
+                      The Pod''s termination grace period countdown begins before
+                      the PreStop hook is executed. Regardless of the outcome of the
+                      handler, the container will eventually terminate within the
+                      Pod''s termination grace period (unless delayed by finalizers).
+                      Other management of the container blocks until the hook completes
+                      or until the termination grace period is reached. More info:
+                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: Command is the command line to execute inside
+                                the container, the working directory for the command  is
+                                root ('/') in the container's filesystem. The command
+                                is simply exec'd, it is not run inside a shell, so traditional
+                                shell instructions ('|', etc) won't work. To use a shell,
+                                you need to explicitly call out to that shell. Exit
+                                status of 0 is treated as live/healthy and non-zero
+                                is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header to
+                                  be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: The header field name. This will be
+                                      canonicalized upon output, so case-variant names
+                                      will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Name or number of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                            - port
+                          type: object
+                        sleep:
+                          description: Sleep represents the duration that the container
+                            should sleep before being terminated.
+                          properties:
+                            seconds:
+                              description: Seconds is the number of seconds to sleep.
+                              format: int64
+                              type: integer
+                          required:
+                            - seconds
+                          type: object
+                        tcpSocket:
+                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
+                            and kept for the backward compatibility. There are no validation
+                            of this field and lifecycle hooks will fail in runtime when
+                            tcp handler is specified.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              description: Number or name of the port to access on the
+                                container. Number must be in the range 1 to 65535. Name
+                                must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                            - port
+                          type: object
+                      type: object
+                  type: object
+                livenessProbe:
+                  description: Liveness config for the OpenTelemetry Collector except
+                    the probe handler which is auto generated from the health extension
+                    of the collector. It is only effective when healthcheckextension
+                    is configured in the OpenTelemetry Collector pipeline.
+                  properties:
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      format: int32
+                      type: integer
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. Defaults to 0 seconds.
+                      Minimum value is 0. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to be
+                        considered successful after having failed. Defaults to 1. Must
+                        be 1 for liveness and startup. Minimum value is 1.
+                      format: int32
+                      type: integer
+                    terminationGracePeriodSeconds:
+                      description: Optional duration in seconds the pod needs to terminate
+                        gracefully upon probe failure. The grace period is the duration
+                        in seconds after the processes running in the pod are sent a
+                        termination signal and the time when the processes are forcibly
+                        halted with a kill signal. Set this value longer than the expected
+                        cleanup time for your process. If this value is nil, the pod's
+                        terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec. Value must
+                        be non-negative integer. The value zero indicates stop immediately
+                        via the kill signal (no opportunity to shut down). This is a
+                        beta field and requires enabling ProbeTerminationGracePeriod
+                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
+                        is used if unset.
+                      format: int64
+                      type: integer
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      format: int32
+                      type: integer
+                  type: object
+                managementState:
+                  default: managed
+                  description: ManagementState defines if the CR should be managed by
+                    the operator or not. Default is managed.
+                  enum:
+                    - managed
+                    - unmanaged
+                  type: string
+                maxReplicas:
+                  description: 'MaxReplicas sets an upper bound to the autoscaling feature.
+                  If MaxReplicas is set autoscaling is enabled. Deprecated: use "AmazonCloudWatchAgent.Spec.Autoscaler.MaxReplicas"
+                  instead.'
+                  format: int32
+                  type: integer
+                minReplicas:
+                  description: 'MinReplicas sets a lower bound to the autoscaling feature.  Set
+                  this if you are using autoscaling. It must be at least 1 Deprecated:
+                  use "AmazonCloudWatchAgent.Spec.Autoscaler.MinReplicas" instead.'
+                  format: int32
+                  type: integer
+                mode:
+                  description: Mode represents how the collector should be deployed
+                    (deployment, daemonset, statefulset or sidecar)
+                  enum:
+                    - daemonset
+                    - deployment
+                    - sidecar
+                    - statefulset
+                  type: string
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector to schedule OpenTelemetry Collector pods.
+                    This is only relevant to daemonset, statefulset, and deployment
+                    mode
+                  type: object
+                observability:
+                  description: ObservabilitySpec defines how telemetry data gets handled.
+                  properties:
+                    metrics:
+                      description: Metrics defines the metrics configuration for operands.
+                      properties:
+                        enableMetrics:
+                          description: EnableMetrics specifies if ServiceMonitor or
+                            PodMonitor(for sidecar mode) should be created for the service
+                            managed by the OpenTelemetry Operator. The operator.observability.prometheus
+                            feature gate must be enabled to use this feature.
+                          type: boolean
+                      type: object
+                  type: object
+                podAnnotations:
+                  additionalProperties:
+                    type: string
+                  description: PodAnnotations is the set of annotations that will be
+                    attached to Collector and Target Allocator pods.
+                  type: object
+                podDisruptionBudget:
+                  description: PodDisruptionBudget specifies the pod disruption budget
+                    configuration to use for the AmazonCloudWatchAgent workload.
+                  properties:
+                    maxUnavailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: An eviction is allowed if at most "maxUnavailable"
+                        pods selected by "selector" are unavailable after the eviction,
+                        i.e. even in absence of the evicted pod. For example, one can
+                        prevent all voluntary evictions by specifying 0. This is a mutually
+                        exclusive setting with "minAvailable".
+                      x-kubernetes-int-or-string: true
+                    minAvailable:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: An eviction is allowed if at least "minAvailable"
+                        pods selected by "selector" will still be available after the
+                        eviction, i.e. even in the absence of the evicted pod.  So for
+                        example you can prevent all voluntary evictions by specifying
+                        "100%".
+                      x-kubernetes-int-or-string: true
+                  type: object
+                podSecurityContext:
+                  description: "PodSecurityContext configures the pod security context
+                  for the opentelemetry-collector pod, when running as a deployment,
+                  daemonset, or statefulset. \n In sidecar mode, the amazon-cloudwatch-agent-operator
+                  will ignore this setting."
+                  properties:
+                    fsGroup:
+                      description: "A special supplemental group that applies to all
+                      containers in a pod. Some volume types allow the Kubelet to
+                      change the ownership of that volume to be owned by the pod:
+                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
+                      set (new files created in the volume will be owned by FSGroup)
+                      3. The permission bits are OR'd with rw-rw---- \n If unset,
+                      the Kubelet will not modify the ownership and permissions of
+                      any volume. Note that this field cannot be set when spec.os.name
+                      is windows."
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified, "Always" is used. Note that this field cannot
+                      be set when spec.os.name is windows.'
+                      type: string
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset. May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to start
+                        the container if it does. If unset or false, no such validation
+                        will be performed. May also be set in SecurityContext.  If set
+                        in both SecurityContext and PodSecurityContext, the value specified
+                        in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container. Note that this field cannot
+                        be set when spec.os.name is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
                           type: string
                       type: object
-                    type: array
-                  type:
-                    description: 'Type default value is: "" Supported types are: ingress'
-                    enum:
-                    - ingress
-                    - route
-                    type: string
-                type: object
-              mode:
-                description: Mode represents how the collector should be deployed
-                  (deployment, daemonset, statefulset or sidecar)
-                enum:
-                - daemonset
-                - deployment
-                - sidecar
-                - statefulset
-                type: string
-              nodeSelector:
-                additionalProperties:
-                  type: string
-                description: NodeSelector to schedule CloudWatch Agent pods. This
-                  is only relevant to daemonset, statefulset, and deployment mode
-                type: object
-              podAnnotations:
-                additionalProperties:
-                  type: string
-                description: PodAnnotations is the set of annotations that will be
-                  attached to Collector and Target Allocator pods.
-                type: object
-              ports:
-                description: Ports allows a set of ports to be exposed by the underlying
-                  v1.Service. By default, the operator will attempt to infer the required
-                  ports by parsing the .Spec.Config property but this property can
-                  be used to open additional ports that can't be inferred by the operator,
-                  like for custom receivers.
-                items:
-                  description: ServicePort contains information on service's port.
-                  properties:
-                    appProtocol:
-                      description: The application protocol for this port. This field
-                        follows standard Kubernetes label syntax. Un-prefixed names
-                        are reserved for IANA standard service names (as per RFC-6335
-                        and https://www.iana.org/assignments/service-names). Non-standard
-                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
-                      type: string
-                    name:
-                      description: The name of this port within the service. This
-                        must be a DNS_LABEL. All ports within a ServiceSpec must have
-                        unique names. When considering the endpoints for a Service,
-                        this must match the 'name' field in the EndpointPort. Optional
-                        if only one ServicePort is defined on this service.
-                      type: string
-                    nodePort:
-                      description: 'The port on each node on which this service is
+                    seccompProfile:
+                      description: The seccomp options to use by the containers in this
+                        pod. Note that this field cannot be set when spec.os.name is
+                        windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must be
+                            preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must be set if type is "Localhost". Must NOT be
+                            set for any other type.
+                          type: string
+                        type:
+                          description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    supplementalGroups:
+                      description: A list of groups applied to the first process run
+                        in each container, in addition to the container's primary GID,
+                        the fsGroup (if specified), and group memberships defined in
+                        the container image for the uid of the container process. If
+                        unspecified, no additional groups are added to any container.
+                        Note that group memberships defined in the container image for
+                        the uid of the container process are still effective, even if
+                        they are not included in this list. Note that this field cannot
+                        be set when spec.os.name is windows.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      description: Sysctls hold a list of namespaced sysctls used for
+                        the pod. Pods with unsupported sysctls (by the container runtime)
+                        might fail to launch. Note that this field cannot be set when
+                        spec.os.name is windows.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext
+                        will be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named by
+                            the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. All of a Pod's containers
+                            must have the same effective HostProcess value (it is not
+                            allowed to have a mix of HostProcess containers and non-HostProcess
+                            containers). In addition, if HostProcess is true then HostNetwork
+                            must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                ports:
+                  description: Ports allows a set of ports to be exposed by the underlying
+                    v1.Service. By default, the operator will attempt to infer the required
+                    ports by parsing the .Spec.Config property but this property can
+                    be used to open additional ports that can't be inferred by the operator,
+                    like for custom receivers.
+                  items:
+                    description: ServicePort contains information on service's port.
+                    properties:
+                      appProtocol:
+                        description: "The application protocol for this port. This is
+                        used as a hint for implementations to offer richer behavior
+                        for protocols that they understand. This field follows standard
+                        Kubernetes label syntax. Valid values are either: \n * Un-prefixed
+                        protocol names - reserved for IANA standard service names
+                        (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+                        \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
+                        - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described
+                        in https://www.rfc-editor.org/rfc/rfc6455 * 'kubernetes.io/wss'
+                        - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                        \n * Other protocols should use implementation-defined prefixed
+                        names such as mycompany.com/my-custom-protocol."
+                        type: string
+                      name:
+                        description: The name of this port within the service. This
+                          must be a DNS_LABEL. All ports within a ServiceSpec must have
+                          unique names. When considering the endpoints for a Service,
+                          this must match the 'name' field in the EndpointPort. Optional
+                          if only one ServicePort is defined on this service.
+                        type: string
+                      nodePort:
+                        description: 'The port on each node on which this service is
                         exposed when type is NodePort or LoadBalancer.  Usually assigned
                         by the system. If a value is specified, in-range, and not
                         in use it will be used, otherwise the operation will fail.  If
@@ -349,22 +4776,22 @@ spec:
                         does not need it, creation will fail. This field will be wiped
                         when updating a Service to no longer need it (e.g. changing
                         type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                      format: int32
-                      type: integer
-                    port:
-                      description: The port that will be exposed by this service.
-                      format: int32
-                      type: integer
-                    protocol:
-                      default: TCP
-                      description: The IP protocol for this port. Supports "TCP",
-                        "UDP", and "SCTP". Default is TCP.
-                      type: string
-                    targetPort:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: 'Number or name of the port to access on the pods
+                        format: int32
+                        type: integer
+                      port:
+                        description: The port that will be exposed by this service.
+                        format: int32
+                        type: integer
+                      protocol:
+                        default: TCP
+                        description: The IP protocol for this port. Supports "TCP",
+                          "UDP", and "SCTP". Default is TCP.
+                        type: string
+                      targetPort:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: 'Number or name of the port to access on the pods
                         targeted by the service. Number must be in the range 1 to
                         65535. Name must be an IANA_SVC_NAME. If this is a string,
                         it will be looked up as a named port in the target Pod''s
@@ -372,173 +4799,579 @@ spec:
                         ''port'' field is used (an identity map). This field is ignored
                         for services with clusterIP=None, and should be omitted or
                         set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
-                      x-kubernetes-int-or-string: true
-                  required:
-                  - port
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
-              priorityClassName:
-                description: If specified, indicates the pod's priority. If not specified,
-                  the pod priority will be default or zero if there is no default.
-                type: string
-              replicas:
-                description: Replicas is the number of pod instances for the underlying
-                  CloudWatch Agent. Set this if your are not using autoscaling
-                format: int32
-                type: integer
-              resources:
-                description: Resources to set on the CloudWatch Agent pods.
-                properties:
-                  claims:
-                    description: "Claims lists the names of resources, defined in
+                        x-kubernetes-int-or-string: true
+                    required:
+                      - port
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                priorityClassName:
+                  description: If specified, indicates the pod's priority. If not specified,
+                    the pod priority will be default or zero if there is no default.
+                  type: string
+                replicas:
+                  description: Replicas is the number of pod instances for the underlying
+                    OpenTelemetry Collector. Set this if your are not using autoscaling
+                  format: int32
+                  type: integer
+                resources:
+                  description: Resources to set on the OpenTelemetry Collector pods.
+                  properties:
+                    claims:
+                      description: "Claims lists the names of resources, defined in
                       spec.resourceClaims, that are used by this container. \n This
                       is an alpha field and requires enabling the DynamicResourceAllocation
                       feature gate. \n This field is immutable. It can only be set
                       for containers."
-                    items:
-                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                      properties:
-                        name:
-                          description: Name must match the name of one entry in pod.spec.resourceClaims
-                            of the Pod where this field is used. It makes that resource
-                            available inside a container.
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-map-keys:
-                    - name
-                    x-kubernetes-list-type: map
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources
+                      items:
+                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                        properties:
+                          name:
+                            description: Name must match the name of one entry in pod.spec.resourceClaims
+                              of the Pod where this field is used. It makes that resource
+                              available inside a container.
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - name
+                      x-kubernetes-list-type: map
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute resources
                       allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
                       resources required. If Requests is omitted for a container,
                       it defaults to Limits if that is explicitly specified, otherwise
                       to an implementation-defined value. Requests cannot exceed Limits.
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                    type: object
-                type: object
-              serviceAccount:
-                description: ServiceAccount indicates the name of an existing service
-                  account to use with this instance. When set, the operator will not
-                  automatically create a ServiceAccount for the collector.
-                type: string
-              tolerations:
-                description: Toleration to schedule CloudWatch Agent pods. This is
-                  only relevant to daemonset, statefulset, and deployment mode
-                items:
-                  description: The pod this Toleration is attached to tolerates any
-                    taint that matches the triple <key,value,effect> using the matching
-                    operator <operator>.
+                      type: object
+                  type: object
+                securityContext:
+                  description: "SecurityContext configures the container security context
+                  for the opentelemetry-collector container. \n In deployment, daemonset,
+                  or statefulset mode, this controls the security context settings
+                  for the primary application container. \n In sidecar mode, this
+                  controls the security context for the injected sidecar container."
                   properties:
-                    effect:
-                      description: Effect indicates the taint effect to match. Empty
-                        means match all taint effects. When specified, allowed values
-                        are NoSchedule, PreferNoSchedule and NoExecute.
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                      Note that this field cannot be set when spec.os.name is windows.'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container
+                        runtime. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in privileged
+                        containers are essentially equivalent to root on the host. Defaults
+                        to false. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use for
+                        the containers. The default is DefaultProcMount which uses the
+                        container runtime defaults for readonly paths and masked paths.
+                        This requires the ProcMountType feature flag to be enabled.
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: string
-                    key:
-                      description: Key is the taint key that the toleration applies
-                        to. Empty means match all taint keys. If the key is empty,
-                        operator must be Exists; this combination means to match all
-                        values and all keys.
-                      type: string
-                    operator:
-                      description: Operator represents a key's relationship to the
-                        value. Valid operators are Exists and Equal. Defaults to Equal.
-                        Exists is equivalent to wildcard for value, so that a pod
-                        can tolerate all taints of a particular category.
-                      type: string
-                    tolerationSeconds:
-                      description: TolerationSeconds represents the period of time
-                        the toleration (which must be of effect NoExecute, otherwise
-                        this field is ignored) tolerates the taint. By default, it
-                        is not set, which means tolerate the taint forever (do not
-                        evict). Zero and negative values will be treated as 0 (evict
-                        immediately) by the system.
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
-                    value:
-                      description: Value is the taint value the toleration matches
-                        to. If the operator is Exists, the value should be empty,
-                        otherwise just a regular string.
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to start
+                        the container if it does. If unset or false, no such validation
+                        will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence. Note that this field cannot be set when spec.os.name
+                        is windows.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by this container. If
+                        seccomp options are provided at both the pod & container level,
+                        the container options override the pod options. Note that this
+                        field cannot be set when spec.os.name is windows.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must be
+                            preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must be set if type is "Localhost". Must NOT be
+                            set for any other type.
+                          type: string
+                        type:
+                          description: "type indicates which kind of seccomp profile
+                          will be applied. Valid options are: \n Localhost - a profile
+                          defined in a file on the node should be used. RuntimeDefault
+                          - the container runtime default profile should be used.
+                          Unconfined - no profile should be applied."
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will
+                        be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence. Note
+                        that this field cannot be set when spec.os.name is linux.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named by
+                            the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        hostProcess:
+                          description: HostProcess determines if a container should
+                            be run as a 'Host Process' container. All of a Pod's containers
+                            must have the same effective HostProcess value (it is not
+                            allowed to have a mix of HostProcess containers and non-HostProcess
+                            containers). In addition, if HostProcess is true then HostNetwork
+                            must also be set to true.
+                          type: boolean
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  description: ServiceAccount indicates the name of an existing service
+                    account to use with this instance. When set, the operator will not
+                    automatically create a ServiceAccount for the collector.
+                  type: string
+                terminationGracePeriodSeconds:
+                  description: Duration in seconds the pod needs to terminate gracefully
+                    upon probe failure.
+                  format: int64
+                  type: integer
+                tolerations:
+                  description: Toleration to schedule OpenTelemetry Collector pods.
+                    This is only relevant to daemonset, statefulset, and deployment
+                    mode
+                  items:
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match all
+                          values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod
+                          can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default, it
+                          is not set, which means tolerate the taint forever (do not
+                          evict). Zero and negative values will be treated as 0 (evict
+                          immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+                topologySpreadConstraints:
+                  description: TopologySpreadConstraints embedded kubernetes pod configuration
+                    option, controls how pods are spread across your cluster among failure-domains
+                    such as regions, zones, nodes, and other user-defined topology domains
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+                    This is only relevant to statefulset, and deployment mode
+                  items:
+                    description: TopologySpreadConstraint specifies how to spread matching
+                      pods among the given topology.
+                    properties:
+                      labelSelector:
+                        description: LabelSelector is used to find matching pods. Pods
+                          that match this label selector are counted to determine the
+                          number of pods in their corresponding topology domain.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      matchLabelKeys:
+                        description: "MatchLabelKeys is a set of pod label keys to select
+                        the pods over which spreading will be calculated. The keys
+                        are used to lookup values from the incoming pod labels, those
+                        key-value labels are ANDed with labelSelector to select the
+                        group of existing pods over which spreading will be calculated
+                        for the incoming pod. The same key is forbidden to exist in
+                        both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot
+                        be set when LabelSelector isn't set. Keys that don't exist
+                        in the incoming pod labels will be ignored. A null or empty
+                        list means only match against labelSelector. \n This is a
+                        beta field and requires the MatchLabelKeysInPodTopologySpread
+                        feature gate to be enabled (enabled by default)."
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      maxSkew:
+                        description: 'MaxSkew describes the degree to which pods may
+                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
+                        it is the maximum permitted difference between the number
+                        of matching pods in the target topology and the global minimum.
+                        The global minimum is the minimum number of matching pods
+                        in an eligible domain or zero if the number of eligible domains
+                        is less than MinDomains. For example, in a 3-zone cluster,
+                        MaxSkew is set to 1, and pods with the same labelSelector
+                        spread as 2/2/1: In this case, the global minimum is 1. |
+                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                        is 1, incoming pod can only be scheduled to zone3 to become
+                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
+                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
+                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                        it is used to give higher precedence to topologies that satisfy
+                        it. It''s a required field. Default value is 1 and 0 is not
+                        allowed.'
+                        format: int32
+                        type: integer
+                      minDomains:
+                        description: "MinDomains indicates a minimum number of eligible
+                        domains. When the number of eligible domains with matching
+                        topology keys is less than minDomains, Pod Topology Spread
+                        treats \"global minimum\" as 0, and then the calculation of
+                        Skew is performed. And when the number of eligible domains
+                        with matching topology keys equals or greater than minDomains,
+                        this value has no effect on scheduling. As a result, when
+                        the number of eligible domains is less than minDomains, scheduler
+                        won't schedule more than maxSkew Pods to those domains. If
+                        value is nil, the constraint behaves as if MinDomains is equal
+                        to 1. Valid values are integers greater than 0. When value
+                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
+                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
+                        is set to 5 and pods with the same labelSelector spread as
+                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                        The number of domains is less than 5(MinDomains), so \"global
+                        minimum\" is treated as 0. In this situation, new pod with
+                        the same labelSelector cannot be scheduled, because computed
+                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
+                        three zones, it will violate MaxSkew. \n This is a beta field
+                        and requires the MinDomainsInPodTopologySpread feature gate
+                        to be enabled (enabled by default)."
+                        format: int32
+                        type: integer
+                      nodeAffinityPolicy:
+                        description: "NodeAffinityPolicy indicates how we will treat
+                        Pod's nodeAffinity/nodeSelector when calculating pod topology
+                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
+                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
+                        are ignored. All nodes are included in the calculations. \n
+                        If this value is nil, the behavior is equivalent to the Honor
+                        policy. This is a beta-level feature default enabled by the
+                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                        type: string
+                      nodeTaintsPolicy:
+                        description: "NodeTaintsPolicy indicates how we will treat node
+                        taints when calculating pod topology spread skew. Options
+                        are: - Honor: nodes without taints, along with tainted nodes
+                        for which the incoming pod has a toleration, are included.
+                        - Ignore: node taints are ignored. All nodes are included.
+                        \n If this value is nil, the behavior is equivalent to the
+                        Ignore policy. This is a beta-level feature default enabled
+                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                        type: string
+                      topologyKey:
+                        description: TopologyKey is the key of node labels. Nodes that
+                          have a label with this key and identical values are considered
+                          to be in the same topology. We consider each <key, value>
+                          as a "bucket", and try to put balanced number of pods into
+                          each bucket. We define a domain as a particular instance of
+                          a topology. Also, we define an eligible domain as a domain
+                          whose nodes meet the requirements of nodeAffinityPolicy and
+                          nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
+                          each Node is a domain of that topology. And, if TopologyKey
+                          is "topology.kubernetes.io/zone", each zone is a domain of
+                          that topology. It's a required field.
+                        type: string
+                      whenUnsatisfiable:
+                        description: 'WhenUnsatisfiable indicates how to deal with a
+                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
+                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
+                        tells the scheduler to schedule the pod in any location, but
+                        giving higher precedence to topologies that would help reduce
+                        the skew. A constraint is considered "Unsatisfiable" for an
+                        incoming pod if and only if every possible node assignment
+                        for that pod would violate "MaxSkew" on some topology. For
+                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
+                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
+                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
+                        set to DoNotSchedule, incoming pod can only be scheduled to
+                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
+                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
+                        can still be imbalanced, but scheduler won''t make it *more*
+                        imbalanced. It''s a required field.'
+                        type: string
+                    required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                    type: object
+                  type: array
+                updateStrategy:
+                  description: UpdateStrategy represents the strategy the operator will
+                    take replacing existing DaemonSet pods with new pods https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec
+                    This is only applicable to Daemonset mode.
+                  properties:
+                    rollingUpdate:
+                      description: 'Rolling update config params. Present only if type
+                      = "RollingUpdate". --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
+                      See https://github.com/kubernetes/kubernetes/issues/35345'
+                      properties:
+                        maxSurge:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: 'The maximum number of nodes with an existing
+                          available DaemonSet pod that can have an updated DaemonSet
+                          pod during during an update. Value can be an absolute number
+                          (ex: 5) or a percentage of desired pods (ex: 10%). This
+                          can not be 0 if MaxUnavailable is 0. Absolute number is
+                          calculated from percentage by rounding up to a minimum of
+                          1. Default value is 0. Example: when this is set to 30%,
+                          at most 30% of the total number of nodes that should be
+                          running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their a new pod created before the old pod is marked
+                          as deleted. The update starts by launching new pods on 30%
+                          of nodes. Once an updated pod is available (Ready for at
+                          least minReadySeconds) the old DaemonSet pod on that node
+                          is marked deleted. If the old pod becomes unavailable for
+                          any reason (Ready transitions to false, is evicted, or is
+                          drained) an updated pod is immediatedly created on that
+                          node without considering surge limits. Allowing surge implies
+                          the possibility that the resources consumed by the daemonset
+                          on any given node can double if the readiness check fails,
+                          and so resource intensive daemonsets should take into account
+                          that they may cause evictions during disruption.'
+                          x-kubernetes-int-or-string: true
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: 'The maximum number of DaemonSet pods that can
+                          be unavailable during the update. Value can be an absolute
+                          number (ex: 5) or a percentage of total number of DaemonSet
+                          pods at the start of the update (ex: 10%). Absolute number
+                          is calculated from percentage by rounding up. This cannot
+                          be 0 if MaxSurge is 0 Default value is 1. Example: when
+                          this is set to 30%, at most 30% of the total number of nodes
+                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                          can have their pods stopped for an update at any given time.
+                          The update starts by stopping at most 30% of those DaemonSet
+                          pods and then brings up new DaemonSet pods in their place.
+                          Once the new pods are available, it then proceeds onto other
+                          DaemonSet pods, thus ensuring that at least 70% of original
+                          number of DaemonSet pods are available at all times during
+                          the update.'
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type:
+                      description: Type of daemon set update. Can be "RollingUpdate"
+                        or "OnDelete". Default is RollingUpdate.
                       type: string
                   type: object
-                type: array
-              upgradeStrategy:
-                description: UpgradeStrategy represents how the operator will handle
-                  upgrades to the CR when a newer version of the operator is deployed
-                enum:
-                - automatic
-                - none
-                type: string
-              volumeClaimTemplates:
-                description: VolumeClaimTemplates will provide stable storage using
-                  PersistentVolumes. Only available when the mode=statefulset.
-                items:
-                  description: PersistentVolumeClaim is a user's request for and claim
-                    to a persistent volume
-                  properties:
-                    apiVersion:
-                      description: 'APIVersion defines the versioned schema of this
+                upgradeStrategy:
+                  description: UpgradeStrategy represents how the operator will handle
+                    upgrades to the CR when a newer version of the operator is deployed
+                  enum:
+                    - automatic
+                    - none
+                  type: string
+                volumeClaimTemplates:
+                  description: VolumeClaimTemplates will provide stable storage using
+                    PersistentVolumes. Only available when the mode=statefulset.
+                  items:
+                    description: PersistentVolumeClaim is a user's request for and claim
+                      to a persistent volume
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this
                         representation of an object. Servers should convert recognized
                         schemas to the latest internal value, and may reject unrecognized
                         values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                      type: string
-                    kind:
-                      description: 'Kind is a string value representing the REST resource
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource
                         this object represents. Servers may infer this from the endpoint
                         the client submits requests to. Cannot be updated. In CamelCase.
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    metadata:
-                      description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      properties:
-                        annotations:
-                          additionalProperties:
+                        type: string
+                      metadata:
+                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
                             type: string
-                          type: object
-                        finalizers:
-                          items:
+                          namespace:
                             type: string
-                          type: array
-                        labels:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      type: object
-                    spec:
-                      description: 'spec defines the desired characteristics of a
+                        type: object
+                      spec:
+                        description: 'spec defines the desired characteristics of a
                         volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        accessModes:
-                          description: 'accessModes contains the desired access modes
+                        properties:
+                          accessModes:
+                            description: 'accessModes contains the desired access modes
                             the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                          items:
-                            type: string
-                          type: array
-                        dataSource:
-                          description: 'dataSource field can be used to specify either:
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'dataSource field can be used to specify either:
                             * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                             * An existing PVC (PersistentVolumeClaim) If the provisioner
                             or an external controller can support the specified data
@@ -549,26 +5382,26 @@ spec:
                             to dataSource when dataSourceRef.namespace is not specified.
                             If the namespace is specified, then dataSourceRef will
                             not be copied to dataSource.'
-                          properties:
-                            apiGroup:
-                              description: APIGroup is the group for the resource
-                                being referenced. If APIGroup is not specified, the
-                                specified Kind must be in the core API group. For
-                                any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                          required:
-                          - kind
-                          - name
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        dataSourceRef:
-                          description: 'dataSourceRef specifies the object from which
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified, the
+                                  specified Kind must be in the core API group. For
+                                  any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSourceRef:
+                            description: 'dataSourceRef specifies the object from which
                             to populate the volume with data, if a non-empty volume
                             is desired. This may be any object from a non-empty API
                             group (non core object) or a PersistentVolumeClaim object.
@@ -595,459 +5428,540 @@ spec:
                             AnyVolumeDataSource feature gate to be enabled. (Alpha)
                             Using the namespace field of dataSourceRef requires the
                             CrossNamespaceVolumeDataSource feature gate to be enabled.'
-                          properties:
-                            apiGroup:
-                              description: APIGroup is the group for the resource
-                                being referenced. If APIGroup is not specified, the
-                                specified Kind must be in the core API group. For
-                                any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                            namespace:
-                              description: Namespace is the namespace of resource
-                                being referenced Note that when a namespace is specified,
-                                a gateway.networking.k8s.io/ReferenceGrant object
-                                is required in the referent namespace to allow that
-                                namespace's owner to accept the reference. See the
-                                ReferenceGrant documentation for details. (Alpha)
-                                This field requires the CrossNamespaceVolumeDataSource
-                                feature gate to be enabled.
-                              type: string
-                          required:
-                          - kind
-                          - name
-                          type: object
-                        resources:
-                          description: 'resources represents the minimum resources
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified, the
+                                  specified Kind must be in the core API group. For
+                                  any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of resource
+                                  being referenced Note that when a namespace is specified,
+                                  a gateway.networking.k8s.io/ReferenceGrant object
+                                  is required in the referent namespace to allow that
+                                  namespace's owner to accept the reference. See the
+                                  ReferenceGrant documentation for details. (Alpha)
+                                  This field requires the CrossNamespaceVolumeDataSource
+                                  feature gate to be enabled.
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          resources:
+                            description: 'resources represents the minimum resources
                             the volume should have. If RecoverVolumeExpansionFailure
                             feature is enabled users are allowed to specify resource
                             requirements that are lower than previous value but must
                             still be higher than capacity recorded in the status field
                             of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                          properties:
-                            claims:
-                              description: "Claims lists the names of resources, defined
-                                in spec.resourceClaims, that are used by this container.
-                                \n This is an alpha field and requires enabling the
-                                DynamicResourceAllocation feature gate. \n This field
-                                is immutable. It can only be set for containers."
-                              items:
-                                description: ResourceClaim references one entry in
-                                  PodSpec.ResourceClaims.
-                                properties:
-                                  name:
-                                    description: Name must match the name of one entry
-                                      in pod.spec.resourceClaims of the Pod where
-                                      this field is used. It makes that resource available
-                                      inside a container.
-                                    type: string
-                                required:
-                                - name
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                              - name
-                              x-kubernetes-list-type: map
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
                                 compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
                                 of compute resources required. If Requests is omitted
                                 for a container, it defaults to Limits if that is
                                 explicitly specified, otherwise to an implementation-defined
                                 value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                              type: object
-                          type: object
-                        selector:
-                          description: selector is a label query over volumes to consider
-                            for binding.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
                                 type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        storageClassName:
-                          description: 'storageClassName is the name of the StorageClass
-                            required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                          type: string
-                        volumeMode:
-                          description: volumeMode defines what type of volume is required
-                            by the claim. Value of Filesystem is implied when not
-                            included in claim spec.
-                          type: string
-                        volumeName:
-                          description: volumeName is the binding reference to the
-                            PersistentVolume backing this claim.
-                          type: string
-                      type: object
-                    status:
-                      description: 'status represents the current information/status
-                        of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        accessModes:
-                          description: 'accessModes contains the actual access modes
-                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                          items:
-                            type: string
-                          type: array
-                        allocatedResources:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: allocatedResources is the storage resource
-                            within AllocatedResources tracks the capacity allocated
-                            to a PVC. It may be larger than the actual capacity when
-                            a volume expansion operation is requested. For storage
-                            quota, the larger value from allocatedResources and PVC.spec.resources
-                            is used. If allocatedResources is not set, PVC.spec.resources
-                            alone is used for quota calculation. If a volume expansion
-                            capacity request is lowered, allocatedResources is only
-                            lowered if there are no expansion operations in progress
-                            and if the actual volume capacity is equal or lower than
-                            the requested capacity. This is an alpha field and requires
-                            enabling RecoverVolumeExpansionFailure feature.
-                          type: object
-                        capacity:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: capacity represents the actual resources of
-                            the underlying volume.
-                          type: object
-                        conditions:
-                          description: conditions is the current Condition of persistent
-                            volume claim. If underlying persistent volume is being
-                            resized then the Condition will be set to 'ResizeStarted'.
-                          items:
-                            description: PersistentVolumeClaimCondition contains details
-                              about state of pvc
+                            type: object
+                          selector:
+                            description: selector is a label query over volumes to consider
+                              for binding.
                             properties:
-                              lastProbeTime:
-                                description: lastProbeTime is the time we probed the
-                                  condition.
-                                format: date-time
-                                type: string
-                              lastTransitionTime:
-                                description: lastTransitionTime is the time the condition
-                                  transitioned from one status to another.
-                                format: date-time
-                                type: string
-                              message:
-                                description: message is the human-readable message
-                                  indicating details about last transition.
-                                type: string
-                              reason:
-                                description: reason is a unique, this should be a
-                                  short, machine understandable string that gives
-                                  the reason for condition's last transition. If it
-                                  reports "ResizeStarted" that means the underlying
-                                  persistent volume is being resized.
-                                type: string
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be empty.
+                                        This array is replaced during a strategic merge
+                                        patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          storageClassName:
+                            description: 'storageClassName is the name of the StorageClass
+                            required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            type: string
+                          volumeAttributesClassName:
+                            description: 'volumeAttributesClassName may be used to set
+                            the VolumeAttributesClass used by this claim. If specified,
+                            the CSI driver will create or update the volume with the
+                            attributes defined in the corresponding VolumeAttributesClass.
+                            This has a different purpose than storageClassName, it
+                            can be changed after the claim is created. An empty string
+                            value means that no VolumeAttributesClass will be applied
+                            to the claim but it''s not allowed to reset this field
+                            to empty string once it is set. If unspecified and the
+                            PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                            will be set by the persistentvolume controller if it exists.
+                            If the resource referred to by volumeAttributesClass does
+                            not exist, this PersistentVolumeClaim will be set to a
+                            Pending state, as reflected by the modifyVolumeStatus
+                            field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                            (Alpha) Using this field requires the VolumeAttributesClass
+                            feature gate to be enabled.'
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is required
+                              by the claim. Value of Filesystem is implied when not
+                              included in claim spec.
+                            type: string
+                          volumeName:
+                            description: volumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                      status:
+                        description: 'status represents the current information/status
+                        of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        properties:
+                          accessModes:
+                            description: 'accessModes contains the actual access modes
+                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          allocatedResourceStatuses:
+                            additionalProperties:
+                              description: When a controller receives persistentvolume
+                                claim update with ClaimResourceStatus for a resource
+                                that it does not recognizes, then it should ignore that
+                                update and let other controllers handle it.
+                              type: string
+                            description: "allocatedResourceStatuses stores status of
+                            resource being resized for the given PVC. Key names follow
+                            standard Kubernetes label syntax. Valid values are either:
+                            * Un-prefixed keys: - storage - the capacity of the volume.
+                            * Custom resources must use implementation-defined prefixed
+                            names such as \"example.com/my-custom-resource\" Apart
+                            from above values - keys that are unprefixed or have kubernetes.io
+                            prefix are considered reserved and hence may not be used.
+                            \n ClaimResourceStatus can be in any of following states:
+                            - ControllerResizeInProgress: State set when resize controller
+                            starts resizing the volume in control-plane. - ControllerResizeFailed:
+                            State set when resize has failed in resize controller
+                            with a terminal error. - NodeResizePending: State set
+                            when resize controller has finished resizing the volume
+                            but further resizing of volume is needed on the node.
+                            - NodeResizeInProgress: State set when kubelet starts
+                            resizing the volume. - NodeResizeFailed: State set when
+                            resizing has failed in kubelet with a terminal error.
+                            Transient errors don't set NodeResizeFailed. For example:
+                            if expanding a PVC for more capacity - this field can
+                            be one of the following states: - pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeFailed\" When this field is not set, it
+                            means that no resize operation is in progress for the
+                            given PVC. \n A controller that receives PVC update with
+                            previously unknown resourceName or ClaimResourceStatus
+                            should ignore the update for the purpose it was designed.
+                            For example - a controller that only is responsible for
+                            resizing capacity of the volume, should ignore PVC updates
+                            that change other valid resources associated with PVC.
+                            \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                            feature."
+                            type: object
+                            x-kubernetes-map-type: granular
+                          allocatedResources:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: "allocatedResources tracks the resources allocated
+                            to a PVC including its capacity. Key names follow standard
+                            Kubernetes label syntax. Valid values are either: * Un-prefixed
+                            keys: - storage - the capacity of the volume. * Custom
+                            resources must use implementation-defined prefixed names
+                            such as \"example.com/my-custom-resource\" Apart from
+                            above values - keys that are unprefixed or have kubernetes.io
+                            prefix are considered reserved and hence may not be used.
+                            \n Capacity reported here may be larger than the actual
+                            capacity when a volume expansion operation is requested.
+                            For storage quota, the larger value from allocatedResources
+                            and PVC.spec.resources is used. If allocatedResources
+                            is not set, PVC.spec.resources alone is used for quota
+                            calculation. If a volume expansion capacity request is
+                            lowered, allocatedResources is only lowered if there are
+                            no expansion operations in progress and if the actual
+                            volume capacity is equal or lower than the requested capacity.
+                            \n A controller that receives PVC update with previously
+                            unknown resourceName should ignore the update for the
+                            purpose it was designed. For example - a controller that
+                            only is responsible for resizing capacity of the volume,
+                            should ignore PVC updates that change other valid resources
+                            associated with PVC. \n This is an alpha field and requires
+                            enabling RecoverVolumeExpansionFailure feature."
+                            type: object
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: capacity represents the actual resources of
+                              the underlying volume.
+                            type: object
+                          conditions:
+                            description: conditions is the current Condition of persistent
+                              volume claim. If underlying persistent volume is being
+                              resized then the Condition will be set to 'ResizeStarted'.
+                            items:
+                              description: PersistentVolumeClaimCondition contains details
+                                about state of pvc
+                              properties:
+                                lastProbeTime:
+                                  description: lastProbeTime is the time we probed the
+                                    condition.
+                                  format: date-time
+                                  type: string
+                                lastTransitionTime:
+                                  description: lastTransitionTime is the time the condition
+                                    transitioned from one status to another.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: message is the human-readable message
+                                    indicating details about last transition.
+                                  type: string
+                                reason:
+                                  description: reason is a unique, this should be a
+                                    short, machine understandable string that gives
+                                    the reason for condition's last transition. If it
+                                    reports "ResizeStarted" that means the underlying
+                                    persistent volume is being resized.
+                                  type: string
+                                status:
+                                  type: string
+                                type:
+                                  description: PersistentVolumeClaimConditionType is
+                                    a valid value of PersistentVolumeClaimCondition.Type
+                                  type: string
+                              required:
+                                - status
+                                - type
+                              type: object
+                            type: array
+                          currentVolumeAttributesClassName:
+                            description: currentVolumeAttributesClassName is the current
+                              name of the VolumeAttributesClass the PVC is using. When
+                              unset, there is no VolumeAttributeClass applied to this
+                              PersistentVolumeClaim This is an alpha field and requires
+                              enabling VolumeAttributesClass feature.
+                            type: string
+                          modifyVolumeStatus:
+                            description: ModifyVolumeStatus represents the status object
+                              of ControllerModifyVolume operation. When this is unset,
+                              there is no ModifyVolume operation being attempted. This
+                              is an alpha field and requires enabling VolumeAttributesClass
+                              feature.
+                            properties:
                               status:
+                                description: 'status is the status of the ControllerModifyVolume
+                                operation. It can be in any of following states: -
+                                Pending Pending indicates that the PersistentVolumeClaim
+                                cannot be modified due to unmet requirements, such
+                                as the specified VolumeAttributesClass not existing.
+                                - InProgress InProgress indicates that the volume
+                                is being modified. - Infeasible Infeasible indicates
+                                that the request has been rejected as invalid by the
+                                CSI driver. To resolve the error, a valid VolumeAttributesClass
+                                needs to be specified. Note: New statuses can be added
+                                in the future. Consumers should check for unknown
+                                statuses and fail appropriately.'
                                 type: string
-                              type:
-                                description: PersistentVolumeClaimConditionType is
-                                  a valid value of PersistentVolumeClaimCondition.Type
+                              targetVolumeAttributesClassName:
+                                description: targetVolumeAttributesClassName is the
+                                  name of the VolumeAttributesClass the PVC currently
+                                  being reconciled
                                 type: string
                             required:
-                            - status
-                            - type
+                              - status
                             type: object
-                          type: array
-                        phase:
-                          description: phase represents the current phase of PersistentVolumeClaim.
-                          type: string
-                        resizeStatus:
-                          description: resizeStatus stores status of resize operation.
-                            ResizeStatus is not set by default but when expansion
-                            is complete resizeStatus is set to empty string by resize
-                            controller or kubelet. This is an alpha field and requires
-                            enabling RecoverVolumeExpansionFailure feature.
-                          type: string
-                      type: object
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
-              volumeMounts:
-                description: VolumeMounts represents the mount points to use in the
-                  underlying collector deployment(s)
-                items:
-                  description: VolumeMount describes a mounting of a Volume within
-                    a container.
-                  properties:
-                    mountPath:
-                      description: Path within the container at which the volume should
-                        be mounted.  Must not contain ':'.
-                      type: string
-                    mountPropagation:
-                      description: mountPropagation determines how mounts are propagated
-                        from the host to container and the other way around. When
-                        not set, MountPropagationNone is used. This field is beta
-                        in 1.10.
-                      type: string
-                    name:
-                      description: This must match the Name of a Volume.
-                      type: string
-                    readOnly:
-                      description: Mounted read-only if true, read-write otherwise
-                        (false or unspecified). Defaults to false.
-                      type: boolean
-                    subPath:
-                      description: Path within the volume from which the container's
-                        volume should be mounted. Defaults to "" (volume's root).
-                      type: string
-                    subPathExpr:
-                      description: Expanded path within the volume from which the
-                        container's volume should be mounted. Behaves similarly to
-                        SubPath but environment variable references $(VAR_NAME) are
-                        expanded using the container's environment. Defaults to ""
-                        (volume's root). SubPathExpr and SubPath are mutually exclusive.
-                      type: string
-                  required:
-                  - mountPath
-                  - name
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
-              volumes:
-                description: Volumes represents which volumes to use in the underlying
-                  collector deployment(s).
-                items:
-                  description: Volume represents a named volume in a pod that may
-                    be accessed by any container in the pod.
-                  properties:
-                    awsElasticBlockStore:
-                      description: 'awsElasticBlockStore represents an AWS Disk resource
+                          phase:
+                            description: phase represents the current phase of PersistentVolumeClaim.
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumeMounts:
+                  description: VolumeMounts represents the mount points to use in the
+                    underlying collector deployment(s)
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume should
+                          be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                      subPathExpr:
+                        description: Expanded path within the volume from which the
+                          container's volume should be mounted. Behaves similarly to
+                          SubPath but environment variable references $(VAR_NAME) are
+                          expanded using the container's environment. Defaults to ""
+                          (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                        type: string
+                    required:
+                      - mountPath
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumes:
+                  description: Volumes represents which volumes to use in the underlying
+                    collector deployment(s).
+                  items:
+                    description: Volume represents a named volume in a pod that may
+                      be accessed by any container in the pod.
+                    properties:
+                      awsElasticBlockStore:
+                        description: 'awsElasticBlockStore represents an AWS Disk resource
                         that is attached to a kubelet''s host machine and then exposed
                         to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                      properties:
-                        fsType:
-                          description: 'fsType is the filesystem type of the volume
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
                             that you want to mount. Tip: Ensure that the filesystem
                             type is supported by the host operating system. Examples:
                             "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                             if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
-                          type: string
-                        partition:
-                          description: 'partition is the partition in the volume that
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume that
                             you want to mount. If omitted, the default is to mount
                             by volume name. Examples: For volume /dev/sda1, you specify
                             the partition as "1". Similarly, the volume partition
                             for /dev/sda is "0" (or you can leave the property empty).'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'readOnly value true will force the readOnly
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly value true will force the readOnly
                             setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: boolean
-                        volumeID:
-                          description: 'volumeID is unique ID of the persistent disk
+                            type: boolean
+                          volumeID:
+                            description: 'volumeID is unique ID of the persistent disk
                             resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on
-                        the host and bind mount to the pod.
-                      properties:
-                        cachingMode:
-                          description: 'cachingMode is the Host Caching mode: None,
+                            type: string
+                        required:
+                          - volumeID
+                        type: object
+                      azureDisk:
+                        description: azureDisk represents an Azure Data Disk mount on
+                          the host and bind mount to the pod.
+                        properties:
+                          cachingMode:
+                            description: 'cachingMode is the Host Caching mode: None,
                             Read Only, Read Write.'
-                          type: string
-                        diskName:
-                          description: diskName is the Name of the data disk in the
-                            blob storage
-                          type: string
-                        diskURI:
-                          description: diskURI is the URI of data disk in the blob
-                            storage
-                          type: string
-                        fsType:
-                          description: fsType is Filesystem type to mount. Must be
-                            a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        kind:
-                          description: 'kind expected values are Shared: multiple
+                            type: string
+                          diskName:
+                            description: diskName is the Name of the data disk in the
+                              blob storage
+                            type: string
+                          diskURI:
+                            description: diskURI is the URI of data disk in the blob
+                              storage
+                            type: string
+                          fsType:
+                            description: fsType is Filesystem type to mount. Must be
+                              a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified.
+                            type: string
+                          kind:
+                            description: 'kind expected values are Shared: multiple
                             blob disks per storage account  Dedicated: single blob
                             disk per storage account  Managed: azure managed data
                             disk (only in managed availability set). defaults to shared'
-                          type: string
-                        readOnly:
-                          description: readOnly Defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      description: azureFile represents an Azure File Service mount
-                        on the host and bind mount to the pod.
-                      properties:
-                        readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretName:
-                          description: secretName is the  name of secret that contains
-                            Azure Storage Account Name and Key
-                          type: string
-                        shareName:
-                          description: shareName is the azure share Name
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that
-                        shares a pod's lifetime
-                      properties:
-                        monitors:
-                          description: 'monitors is Required: Monitors is a collection
-                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          items:
                             type: string
-                          type: array
-                        path:
-                          description: 'path is Optional: Used as the mounted root,
+                          readOnly:
+                            description: readOnly Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                        required:
+                          - diskName
+                          - diskURI
+                        type: object
+                      azureFile:
+                        description: azureFile represents an Azure File Service mount
+                          on the host and bind mount to the pod.
+                        properties:
+                          readOnly:
+                            description: readOnly defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: secretName is the  name of secret that contains
+                              Azure Storage Account Name and Key
+                            type: string
+                          shareName:
+                            description: shareName is the azure share Name
+                            type: string
+                        required:
+                          - secretName
+                          - shareName
+                        type: object
+                      cephfs:
+                        description: cephFS represents a Ceph FS mount on the host that
+                          shares a pod's lifetime
+                        properties:
+                          monitors:
+                            description: 'monitors is Required: Monitors is a collection
+                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            description: 'path is Optional: Used as the mounted root,
                             rather than the full Ceph tree, default is /'
-                          type: string
-                        readOnly:
-                          description: 'readOnly is Optional: Defaults to false (read/write).
+                            type: string
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.
                             More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: boolean
-                        secretFile:
-                          description: 'secretFile is Optional: SecretFile is the
+                            type: boolean
+                          secretFile:
+                            description: 'secretFile is Optional: SecretFile is the
                             path to key ring for User, default is /etc/ceph/user.secret
                             More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                        secretRef:
-                          description: 'secretRef is Optional: SecretRef is reference
+                            type: string
+                          secretRef:
+                            description: 'secretRef is Optional: SecretRef is reference
                             to the authentication secret for User, default is empty.
                             More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        user:
-                          description: 'user is optional: User is the rados user name,
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          user:
+                            description: 'user is optional: User is the rados user name,
                             default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      description: 'cinder represents a cinder volume attached and
+                            type: string
+                        required:
+                          - monitors
+                        type: object
+                      cinder:
+                        description: 'cinder represents a cinder volume attached and
                         mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                      properties:
-                        fsType:
-                          description: 'fsType is the filesystem type to mount. Must
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type to mount. Must
                             be a filesystem type supported by the host operating system.
                             Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
                             be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                        readOnly:
-                          description: 'readOnly defaults to false (read/write). ReadOnly
+                            type: string
+                          readOnly:
+                            description: 'readOnly defaults to false (read/write). ReadOnly
                             here will force the ReadOnly setting in VolumeMounts.
                             More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: boolean
-                        secretRef:
-                          description: 'secretRef is optional: points to a secret
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is optional: points to a secret
                             object containing parameters used to connect to OpenStack.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        volumeID:
-                          description: 'volumeID used to identify the volume in cinder.
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          volumeID:
+                            description: 'volumeID used to identify the volume in cinder.
                             More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      description: configMap represents a configMap that should populate
-                        this volume
-                      properties:
-                        defaultMode:
-                          description: 'defaultMode is optional: mode bits used to
+                            type: string
+                        required:
+                          - volumeID
+                        type: object
+                      configMap:
+                        description: configMap represents a configMap that should populate
+                          this volume
+                        properties:
+                          defaultMode:
+                            description: 'defaultMode is optional: mode bits used to
                             set permissions on created files by default. Must be an
                             octal value between 0000 and 0777 or a decimal value between
                             0 and 511. YAML accepts both octal and decimal values,
@@ -1056,26 +5970,26 @@ spec:
                             this setting. This might be in conflict with other options
                             that affect the file mode, like fsGroup, and the result
                             can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: items if unspecified, each key-value pair in
-                            the Data field of the referenced ConfigMap will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the ConfigMap, the volume setup will error unless it is
-                            marked optional. Paths must be relative and may not contain
-                            the '..' path or start with '..'.
+                            format: int32
+                            type: integer
                           items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: key is the key to project.
-                                type: string
-                              mode:
-                                description: 'mode is Optional: mode bits used to
+                            description: items if unspecified, each key-value pair in
+                              the Data field of the referenced ConfigMap will be projected
+                              into the volume as a file whose name is the key and content
+                              is the value. If specified, the listed keys will be projected
+                              into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in
+                              the ConfigMap, the volume setup will error unless it is
+                              marked optional. Paths must be relative and may not contain
+                              the '..' path or start with '..'.
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: 'mode is Optional: mode bits used to
                                   set permissions on this file. Must be an octal value
                                   between 0000 and 0777 or a decimal value between
                                   0 and 511. YAML accepts both octal and decimal values,
@@ -1084,80 +5998,80 @@ spec:
                                   This might be in conflict with other options that
                                   affect the file mode, like fsGroup, and the result
                                   can be other mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: path is the relative path of the file
-                                  to map the key to. May not be an absolute path.
-                                  May not contain the path element '..'. May not start
-                                  with the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path is the relative path of the file
+                                    to map the key to. May not be an absolute path.
+                                    May not contain the path element '..'. May not start
+                                    with the string '..'.
+                                  type: string
+                              required:
+                                - key
+                                - path
+                              type: object
+                            type: array
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                             TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                        optional:
-                          description: optional specify whether the ConfigMap or its
-                            keys must be defined
-                          type: boolean
-                      type: object
-                      x-kubernetes-map-type: atomic
-                    csi:
-                      description: csi (Container Storage Interface) represents ephemeral
-                        storage that is handled by certain external CSI drivers (Beta
-                        feature).
-                      properties:
-                        driver:
-                          description: driver is the name of the CSI driver that handles
-                            this volume. Consult with your admin for the correct name
-                            as registered in the cluster.
-                          type: string
-                        fsType:
-                          description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                            If not provided, the empty value is passed to the associated
-                            CSI driver which will determine the default filesystem
-                            to apply.
-                          type: string
-                        nodePublishSecretRef:
-                          description: nodePublishSecretRef is a reference to the
-                            secret object containing sensitive information to pass
-                            to the CSI driver to complete the CSI NodePublishVolume
-                            and NodeUnpublishVolume calls. This field is optional,
-                            and  may be empty if no secret is required. If the secret
-                            object contains more than one secret, all secret references
-                            are passed.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        readOnly:
-                          description: readOnly specifies a read-only configuration
-                            for the volume. Defaults to false (read/write).
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
                             type: string
-                          description: volumeAttributes stores driver-specific properties
-                            that are passed to the CSI driver. Consult your driver's
-                            documentation for supported values.
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      description: downwardAPI represents downward API about the pod
-                        that should populate this volume
-                      properties:
-                        defaultMode:
-                          description: 'Optional: mode bits to use on created files
+                          optional:
+                            description: optional specify whether the ConfigMap or its
+                              keys must be defined
+                            type: boolean
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      csi:
+                        description: csi (Container Storage Interface) represents ephemeral
+                          storage that is handled by certain external CSI drivers (Beta
+                          feature).
+                        properties:
+                          driver:
+                            description: driver is the name of the CSI driver that handles
+                              this volume. Consult with your admin for the correct name
+                              as registered in the cluster.
+                            type: string
+                          fsType:
+                            description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                              If not provided, the empty value is passed to the associated
+                              CSI driver which will determine the default filesystem
+                              to apply.
+                            type: string
+                          nodePublishSecretRef:
+                            description: nodePublishSecretRef is a reference to the
+                              secret object containing sensitive information to pass
+                              to the CSI driver to complete the CSI NodePublishVolume
+                              and NodeUnpublishVolume calls. This field is optional,
+                              and  may be empty if no secret is required. If the secret
+                              object contains more than one secret, all secret references
+                              are passed.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          readOnly:
+                            description: readOnly specifies a read-only configuration
+                              for the volume. Defaults to false (read/write).
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            description: volumeAttributes stores driver-specific properties
+                              that are passed to the CSI driver. Consult your driver's
+                              documentation for supported values.
+                            type: object
+                        required:
+                          - driver
+                        type: object
+                      downwardAPI:
+                        description: downwardAPI represents downward API about the pod
+                          that should populate this volume
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
                             by default. Must be a Optional: mode bits used to set
                             permissions on created files by default. Must be an octal
                             value between 0000 and 0777 or a decimal value between
@@ -1167,33 +6081,33 @@ spec:
                             this setting. This might be in conflict with other options
                             that affect the file mode, like fsGroup, and the result
                             can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: Items is a list of downward API volume file
+                            format: int32
+                            type: integer
                           items:
-                            description: DownwardAPIVolumeFile represents information
-                              to create the file containing the pod field
-                            properties:
-                              fieldRef:
-                                description: 'Required: Selects a field of the pod:
+                            description: Items is a list of downward API volume file
+                            items:
+                              description: DownwardAPIVolumeFile represents information
+                                to create the file containing the pod field
+                              properties:
+                                fieldRef:
+                                  description: 'Required: Selects a field of the pod:
                                   only annotations, labels, name and namespace are
                                   supported.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                - fieldPath
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              mode:
-                                description: 'Optional: mode bits used to set permissions
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the
+                                        specified API version.
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                mode:
+                                  description: 'Optional: mode bits used to set permissions
                                   on this file, must be an octal value between 0000
                                   and 0777 or a decimal value between 0 and 511. YAML
                                   accepts both octal and decimal values, JSON requires
@@ -1202,71 +6116,71 @@ spec:
                                   be in conflict with other options that affect the
                                   file mode, like fsGroup, and the result can be other
                                   mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: 'Required: Path is  the relative path
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: 'Required: Path is  the relative path
                                   name of the file to be created. Must not be absolute
                                   or contain the ''..'' path. Must be utf-8 encoded.
                                   The first item of the relative path must not start
                                   with ''..'''
-                                type: string
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container:
+                                  type: string
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
                                   only resources limits and requests (limits.cpu,
                                   limits.memory, requests.cpu and requests.memory)
                                   are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
                                       optional for env vars'
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                - resource
-                                type: object
-                                x-kubernetes-map-type: atomic
-                            required:
-                            - path
-                            type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      description: 'emptyDir represents a temporary directory that
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                                - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        description: 'emptyDir represents a temporary directory that
                         shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                      properties:
-                        medium:
-                          description: 'medium represents what type of storage medium
+                        properties:
+                          medium:
+                            description: 'medium represents what type of storage medium
                             should back this directory. The default is "" which means
                             to use the node''s default medium. Must be an empty string
                             (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          description: 'sizeLimit is the total amount of local storage
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            description: 'sizeLimit is the total amount of local storage
                             required for this EmptyDir volume. The size limit is also
                             applicable for memory medium. The maximum usage on memory
                             medium EmptyDir would be the minimum value between the
                             SizeLimit specified here and the sum of memory limits
                             of all containers in a pod. The default is nil which means
                             that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    ephemeral:
-                      description: "ephemeral represents a volume that is handled
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        description: "ephemeral represents a volume that is handled
                         by a cluster storage driver. The volume's lifecycle is tied
                         to the pod that defines it - it will be created before the
                         pod starts, and deleted when the pod is removed. \n Use this
@@ -1283,9 +6197,9 @@ spec:
                         is meant to be used that way - see the documentation of the
                         driver for more information. \n A pod can use both types of
                         ephemeral volumes and persistent volumes at the same time."
-                      properties:
-                        volumeClaimTemplate:
-                          description: "Will be used to create a stand-alone PVC to
+                        properties:
+                          volumeClaimTemplate:
+                            description: "Will be used to create a stand-alone PVC to
                             provision the volume. The pod in which this EphemeralVolumeSource
                             is embedded will be the owner of the PVC, i.e. the PVC
                             will be deleted together with the pod.  The name of the
@@ -1304,43 +6218,43 @@ spec:
                             field is read-only and no changes will be made by Kubernetes
                             to the PVC after it has been created. \n Required, must
                             not be nil."
-                          properties:
-                            metadata:
-                              description: May contain labels and annotations that
-                                will be copied into the PVC when creating it. No other
-                                fields are allowed and will be rejected during validation.
-                              properties:
-                                annotations:
-                                  additionalProperties:
+                            properties:
+                              metadata:
+                                description: May contain labels and annotations that
+                                  will be copied into the PVC when creating it. No other
+                                  fields are allowed and will be rejected during validation.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
                                     type: string
-                                  type: object
-                                finalizers:
-                                  items:
+                                  namespace:
                                     type: string
-                                  type: array
-                                labels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                name:
-                                  type: string
-                                namespace:
-                                  type: string
-                              type: object
-                            spec:
-                              description: The specification for the PersistentVolumeClaim.
-                                The entire content is copied unchanged into the PVC
-                                that gets created from this template. The same fields
-                                as in a PersistentVolumeClaim are also valid here.
-                              properties:
-                                accessModes:
-                                  description: 'accessModes contains the desired access
+                                type: object
+                              spec:
+                                description: The specification for the PersistentVolumeClaim.
+                                  The entire content is copied unchanged into the PVC
+                                  that gets created from this template. The same fields
+                                  as in a PersistentVolumeClaim are also valid here.
+                                properties:
+                                  accessModes:
+                                    description: 'accessModes contains the desired access
                                     modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                  items:
-                                    type: string
-                                  type: array
-                                dataSource:
-                                  description: 'dataSource field can be used to specify
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    description: 'dataSource field can be used to specify
                                     either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                     * An existing PVC (PersistentVolumeClaim) If the
                                     provisioner or an external controller can support
@@ -1352,29 +6266,29 @@ spec:
                                     be copied to dataSource when dataSourceRef.namespace
                                     is not specified. If the namespace is specified,
                                     then dataSourceRef will not be copied to dataSource.'
-                                  properties:
-                                    apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API
-                                        group. For any other third-party types, APIGroup
-                                        is required.
-                                      type: string
-                                    kind:
-                                      description: Kind is the type of resource being
-                                        referenced
-                                      type: string
-                                    name:
-                                      description: Name is the name of resource being
-                                        referenced
-                                      type: string
-                                  required:
-                                  - kind
-                                  - name
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                dataSourceRef:
-                                  description: 'dataSourceRef specifies the object
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API
+                                          group. For any other third-party types, APIGroup
+                                          is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource being
+                                          referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource being
+                                          referenced
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  dataSourceRef:
+                                    description: 'dataSourceRef specifies the object
                                     from which to populate the volume with data, if
                                     a non-empty volume is desired. This may be any
                                     object from a non-empty API group (non core object)
@@ -1406,551 +6320,644 @@ spec:
                                     namespace field of dataSourceRef requires the
                                     CrossNamespaceVolumeDataSource feature gate to
                                     be enabled.'
-                                  properties:
-                                    apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API
-                                        group. For any other third-party types, APIGroup
-                                        is required.
-                                      type: string
-                                    kind:
-                                      description: Kind is the type of resource being
-                                        referenced
-                                      type: string
-                                    name:
-                                      description: Name is the name of resource being
-                                        referenced
-                                      type: string
-                                    namespace:
-                                      description: Namespace is the namespace of resource
-                                        being referenced Note that when a namespace
-                                        is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                        object is required in the referent namespace
-                                        to allow that namespace's owner to accept
-                                        the reference. See the ReferenceGrant documentation
-                                        for details. (Alpha) This field requires the
-                                        CrossNamespaceVolumeDataSource feature gate
-                                        to be enabled.
-                                      type: string
-                                  required:
-                                  - kind
-                                  - name
-                                  type: object
-                                resources:
-                                  description: 'resources represents the minimum resources
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API
+                                          group. For any other third-party types, APIGroup
+                                          is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource being
+                                          referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource being
+                                          referenced
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the namespace of resource
+                                          being referenced Note that when a namespace
+                                          is specified, a gateway.networking.k8s.io/ReferenceGrant
+                                          object is required in the referent namespace
+                                          to allow that namespace's owner to accept
+                                          the reference. See the ReferenceGrant documentation
+                                          for details. (Alpha) This field requires the
+                                          CrossNamespaceVolumeDataSource feature gate
+                                          to be enabled.
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  resources:
+                                    description: 'resources represents the minimum resources
                                     the volume should have. If RecoverVolumeExpansionFailure
                                     feature is enabled users are allowed to specify
                                     resource requirements that are lower than previous
                                     value but must still be higher than capacity recorded
                                     in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                  properties:
-                                    claims:
-                                      description: "Claims lists the names of resources,
-                                        defined in spec.resourceClaims, that are used
-                                        by this container. \n This is an alpha field
-                                        and requires enabling the DynamicResourceAllocation
-                                        feature gate. \n This field is immutable.
-                                        It can only be set for containers."
-                                      items:
-                                        description: ResourceClaim references one
-                                          entry in PodSpec.ResourceClaims.
-                                        properties:
-                                          name:
-                                            description: Name must match the name
-                                              of one entry in pod.spec.resourceClaims
-                                              of the Pod where this field is used.
-                                              It makes that resource available inside
-                                              a container.
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                      - name
-                                      x-kubernetes-list-type: map
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount
                                         of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
                                         amount of compute resources required. If Requests
                                         is omitted for a container, it defaults to
                                         Limits if that is explicitly specified, otherwise
                                         to an implementation-defined value. Requests
                                         cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                      type: object
-                                  type: object
-                                selector:
-                                  description: selector is a label query over volumes
-                                    to consider for binding.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
                                         type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                storageClassName:
-                                  description: 'storageClassName is the name of the
+                                    type: object
+                                  selector:
+                                    description: selector is a label query over volumes
+                                      to consider for binding.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  storageClassName:
+                                    description: 'storageClassName is the name of the
                                     StorageClass required by the claim. More info:
                                     https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                  type: string
-                                volumeMode:
-                                  description: volumeMode defines what type of volume
-                                    is required by the claim. Value of Filesystem
-                                    is implied when not included in claim spec.
-                                  type: string
-                                volumeName:
-                                  description: volumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
-                                  type: string
-                              type: object
-                          required:
-                          - spec
-                          type: object
-                      type: object
-                    fc:
-                      description: fc represents a Fibre Channel resource that is
-                        attached to a kubelet's host machine and then exposed to the
-                        pod.
-                      properties:
-                        fsType:
-                          description: 'fsType is the filesystem type to mount. Must
+                                    type: string
+                                  volumeAttributesClassName:
+                                    description: 'volumeAttributesClassName may be used
+                                    to set the VolumeAttributesClass used by this
+                                    claim. If specified, the CSI driver will create
+                                    or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This
+                                    has a different purpose than storageClassName,
+                                    it can be changed after the claim is created.
+                                    An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it''s not allowed
+                                    to reset this field to empty string once it is
+                                    set. If unspecified and the PersistentVolumeClaim
+                                    is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller
+                                    if it exists. If the resource referred to by volumeAttributesClass
+                                    does not exist, this PersistentVolumeClaim will
+                                    be set to a Pending state, as reflected by the
+                                    modifyVolumeStatus field, until such as a resource
+                                    exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                    (Alpha) Using this field requires the VolumeAttributesClass
+                                    feature gate to be enabled.'
+                                    type: string
+                                  volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
+                                    type: string
+                                type: object
+                            required:
+                              - spec
+                            type: object
+                        type: object
+                      fc:
+                        description: fc represents a Fibre Channel resource that is
+                          attached to a kubelet's host machine and then exposed to the
+                          pod.
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type to mount. Must
                             be a filesystem type supported by the host operating system.
                             Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                             if unspecified. TODO: how do we prevent errors in the
                             filesystem from compromising the machine'
-                          type: string
-                        lun:
-                          description: 'lun is Optional: FC target lun number'
-                          format: int32
-                          type: integer
-                        readOnly:
-                          description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        targetWWNs:
-                          description: 'targetWWNs is Optional: FC target worldwide
-                            names (WWNs)'
-                          items:
                             type: string
-                          type: array
-                        wwids:
-                          description: 'wwids Optional: FC volume world wide identifiers
+                          lun:
+                            description: 'lun is Optional: FC target lun number'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false (read/write).
+                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            description: 'wwids Optional: FC volume world wide identifiers
                             (wwids) Either wwids or combination of targetWWNs and
                             lun must be set, but not both simultaneously.'
-                          items:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        description: flexVolume represents a generic volume resource
+                          that is provisioned/attached using an exec based plugin.
+                        properties:
+                          driver:
+                            description: driver is the name of the driver to use for
+                              this volume.
                             type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      description: flexVolume represents a generic volume resource
-                        that is provisioned/attached using an exec based plugin.
-                      properties:
-                        driver:
-                          description: driver is the name of the driver to use for
-                            this volume.
-                          type: string
-                        fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends
-                            on FlexVolume script.
-                          type: string
-                        options:
-                          additionalProperties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". The default filesystem depends
+                              on FlexVolume script.
                             type: string
-                          description: 'options is Optional: this field holds extra
+                          options:
+                            additionalProperties:
+                              type: string
+                            description: 'options is Optional: this field holds extra
                             command options if any.'
-                          type: object
-                        readOnly:
-                          description: 'readOnly is Optional: defaults to false (read/write).
+                            type: object
+                          readOnly:
+                            description: 'readOnly is Optional: defaults to false (read/write).
                             ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                          type: boolean
-                        secretRef:
-                          description: 'secretRef is Optional: secretRef is reference
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is Optional: secretRef is reference
                             to the secret object containing sensitive information
                             to pass to the plugin scripts. This may be empty if no
                             secret object is specified. If the secret object contains
                             more than one secret, all secrets are passed to the plugin
                             scripts.'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      description: flocker represents a Flocker volume attached to
-                        a kubelet's host machine. This depends on the Flocker control
-                        service being running
-                      properties:
-                        datasetName:
-                          description: datasetName is Name of the dataset stored as
-                            metadata -> name on the dataset for Flocker should be
-                            considered as deprecated
-                          type: string
-                        datasetUUID:
-                          description: datasetUUID is the UUID of the dataset. This
-                            is unique identifier of a Flocker dataset
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      description: 'gcePersistentDisk represents a GCE Disk resource
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - driver
+                        type: object
+                      flocker:
+                        description: flocker represents a Flocker volume attached to
+                          a kubelet's host machine. This depends on the Flocker control
+                          service being running
+                        properties:
+                          datasetName:
+                            description: datasetName is Name of the dataset stored as
+                              metadata -> name on the dataset for Flocker should be
+                              considered as deprecated
+                            type: string
+                          datasetUUID:
+                            description: datasetUUID is the UUID of the dataset. This
+                              is unique identifier of a Flocker dataset
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        description: 'gcePersistentDisk represents a GCE Disk resource
                         that is attached to a kubelet''s host machine and then exposed
                         to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                      properties:
-                        fsType:
-                          description: 'fsType is filesystem type of the volume that
+                        properties:
+                          fsType:
+                            description: 'fsType is filesystem type of the volume that
                             you want to mount. Tip: Ensure that the filesystem type
                             is supported by the host operating system. Examples: "ext4",
                             "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
-                          type: string
-                        partition:
-                          description: 'partition is the partition in the volume that
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume that
                             you want to mount. If omitted, the default is to mount
                             by volume name. Examples: For volume /dev/sda1, you specify
                             the partition as "1". Similarly, the volume partition
                             for /dev/sda is "0" (or you can leave the property empty).
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          format: int32
-                          type: integer
-                        pdName:
-                          description: 'pdName is unique name of the PD resource in
+                            format: int32
+                            type: integer
+                          pdName:
+                            description: 'pdName is unique name of the PD resource in
                             GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: string
-                        readOnly:
-                          description: 'readOnly here will force the ReadOnly setting
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      description: 'gitRepo represents a git repository at a particular
+                            type: boolean
+                        required:
+                          - pdName
+                        type: object
+                      gitRepo:
+                        description: 'gitRepo represents a git repository at a particular
                         revision. DEPRECATED: GitRepo is deprecated. To provision
                         a container with a git repo, mount an EmptyDir into an InitContainer
                         that clones the repo using git, then mount the EmptyDir into
                         the Pod''s container.'
-                      properties:
-                        directory:
-                          description: directory is the target directory name. Must
-                            not contain or start with '..'.  If '.' is supplied, the
-                            volume directory will be the git repository.  Otherwise,
-                            if specified, the volume will contain the git repository
-                            in the subdirectory with the given name.
-                          type: string
-                        repository:
-                          description: repository is the URL
-                          type: string
-                        revision:
-                          description: revision is the commit hash for the specified
-                            revision.
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      description: 'glusterfs represents a Glusterfs mount on the
+                        properties:
+                          directory:
+                            description: directory is the target directory name. Must
+                              not contain or start with '..'.  If '.' is supplied, the
+                              volume directory will be the git repository.  Otherwise,
+                              if specified, the volume will contain the git repository
+                              in the subdirectory with the given name.
+                            type: string
+                          repository:
+                            description: repository is the URL
+                            type: string
+                          revision:
+                            description: revision is the commit hash for the specified
+                              revision.
+                            type: string
+                        required:
+                          - repository
+                        type: object
+                      glusterfs:
+                        description: 'glusterfs represents a Glusterfs mount on the
                         host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                      properties:
-                        endpoints:
-                          description: 'endpoints is the endpoint name that details
+                        properties:
+                          endpoints:
+                            description: 'endpoints is the endpoint name that details
                             Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        path:
-                          description: 'path is the Glusterfs volume path. More info:
+                            type: string
+                          path:
+                            description: 'path is the Glusterfs volume path. More info:
                             https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: string
-                        readOnly:
-                          description: 'readOnly here will force the Glusterfs volume
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the Glusterfs volume
                             to be mounted with read-only permissions. Defaults to
                             false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      description: 'hostPath represents a pre-existing file or directory
+                            type: boolean
+                        required:
+                          - endpoints
+                          - path
+                        type: object
+                      hostPath:
+                        description: 'hostPath represents a pre-existing file or directory
                         on the host machine that is directly exposed to the container.
                         This is generally used for system agents or other privileged
                         things that are allowed to see the host machine. Most containers
                         will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                         --- TODO(jonesdl) We need to restrict who can use host directory
                         mounts and who can/can not mount host directories as read/write.'
-                      properties:
-                        path:
-                          description: 'path of the directory on the host. If the
+                        properties:
+                          path:
+                            description: 'path of the directory on the host. If the
                             path is a symlink, it will follow the link to the real
                             path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                        type:
-                          description: 'type for HostPath Volume Defaults to "" More
+                            type: string
+                          type:
+                            description: 'type for HostPath Volume Defaults to "" More
                             info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      description: 'iscsi represents an ISCSI Disk resource that is
+                            type: string
+                        required:
+                          - path
+                        type: object
+                      iscsi:
+                        description: 'iscsi represents an ISCSI Disk resource that is
                         attached to a kubelet''s host machine and then exposed to
                         the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                      properties:
-                        chapAuthDiscovery:
-                          description: chapAuthDiscovery defines whether support iSCSI
-                            Discovery CHAP authentication
-                          type: boolean
-                        chapAuthSession:
-                          description: chapAuthSession defines whether support iSCSI
-                            Session CHAP authentication
-                          type: boolean
-                        fsType:
-                          description: 'fsType is the filesystem type of the volume
+                        properties:
+                          chapAuthDiscovery:
+                            description: chapAuthDiscovery defines whether support iSCSI
+                              Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: chapAuthSession defines whether support iSCSI
+                              Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
                             that you want to mount. Tip: Ensure that the filesystem
                             type is supported by the host operating system. Examples:
                             "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                             if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
-                          type: string
-                        initiatorName:
-                          description: initiatorName is the custom iSCSI Initiator
-                            Name. If initiatorName is specified with iscsiInterface
-                            simultaneously, new iSCSI interface <target portal>:<volume
-                            name> will be created for the connection.
-                          type: string
-                        iqn:
-                          description: iqn is the target iSCSI Qualified Name.
-                          type: string
-                        iscsiInterface:
-                          description: iscsiInterface is the interface Name that uses
-                            an iSCSI transport. Defaults to 'default' (tcp).
-                          type: string
-                        lun:
-                          description: lun represents iSCSI Target Lun number.
-                          format: int32
-                          type: integer
-                        portals:
-                          description: portals is the iSCSI Target Portal List. The
-                            portal is either an IP or ip_addr:port if the port is
-                            other than default (typically TCP ports 860 and 3260).
-                          items:
                             type: string
-                          type: array
-                        readOnly:
-                          description: readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false.
-                          type: boolean
-                        secretRef:
-                          description: secretRef is the CHAP Secret for iSCSI target
-                            and initiator authentication
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                          initiatorName:
+                            description: initiatorName is the custom iSCSI Initiator
+                              Name. If initiatorName is specified with iscsiInterface
+                              simultaneously, new iSCSI interface <target portal>:<volume
+                              name> will be created for the connection.
+                            type: string
+                          iqn:
+                            description: iqn is the target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iscsiInterface is the interface Name that uses
+                              an iSCSI transport. Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: lun represents iSCSI Target Lun number.
+                            format: int32
+                            type: integer
+                          portals:
+                            description: portals is the iSCSI Target Portal List. The
+                              portal is either an IP or ip_addr:port if the port is
+                              other than default (typically TCP ports 860 and 3260).
+                            items:
                               type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        targetPortal:
-                          description: targetPortal is iSCSI Target Portal. The Portal
-                            is either an IP or ip_addr:port if the port is other than
-                            default (typically TCP ports 860 and 3260).
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      description: 'name of the volume. Must be a DNS_LABEL and unique
+                            type: array
+                          readOnly:
+                            description: readOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: secretRef is the CHAP Secret for iSCSI target
+                              and initiator authentication
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          targetPortal:
+                            description: targetPortal is iSCSI Target Portal. The Portal
+                              is either an IP or ip_addr:port if the port is other than
+                              default (typically TCP ports 860 and 3260).
+                            type: string
+                        required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                        type: object
+                      name:
+                        description: 'name of the volume. Must be a DNS_LABEL and unique
                         within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    nfs:
-                      description: 'nfs represents an NFS mount on the host that shares
+                        type: string
+                      nfs:
+                        description: 'nfs represents an NFS mount on the host that shares
                         a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                      properties:
-                        path:
-                          description: 'path that is exported by the NFS server. More
+                        properties:
+                          path:
+                            description: 'path that is exported by the NFS server. More
                             info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                        readOnly:
-                          description: 'readOnly here will force the NFS export to
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the NFS export to
                             be mounted with read-only permissions. Defaults to false.
                             More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: boolean
-                        server:
-                          description: 'server is the hostname or IP address of the
+                            type: boolean
+                          server:
+                            description: 'server is the hostname or IP address of the
                             NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      description: 'persistentVolumeClaimVolumeSource represents a
+                            type: string
+                        required:
+                          - path
+                          - server
+                        type: object
+                      persistentVolumeClaim:
+                        description: 'persistentVolumeClaimVolumeSource represents a
                         reference to a PersistentVolumeClaim in the same namespace.
                         More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                      properties:
-                        claimName:
-                          description: 'claimName is the name of a PersistentVolumeClaim
+                        properties:
+                          claimName:
+                            description: 'claimName is the name of a PersistentVolumeClaim
                             in the same namespace as the pod using this volume. More
                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                          type: string
-                        readOnly:
-                          description: readOnly Will force the ReadOnly setting in
-                            VolumeMounts. Default false.
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController
-                        persistent disk attached and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        pdID:
-                          description: pdID is the ID that identifies Photon Controller
-                            persistent disk
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      description: portworxVolume represents a portworx volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: fSType represents the filesystem type to mount
-                            Must be a filesystem type supported by the host operating
-                            system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        volumeID:
-                          description: volumeID uniquely identifies a Portworx volume
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      description: projected items for all in one resources secrets,
-                        configmaps, and downward API
-                      properties:
-                        defaultMode:
-                          description: defaultMode are the mode bits used to set permissions
-                            on created files by default. Must be an octal value between
-                            0000 and 0777 or a decimal value between 0 and 511. YAML
-                            accepts both octal and decimal values, JSON requires decimal
-                            values for mode bits. Directories within the path are
-                            not affected by this setting. This might be in conflict
-                            with other options that affect the file mode, like fsGroup,
-                            and the result can be other mode bits set.
-                          format: int32
-                          type: integer
-                        sources:
-                          description: sources is the list of volume projections
-                          items:
-                            description: Projection that may be projected along with
-                              other supported volume types
-                            properties:
-                              configMap:
-                                description: configMap information about the configMap
-                                  data to project
-                                properties:
-                                  items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
-                                    items:
-                                      description: Maps a string key to a path within
-                                        a volume.
+                            type: string
+                          readOnly:
+                            description: readOnly Will force the ReadOnly setting in
+                              VolumeMounts. Default false.
+                            type: boolean
+                        required:
+                          - claimName
+                        type: object
+                      photonPersistentDisk:
+                        description: photonPersistentDisk represents a PhotonController
+                          persistent disk attached and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified.
+                            type: string
+                          pdID:
+                            description: pdID is the ID that identifies Photon Controller
+                              persistent disk
+                            type: string
+                        required:
+                          - pdID
+                        type: object
+                      portworxVolume:
+                        description: portworxVolume represents a portworx volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fSType represents the filesystem type to mount
+                              Must be a filesystem type supported by the host operating
+                              system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                              if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: volumeID uniquely identifies a Portworx volume
+                            type: string
+                        required:
+                          - volumeID
+                        type: object
+                      projected:
+                        description: projected items for all in one resources secrets,
+                          configmaps, and downward API
+                        properties:
+                          defaultMode:
+                            description: defaultMode are the mode bits used to set permissions
+                              on created files by default. Must be an octal value between
+                              0000 and 0777 or a decimal value between 0 and 511. YAML
+                              accepts both octal and decimal values, JSON requires decimal
+                              values for mode bits. Directories within the path are
+                              not affected by this setting. This might be in conflict
+                              with other options that affect the file mode, like fsGroup,
+                              and the result can be other mode bits set.
+                            format: int32
+                            type: integer
+                          sources:
+                            description: sources is the list of volume projections
+                            items:
+                              description: Projection that may be projected along with
+                                other supported volume types
+                              properties:
+                                clusterTrustBundle:
+                                  description: "ClusterTrustBundle allows a pod to access
+                                  the `.spec.trustBundle` field of ClusterTrustBundle
+                                  objects in an auto-updating file. \n Alpha, gated
+                                  by the ClusterTrustBundleProjection feature gate.
+                                  \n ClusterTrustBundle objects can either be selected
+                                  by name, or by the combination of signer name and
+                                  a label selector. \n Kubelet performs aggressive
+                                  normalization of the PEM contents written into the
+                                  pod filesystem.  Esoteric PEM features such as inter-block
+                                  comments and block headers are stripped.  Certificates
+                                  are deduplicated. The ordering of certificates within
+                                  the file is arbitrary, and Kubelet may change the
+                                  order over time."
+                                  properties:
+                                    labelSelector:
+                                      description: Select all ClusterTrustBundles that
+                                        match this label selector.  Only has effect
+                                        if signerName is set.  Mutually-exclusive with
+                                        name.  If unset, interpreted as "match nothing".  If
+                                        set but empty, interpreted as "match everything".
                                       properties:
-                                        key:
-                                          description: key is the key to project.
-                                          type: string
-                                        mode:
-                                          description: 'mode is Optional: mode bits
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    name:
+                                      description: Select a single ClusterTrustBundle
+                                        by object name.  Mutually-exclusive with signerName
+                                        and labelSelector.
+                                      type: string
+                                    optional:
+                                      description: If true, don't block pod startup
+                                        if the referenced ClusterTrustBundle(s) aren't
+                                        available.  If using name, then the named ClusterTrustBundle
+                                        is allowed not to exist.  If using signerName,
+                                        then the combination of signerName and labelSelector
+                                        is allowed to match zero ClusterTrustBundles.
+                                      type: boolean
+                                    path:
+                                      description: Relative path from the volume root
+                                        to write the bundle.
+                                      type: string
+                                    signerName:
+                                      description: Select all ClusterTrustBundles that
+                                        match this signer name. Mutually-exclusive with
+                                        name.  The contents of all selected ClusterTrustBundles
+                                        will be unified and deduplicated.
+                                      type: string
+                                  required:
+                                    - path
+                                  type: object
+                                configMap:
+                                  description: configMap information about the configMap
+                                    data to project
+                                  properties:
+                                    items:
+                                      description: items if unspecified, each key-value
+                                        pair in the Data field of the referenced ConfigMap
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified which
+                                        is not present in the ConfigMap, the volume
+                                        setup will error unless it is marked optional.
+                                        Paths must be relative and may not contain the
+                                        '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: 'mode is Optional: mode bits
                                             used to set permissions on this file.
                                             Must be an octal value between 0000 and
                                             0777 or a decimal value between 0 and
@@ -1961,64 +6968,64 @@ spec:
                                             in conflict with other options that affect
                                             the file mode, like fsGroup, and the result
                                             can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: path is the relative path of
+                                              the file to map the key to. May not be
+                                              an absolute path. May not contain the
+                                              path element '..'. May not start with
+                                              the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info:
                                       https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
-                                    type: string
-                                  optional:
-                                    description: optional specify whether the ConfigMap
-                                      or its keys must be defined
-                                    type: boolean
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              downwardAPI:
-                                description: downwardAPI information about the downwardAPI
-                                  data to project
-                                properties:
-                                  items:
-                                    description: Items is a list of DownwardAPIVolume
-                                      file
+                                      type: string
+                                    optional:
+                                      description: optional specify whether the ConfigMap
+                                        or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                downwardAPI:
+                                  description: downwardAPI information about the downwardAPI
+                                    data to project
+                                  properties:
                                     items:
-                                      description: DownwardAPIVolumeFile represents
-                                        information to create the file containing
-                                        the pod field
-                                      properties:
-                                        fieldRef:
-                                          description: 'Required: Selects a field
+                                      description: Items is a list of DownwardAPIVolume
+                                        file
+                                      items:
+                                        description: DownwardAPIVolumeFile represents
+                                          information to create the file containing
+                                          the pod field
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field
                                             of the pod: only annotations, labels,
                                             name and namespace are supported.'
-                                          properties:
-                                            apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of,
-                                                defaults to "v1".
-                                              type: string
-                                            fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                        mode:
-                                          description: 'Optional: mode bits used to
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the
+                                                  FieldPath is written in terms of,
+                                                  defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select
+                                                  in the specified API version.
+                                                type: string
+                                            required:
+                                              - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            description: 'Optional: mode bits used to
                                             set permissions on this file, must be
                                             an octal value between 0000 and 0777 or
                                             a decimal value between 0 and 511. YAML
@@ -2029,73 +7036,73 @@ spec:
                                             with other options that affect the file
                                             mode, like fsGroup, and the result can
                                             be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: 'Required: Path is  the relative
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: 'Required: Path is  the relative
                                             path name of the file to be created. Must
                                             not be absolute or contain the ''..''
                                             path. Must be utf-8 encoded. The first
                                             item of the relative path must not start
                                             with ''..'''
-                                          type: string
-                                        resourceFieldRef:
-                                          description: 'Selects a resource of the
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the
                                             container: only resources limits and requests
                                             (limits.cpu, limits.memory, requests.cpu
                                             and requests.memory) are currently supported.'
-                                          properties:
-                                            containerName:
-                                              description: 'Container name: required
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
                                                 for volumes, optional for env vars'
-                                              type: string
-                                            divisor:
-                                              anyOf:
-                                              - type: integer
-                                              - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults
-                                                to "1"
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            resource:
-                                              description: 'Required: resource to
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: Specifies the output format
+                                                  of the exposed resources, defaults
+                                                  to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to
                                                 select'
-                                              type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                          x-kubernetes-map-type: atomic
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
-                                type: object
-                              secret:
-                                description: secret information about the secret data
-                                  to project
-                                properties:
-                                  items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced Secret
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
+                                                type: string
+                                            required:
+                                              - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        required:
+                                          - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  description: secret information about the secret data
+                                    to project
+                                  properties:
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
-                                      properties:
-                                        key:
-                                          description: key is the key to project.
-                                          type: string
-                                        mode:
-                                          description: 'mode is Optional: mode bits
+                                      description: items if unspecified, each key-value
+                                        pair in the Data field of the referenced Secret
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified which
+                                        is not present in the Secret, the volume setup
+                                        will error unless it is marked optional. Paths
+                                        must be relative and may not contain the '..'
+                                        path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: 'mode is Optional: mode bits
                                             used to set permissions on this file.
                                             Must be an octal value between 0000 and
                                             0777 or a decimal value between 0 and
@@ -2106,222 +7113,222 @@ spec:
                                             in conflict with other options that affect
                                             the file mode, like fsGroup, and the result
                                             can be other mode bits set.'
-                                          format: int32
-                                          type: integer
-                                        path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
-                                          type: string
-                                      required:
-                                      - key
-                                      - path
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name of the referent. More info:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: path is the relative path of
+                                              the file to map the key to. May not be
+                                              an absolute path. May not contain the
+                                              path element '..'. May not start with
+                                              the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info:
                                       https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                       TODO: Add other useful fields. apiVersion, kind,
                                       uid?'
-                                    type: string
-                                  optional:
-                                    description: optional field specify whether the
-                                      Secret or its key must be defined
-                                    type: boolean
-                                type: object
-                                x-kubernetes-map-type: atomic
-                              serviceAccountToken:
-                                description: serviceAccountToken is information about
-                                  the serviceAccountToken data to project
-                                properties:
-                                  audience:
-                                    description: audience is the intended audience
-                                      of the token. A recipient of a token must identify
-                                      itself with an identifier specified in the audience
-                                      of the token, and otherwise should reject the
-                                      token. The audience defaults to the identifier
-                                      of the apiserver.
-                                    type: string
-                                  expirationSeconds:
-                                    description: expirationSeconds is the requested
-                                      duration of validity of the service account
-                                      token. As the token approaches expiration, the
-                                      kubelet volume plugin will proactively rotate
-                                      the service account token. The kubelet will
-                                      start trying to rotate the token if the token
-                                      is older than 80 percent of its time to live
-                                      or if the token is older than 24 hours.Defaults
-                                      to 1 hour and must be at least 10 minutes.
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    description: path is the path relative to the
-                                      mount point of the file to project the token
-                                      into.
-                                    type: string
-                                required:
-                                - path
-                                type: object
-                            type: object
-                          type: array
-                      type: object
-                    quobyte:
-                      description: quobyte represents a Quobyte mount on the host
-                        that shares a pod's lifetime
-                      properties:
-                        group:
-                          description: group to map volume access to Default is no
-                            group
-                          type: string
-                        readOnly:
-                          description: readOnly here will force the Quobyte volume
-                            to be mounted with read-only permissions. Defaults to
-                            false.
-                          type: boolean
-                        registry:
-                          description: registry represents a single or multiple Quobyte
-                            Registry services specified as a string as host:port pair
-                            (multiple entries are separated with commas) which acts
-                            as the central registry for volumes
-                          type: string
-                        tenant:
-                          description: tenant owning the given Quobyte volume in the
-                            Backend Used with dynamically provisioned Quobyte volumes,
-                            value is set by the plugin
-                          type: string
-                        user:
-                          description: user to map volume access to Defaults to serivceaccount
-                            user
-                          type: string
-                        volume:
-                          description: volume is a string that references an already
-                            created Quobyte volume by name.
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      description: 'rbd represents a Rados Block Device mount on the
+                                      type: string
+                                    optional:
+                                      description: optional field specify whether the
+                                        Secret or its key must be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                serviceAccountToken:
+                                  description: serviceAccountToken is information about
+                                    the serviceAccountToken data to project
+                                  properties:
+                                    audience:
+                                      description: audience is the intended audience
+                                        of the token. A recipient of a token must identify
+                                        itself with an identifier specified in the audience
+                                        of the token, and otherwise should reject the
+                                        token. The audience defaults to the identifier
+                                        of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: expirationSeconds is the requested
+                                        duration of validity of the service account
+                                        token. As the token approaches expiration, the
+                                        kubelet volume plugin will proactively rotate
+                                        the service account token. The kubelet will
+                                        start trying to rotate the token if the token
+                                        is older than 80 percent of its time to live
+                                        or if the token is older than 24 hours.Defaults
+                                        to 1 hour and must be at least 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      description: path is the path relative to the
+                                        mount point of the file to project the token
+                                        into.
+                                      type: string
+                                  required:
+                                    - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        description: quobyte represents a Quobyte mount on the host
+                          that shares a pod's lifetime
+                        properties:
+                          group:
+                            description: group to map volume access to Default is no
+                              group
+                            type: string
+                          readOnly:
+                            description: readOnly here will force the Quobyte volume
+                              to be mounted with read-only permissions. Defaults to
+                              false.
+                            type: boolean
+                          registry:
+                            description: registry represents a single or multiple Quobyte
+                              Registry services specified as a string as host:port pair
+                              (multiple entries are separated with commas) which acts
+                              as the central registry for volumes
+                            type: string
+                          tenant:
+                            description: tenant owning the given Quobyte volume in the
+                              Backend Used with dynamically provisioned Quobyte volumes,
+                              value is set by the plugin
+                            type: string
+                          user:
+                            description: user to map volume access to Defaults to serivceaccount
+                              user
+                            type: string
+                          volume:
+                            description: volume is a string that references an already
+                              created Quobyte volume by name.
+                            type: string
+                        required:
+                          - registry
+                          - volume
+                        type: object
+                      rbd:
+                        description: 'rbd represents a Rados Block Device mount on the
                         host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                      properties:
-                        fsType:
-                          description: 'fsType is the filesystem type of the volume
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume
                             that you want to mount. Tip: Ensure that the filesystem
                             type is supported by the host operating system. Examples:
                             "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
                             if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
                             TODO: how do we prevent errors in the filesystem from
                             compromising the machine'
-                          type: string
-                        image:
-                          description: 'image is the rados image name. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        keyring:
-                          description: 'keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        monitors:
-                          description: 'monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          items:
                             type: string
-                          type: array
-                        pool:
-                          description: 'pool is the rados pool name. Default is rbd.
+                          image:
+                            description: 'image is the rados image name. More info:
+                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'monitors is a collection of Ceph monitors.
                             More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                        readOnly:
-                          description: 'readOnly here will force the ReadOnly setting
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            description: 'pool is the rados pool name. Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting
                             in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: boolean
-                        secretRef:
-                          description: 'secretRef is name of the authentication secret
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is name of the authentication secret
                             for RBDUser. If provided overrides keyring. Default is
                             nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        user:
-                          description: 'user is the rados user name. Default is admin.
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          user:
+                            description: 'user is the rados user name. Default is admin.
                             More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume
-                        attached and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Default is "xfs".
-                          type: string
-                        gateway:
-                          description: gateway is the host address of the ScaleIO
-                            API Gateway.
-                          type: string
-                        protectionDomain:
-                          description: protectionDomain is the name of the ScaleIO
-                            Protection Domain for the configured storage.
-                          type: string
-                        readOnly:
-                          description: readOnly Defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: secretRef references to the secret for ScaleIO
-                            user and other sensitive information. If this is not provided,
-                            Login operation will fail.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        required:
+                          - image
+                          - monitors
+                        type: object
+                      scaleIO:
+                        description: scaleIO represents a ScaleIO persistent volume
+                          attached and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                            type: string
+                          gateway:
+                            description: gateway is the host address of the ScaleIO
+                              API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: protectionDomain is the name of the ScaleIO
+                              Protection Domain for the configured storage.
+                            type: string
+                          readOnly:
+                            description: readOnly Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef references to the secret for ScaleIO
+                              user and other sensitive information. If this is not provided,
+                              Login operation will fail.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        sslEnabled:
-                          description: sslEnabled Flag enable/disable SSL communication
-                            with Gateway, default false
-                          type: boolean
-                        storageMode:
-                          description: storageMode indicates whether the storage for
-                            a volume should be ThickProvisioned or ThinProvisioned.
-                            Default is ThinProvisioned.
-                          type: string
-                        storagePool:
-                          description: storagePool is the ScaleIO Storage Pool associated
-                            with the protection domain.
-                          type: string
-                        system:
-                          description: system is the name of the storage system as
-                            configured in ScaleIO.
-                          type: string
-                        volumeName:
-                          description: volumeName is the name of a volume already
-                            created in the ScaleIO system that is associated with
-                            this volume source.
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      description: 'secret represents a secret that should populate
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sslEnabled:
+                            description: sslEnabled Flag enable/disable SSL communication
+                              with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: storageMode indicates whether the storage for
+                              a volume should be ThickProvisioned or ThinProvisioned.
+                              Default is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: storagePool is the ScaleIO Storage Pool associated
+                              with the protection domain.
+                            type: string
+                          system:
+                            description: system is the name of the storage system as
+                              configured in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: volumeName is the name of a volume already
+                              created in the ScaleIO system that is associated with
+                              this volume source.
+                            type: string
+                        required:
+                          - gateway
+                          - secretRef
+                          - system
+                        type: object
+                      secret:
+                        description: 'secret represents a secret that should populate
                         this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                      properties:
-                        defaultMode:
-                          description: 'defaultMode is Optional: mode bits used to
+                        properties:
+                          defaultMode:
+                            description: 'defaultMode is Optional: mode bits used to
                             set permissions on created files by default. Must be an
                             octal value between 0000 and 0777 or a decimal value between
                             0 and 511. YAML accepts both octal and decimal values,
@@ -2330,26 +7337,26 @@ spec:
                             this setting. This might be in conflict with other options
                             that affect the file mode, like fsGroup, and the result
                             can be other mode bits set.'
-                          format: int32
-                          type: integer
-                        items:
-                          description: items If unspecified, each key-value pair in
-                            the Data field of the referenced Secret will be projected
-                            into the volume as a file whose name is the key and content
-                            is the value. If specified, the listed keys will be projected
-                            into the specified paths, and unlisted keys will not be
-                            present. If a key is specified which is not present in
-                            the Secret, the volume setup will error unless it is marked
-                            optional. Paths must be relative and may not contain the
-                            '..' path or start with '..'.
+                            format: int32
+                            type: integer
                           items:
-                            description: Maps a string key to a path within a volume.
-                            properties:
-                              key:
-                                description: key is the key to project.
-                                type: string
-                              mode:
-                                description: 'mode is Optional: mode bits used to
+                            description: items If unspecified, each key-value pair in
+                              the Data field of the referenced Secret will be projected
+                              into the volume as a file whose name is the key and content
+                              is the value. If specified, the listed keys will be projected
+                              into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in
+                              the Secret, the volume setup will error unless it is marked
+                              optional. Paths must be relative and may not contain the
+                              '..' path or start with '..'.
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: 'mode is Optional: mode bits used to
                                   set permissions on this file. Must be an octal value
                                   between 0000 and 0777 or a decimal value between
                                   0 and 511. YAML accepts both octal and decimal values,
@@ -2358,151 +7365,151 @@ spec:
                                   This might be in conflict with other options that
                                   affect the file mode, like fsGroup, and the result
                                   can be other mode bits set.'
-                                format: int32
-                                type: integer
-                              path:
-                                description: path is the relative path of the file
-                                  to map the key to. May not be an absolute path.
-                                  May not contain the path element '..'. May not start
-                                  with the string '..'.
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        optional:
-                          description: optional field specify whether the Secret or
-                            its keys must be defined
-                          type: boolean
-                        secretName:
-                          description: 'secretName is the name of the secret in the
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path is the relative path of the file
+                                    to map the key to. May not be an absolute path.
+                                    May not contain the path element '..'. May not start
+                                    with the string '..'.
+                                  type: string
+                              required:
+                                - key
+                                - path
+                              type: object
+                            type: array
+                          optional:
+                            description: optional field specify whether the Secret or
+                              its keys must be defined
+                            type: boolean
+                          secretName:
+                            description: 'secretName is the name of the secret in the
                             pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                          type: string
-                      type: object
-                    storageos:
-                      description: storageOS represents a StorageOS volume attached
-                        and mounted on Kubernetes nodes.
-                      properties:
-                        fsType:
-                          description: fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        readOnly:
-                          description: readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                          type: boolean
-                        secretRef:
-                          description: secretRef specifies the secret to use for obtaining
-                            the StorageOS API credentials.  If not specified, default
-                            values will be attempted.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                      storageos:
+                        description: storageOS represents a StorageOS volume attached
+                          and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must
+                              be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef specifies the secret to use for obtaining
+                              the StorageOS API credentials.  If not specified, default
+                              values will be attempted.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        volumeName:
-                          description: volumeName is the human-readable name of the
-                            StorageOS volume.  Volume names are only unique within
-                            a namespace.
-                          type: string
-                        volumeNamespace:
-                          description: volumeNamespace specifies the scope of the
-                            volume within StorageOS.  If no namespace is specified
-                            then the Pod's namespace will be used.  This allows the
-                            Kubernetes name scoping to be mirrored within StorageOS
-                            for tighter integration. Set VolumeName to any name to
-                            override the default behaviour. Set to "default" if you
-                            are not using namespaces within StorageOS. Namespaces
-                            that do not pre-exist within StorageOS will be created.
-                          type: string
-                      type: object
-                    vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached
-                        and mounted on kubelets host machine
-                      properties:
-                        fsType:
-                          description: fsType is filesystem type to mount. Must be
-                            a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified.
-                          type: string
-                        storagePolicyID:
-                          description: storagePolicyID is the storage Policy Based
-                            Management (SPBM) profile ID associated with the StoragePolicyName.
-                          type: string
-                        storagePolicyName:
-                          description: storagePolicyName is the storage Policy Based
-                            Management (SPBM) profile name.
-                          type: string
-                        volumePath:
-                          description: volumePath is the path that identifies vSphere
-                            volume vmdk
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
-            type: object
-          status:
-            description: AmazonCloudWatchAgentStatus defines the observed state of
-              AmazonCloudWatchAgent.
-            properties:
-              image:
-                description: Image indicates the container image to use for the CloudWatch
-                  Agent.
-                type: string
-              messages:
-                description: 'Messages about actions performed by the operator on
-                  this resource. Deprecated: use Kubernetes events instead.'
-                items:
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          volumeName:
+                            description: volumeName is the human-readable name of the
+                              StorageOS volume.  Volume names are only unique within
+                              a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: volumeNamespace specifies the scope of the
+                              volume within StorageOS.  If no namespace is specified
+                              then the Pod's namespace will be used.  This allows the
+                              Kubernetes name scoping to be mirrored within StorageOS
+                              for tighter integration. Set VolumeName to any name to
+                              override the default behaviour. Set to "default" if you
+                              are not using namespaces within StorageOS. Namespaces
+                              that do not pre-exist within StorageOS will be created.
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        description: vsphereVolume represents a vSphere volume attached
+                          and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is filesystem type to mount. Must be
+                              a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: storagePolicyID is the storage Policy Based
+                              Management (SPBM) profile ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: storagePolicyName is the storage Policy Based
+                              Management (SPBM) profile name.
+                            type: string
+                          volumePath:
+                            description: volumePath is the path that identifies vSphere
+                              volume vmdk
+                            type: string
+                        required:
+                          - volumePath
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            status:
+              description: AmazonCloudWatchAgentStatus defines the observed state of
+                AmazonCloudWatchAgent.
+              properties:
+                image:
+                  description: Image indicates the container image to use for the OpenTelemetry
+                    Collector.
                   type: string
-                type: array
-                x-kubernetes-list-type: atomic
-              replicas:
-                description: 'Replicas is currently not being set and might be removed
+                messages:
+                  description: 'Messages about actions performed by the operator on
+                  this resource. Deprecated: use Kubernetes events instead.'
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                replicas:
+                  description: 'Replicas is currently not being set and might be removed
                   in the next version. Deprecated: use "AmazonCloudWatchAgent.Status.Scale.Replicas"
                   instead.'
-                format: int32
-                type: integer
-              scale:
-                description: Scale is the AmazonCloudWatchAgent's scale subresource
-                  status.
-                properties:
-                  replicas:
-                    description: The total number non-terminated pods targeted by
-                      this AmazonCloudWatchAgent's deployment or statefulSet.
-                    format: int32
-                    type: integer
-                  selector:
-                    description: The selector used to match the AmazonCloudWatchAgent's
-                      deployment or statefulSet pods.
-                    type: string
-                  statusReplicas:
-                    description: StatusReplicas is the number of pods targeted by
-                      this AmazonCloudWatchAgent's with a Ready Condition / Total
-                      number of non-terminated pods targeted by this AmazonCloudWatchAgent's
-                      (their labels match the selector). Deployment, Daemonset, StatefulSet.
-                    type: string
-                type: object
-              version:
-                description: Version of the managed CloudWatch Agent (operand)
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.scale.selector
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.scale.replicas
-      status: { }
+                  format: int32
+                  type: integer
+                scale:
+                  description: Scale is the AmazonCloudWatchAgent's scale subresource
+                    status.
+                  properties:
+                    replicas:
+                      description: The total number non-terminated pods targeted by
+                        this AmazonCloudWatchAgent's deployment or statefulSet.
+                      format: int32
+                      type: integer
+                    selector:
+                      description: The selector used to match the AmazonCloudWatchAgent's
+                        deployment or statefulSet pods.
+                      type: string
+                    statusReplicas:
+                      description: StatusReplicas is the number of pods targeted by
+                        this AmazonCloudWatchAgent's with a Ready Condition / Total
+                        number of non-terminated pods targeted by this AmazonCloudWatchAgent's
+                        (their labels match the selector). Deployment, Daemonset, StatefulSet.
+                      type: string
+                  type: object
+                version:
+                  description: Version of the managed OpenTelemetry Collector (operand)
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          labelSelectorPath: .status.scale.selector
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.scale.replicas
+        status: {}

--- a/helm/crds/cloudwatch.aws.amazon.com_instrumentations.yaml
+++ b/helm/crds/cloudwatch.aws.amazon.com_instrumentations.yaml
@@ -4,8 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-agent-operator
   name: instrumentations.cloudwatch.aws.amazon.com
 spec:
   group: cloudwatch.aws.amazon.com
@@ -14,184 +12,62 @@ spec:
     listKind: InstrumentationList
     plural: instrumentations
     shortNames:
-    - otelinst
-    - otelinsts
+      - otelinst
+      - otelinsts
     singular: instrumentation
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .spec.exporter.endpoint
-      name: Endpoint
-      type: string
-    - jsonPath: .spec.sampler.type
-      name: Sampler
-      type: string
-    - jsonPath: .spec.sampler.argument
-      name: Sampler Arg
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Instrumentation is the spec for OpenTelemetry instrumentation.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.exporter.endpoint
+          name: Endpoint
+          type: string
+        - jsonPath: .spec.sampler.type
+          name: Sampler
+          type: string
+        - jsonPath: .spec.sampler.argument
+          name: Sampler Arg
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Instrumentation is the spec for OpenTelemetry instrumentation.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: InstrumentationSpec defines the desired state of OpenTelemetry
-              SDK and instrumentation.
-            properties:
-              env:
-                description: 'Env defines common env vars. There are four layers for
-                  env vars'' definitions and the precedence order is: `original container
-                  env vars` > `language specific env vars` > `common env vars` > `instrument
-                  spec configs'' vars`. If the former var had been defined, then the
-                  other vars would be ignored.'
-                items:
-                  description: EnvVar represents an environment variable present in
-                    a Container.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: InstrumentationSpec defines the desired state of OpenTelemetry
+                SDK and instrumentation.
+              properties:
+                apacheHttpd:
+                  description: ApacheHttpd defines configuration for Apache HTTPD auto-instrumentation.
                   properties:
-                    name:
-                      description: Name of the environment variable. Must be a C_IDENTIFIER.
-                      type: string
-                    value:
-                      description: 'Variable references $(VAR_NAME) are expanded using
-                        the previously defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        Double $$ are reduced to a single $, which allows for escaping
-                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
-                        string literal "$(VAR_NAME)". Escaped references will never
-                        be expanded, regardless of whether the variable exists or
-                        not. Defaults to "".'
-                      type: string
-                    valueFrom:
-                      description: Source for the environment variable's value. Cannot
-                        be used if value is not empty.
-                      properties:
-                        configMapKeyRef:
-                          description: Selects a key of a ConfigMap.
-                          properties:
-                            key:
-                              description: The key to select.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its key
-                                must be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        fieldRef:
-                          description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
-                          properties:
-                            apiVersion:
-                              description: Version of the schema the FieldPath is
-                                written in terms of, defaults to "v1".
-                              type: string
-                            fieldPath:
-                              description: Path of the field to select in the specified
-                                API version.
-                              type: string
-                          required:
-                          - fieldPath
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        resourceFieldRef:
-                          description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
-                          properties:
-                            containerName:
-                              description: 'Container name: required for volumes,
-                                optional for env vars'
-                              type: string
-                            divisor:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: Specifies the output format of the exposed
-                                resources, defaults to "1"
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            resource:
-                              description: 'Required: resource to select'
-                              type: string
-                          required:
-                          - resource
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        secretKeyRef:
-                          description: Selects a key of a secret in the pod's namespace
-                          properties:
-                            key:
-                              description: The key of the secret to select from.  Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret or its key must
-                                be defined
-                              type: boolean
-                          required:
-                          - key
-                          type: object
-                          x-kubernetes-map-type: atomic
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              exporter:
-                description: Exporter defines exporter configuration.
-                properties:
-                  endpoint:
-                    description: Endpoint is address of the collector with OTLP endpoint.
-                    type: string
-                type: object
-              java:
-                description: Java defines configuration for java auto-instrumentation.
-                properties:
-                  env:
-                    description: 'Env defines java specific env vars. There are four
-                      layers for env vars'' definitions and the precedence order is:
-                      `original container env vars` > `language specific env vars`
-                      > `common env vars` > `instrument spec configs'' vars`. If the
-                      former var had been defined, then the other vars would be ignored.'
-                    items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
-                      properties:
-                        name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
-                          type: string
-                        value:
-                          description: 'Variable references $(VAR_NAME) are expanded
+                    attrs:
+                      description: 'Attrs defines Apache HTTPD agent specific attributes.
+                      The precedence is: `agent default attributes` > `instrument
+                      spec attributes` . Attributes are documented at https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
                             using the previously defined environment variables in
                             the container and any service environment variables. If
                             a variable cannot be resolved, the reference in the input
@@ -200,216 +76,1688 @@ spec:
                             "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
                             Escaped references will never be expanded, regardless
                             of whether the variable exists or not. Defaults to "".'
-                          type: string
-                        valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
-                          properties:
-                            configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            fieldRef:
-                              description: 'Selects a field of the pod: supports metadata.name,
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
                                 metadata.namespace, `metadata.labels[''<KEY>'']`,
                                 `metadata.annotations[''<KEY>'']`, spec.nodeName,
                                 spec.serviceAccountName, status.hostIP, status.podIP,
                                 status.podIPs.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
                                 resources limits and requests (limits.cpu, limits.memory,
                                 limits.ephemeral-storage, requests.cpu, requests.memory
                                 and requests.ephemeral-storage) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
                                     optional for env vars'
-                                  type: string
-                                divisor:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                              x-kubernetes-map-type: atomic
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  image:
-                    description: Image is a container image with javaagent auto-instrumentation
-                      JAR.
-                    type: string
-                  resources:
-                    description: Resources describes the compute resource requirements.
-                    properties:
-                      claims:
-                        description: "Claims lists the names of resources, defined
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    configPath:
+                      description: Location of Apache HTTPD server configuration. Needed
+                        only if different from default "/usr/local/apache2/conf"
+                      type: string
+                    env:
+                      description: 'Env defines Apache HTTPD specific env vars. There
+                      are four layers for env vars'' definitions and the precedence
+                      order is: `original container env vars` > `language specific
+                      env vars` > `common env vars` > `instrument spec configs'' vars`.
+                      If the former var had been defined, then the other vars would
+                      be ignored.'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is a container image with Apache SDK and auto-instrumentation.
+                      type: string
+                    resourceRequirements:
+                      description: Resources describes the compute resource requirements.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
                           in spec.resourceClaims, that are used by this container.
                           \n This is an alpha field and requires enabling the DynamicResourceAllocation
                           feature gate. \n This field is immutable. It can only be
                           set for containers."
-                        items:
-                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                          properties:
-                            name:
-                              description: Name must match the name of one entry in
-                                pod.spec.resourceClaims of the Pod where this field
-                                is used. It makes that resource available inside a
-                                container.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
                           resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
                           resources required. If Requests is omitted for a container,
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. Requests cannot exceed
                           Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-              propagators:
-                description: Propagators defines inter-process context propagation
-                  configuration. Values in this list will be set in the OTEL_PROPAGATORS
-                  env var. Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
-                items:
-                  description: Propagator represents the propagation type.
-                  enum:
-                  - tracecontext
-                  - baggage
-                  - b3
-                  - b3multi
-                  - jaeger
-                  - xray
-                  - ottrace
-                  - none
-                  type: string
-                type: array
-              resource:
-                description: Resource defines the configuration for the resource attributes,
-                  as defined by the OpenTelemetry specification.
-                properties:
-                  addK8sUIDAttributes:
-                    description: AddK8sUIDAttributes defines whether K8s UID attributes
-                      should be collected (e.g. k8s.deployment.uid).
-                    type: boolean
-                  resourceAttributes:
-                    additionalProperties:
+                          type: object
+                      type: object
+                    version:
+                      description: Apache HTTPD server version. One of 2.4 or 2.2. Default
+                        is 2.4
                       type: string
-                    description: 'Attributes defines attributes that are added to
-                      the resource. For example environment: dev'
+                    volumeLimitSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: VolumeSizeLimit defines size limit for volume used
+                        for auto-instrumentation. The default size is 200Mi.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                dotnet:
+                  description: DotNet defines configuration for DotNet auto-instrumentation.
+                  properties:
+                    env:
+                      description: 'Env defines DotNet specific env vars. There are
+                      four layers for env vars'' definitions and the precedence order
+                      is: `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is a container image with DotNet SDK and auto-instrumentation.
+                      type: string
+                    resourceRequirements:
+                      description: Resources describes the compute resource requirements.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    volumeLimitSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: VolumeSizeLimit defines size limit for volume used
+                        for auto-instrumentation. The default size is 200Mi.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                env:
+                  description: 'Env defines common env vars. There are four layers for
+                  env vars'' definitions and the precedence order is: `original container
+                  env vars` > `language specific env vars` > `common env vars` > `instrument
+                  spec configs'' vars`. If the former var had been defined, then the
+                  other vars would be ignored.'
+                  items:
+                    description: EnvVar represents an environment variable present in
+                      a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded using
+                        the previously defined environment variables in the container
+                        and any service environment variables. If a variable cannot
+                        be resolved, the reference in the input string will be unchanged.
+                        Double $$ are reduced to a single $, which allows for escaping
+                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
+                        string literal "$(VAR_NAME)". Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value. Cannot
+                          be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP,
+                            status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                              - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                            resources limits and requests (limits.cpu, limits.memory,
+                            limits.ephemeral-storage, requests.cpu, requests.memory
+                            and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                              - resource
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key must
+                                  be defined
+                                type: boolean
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                    required:
+                      - name
                     type: object
-                type: object
-              sampler:
-                description: Sampler defines sampling configuration.
-                properties:
-                  argument:
-                    description: Argument defines sampler argument. The value depends
-                      on the sampler type. For instance for parentbased_traceidratio
-                      sampler type it is a number in range [0..1] e.g. 0.25. The value
-                      will be set in the OTEL_TRACES_SAMPLER_ARG env var.
-                    type: string
-                  type:
-                    description: Type defines sampler type. The value will be set
-                      in the OTEL_TRACES_SAMPLER env var. The value can be for instance
-                      parentbased_always_on, parentbased_always_off, parentbased_traceidratio...
+                  type: array
+                exporter:
+                  description: Exporter defines exporter configuration.
+                  properties:
+                    endpoint:
+                      description: Endpoint is address of the collector with OTLP endpoint.
+                      type: string
+                  type: object
+                go:
+                  description: Go defines configuration for Go auto-instrumentation.
+                    When using Go auto-instrumentation you must provide a value for
+                    the OTEL_GO_AUTO_TARGET_EXE env var via the Instrumentation env
+                    vars or via the instrumentation.opentelemetry.io/otel-go-auto-target-exe
+                    pod annotation. Failure to set this value causes instrumentation
+                    injection to abort, leaving the original pod unchanged.
+                  properties:
+                    env:
+                      description: 'Env defines Go specific env vars. There are four
+                      layers for env vars'' definitions and the precedence order is:
+                      `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is a container image with Go SDK and auto-instrumentation.
+                      type: string
+                    resourceRequirements:
+                      description: Resources describes the compute resource requirements.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    volumeLimitSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: VolumeSizeLimit defines size limit for volume used
+                        for auto-instrumentation. The default size is 200Mi.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                java:
+                  description: Java defines configuration for java auto-instrumentation.
+                  properties:
+                    env:
+                      description: 'Env defines java specific env vars. There are four
+                      layers for env vars'' definitions and the precedence order is:
+                      `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is a container image with javaagent auto-instrumentation
+                        JAR.
+                      type: string
+                    resources:
+                      description: Resources describes the compute resource requirements.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    volumeLimitSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: VolumeSizeLimit defines size limit for volume used
+                        for auto-instrumentation. The default size is 200Mi.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                nginx:
+                  description: Nginx defines configuration for Nginx auto-instrumentation.
+                  properties:
+                    attrs:
+                      description: 'Attrs defines Nginx agent specific attributes. The
+                      precedence order is: `agent default attributes` > `instrument
+                      spec attributes` . Attributes are documented at https://github.com/open-telemetry/opentelemetry-cpp-contrib/tree/main/instrumentation/otel-webserver-module'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    configFile:
+                      description: Location of Nginx configuration file. Needed only
+                        if different from default "/etx/nginx/nginx.conf"
+                      type: string
+                    env:
+                      description: 'Env defines Nginx specific env vars. There are four
+                      layers for env vars'' definitions and the precedence order is:
+                      `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is a container image with Nginx SDK and auto-instrumentation.
+                      type: string
+                    resourceRequirements:
+                      description: Resources describes the compute resource requirements.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    volumeLimitSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: VolumeSizeLimit defines size limit for volume used
+                        for auto-instrumentation. The default size is 200Mi.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                nodejs:
+                  description: NodeJS defines configuration for nodejs auto-instrumentation.
+                  properties:
+                    env:
+                      description: 'Env defines nodejs specific env vars. There are
+                      four layers for env vars'' definitions and the precedence order
+                      is: `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is a container image with NodeJS SDK and auto-instrumentation.
+                      type: string
+                    resourceRequirements:
+                      description: Resources describes the compute resource requirements.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    volumeLimitSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: VolumeSizeLimit defines size limit for volume used
+                        for auto-instrumentation. The default size is 200Mi.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                propagators:
+                  description: Propagators defines inter-process context propagation
+                    configuration. Values in this list will be set in the OTEL_PROPAGATORS
+                    env var. Enum=tracecontext;baggage;b3;b3multi;jaeger;xray;ottrace;none
+                  items:
+                    description: Propagator represents the propagation type.
                     enum:
-                    - always_on
-                    - always_off
-                    - traceidratio
-                    - parentbased_always_on
-                    - parentbased_always_off
-                    - parentbased_traceidratio
-                    - jaeger_remote
-                    - xray
+                      - tracecontext
+                      - baggage
+                      - b3
+                      - b3multi
+                      - jaeger
+                      - xray
+                      - ottrace
+                      - none
                     type: string
-                type: object
-            type: object
-          status:
-            description: InstrumentationStatus defines status of the instrumentation.
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: { }
+                  type: array
+                python:
+                  description: Python defines configuration for python auto-instrumentation.
+                  properties:
+                    env:
+                      description: 'Env defines python specific env vars. There are
+                      four layers for env vars'' definitions and the precedence order
+                      is: `original container env vars` > `language specific env vars`
+                      > `common env vars` > `instrument spec configs'' vars`. If the
+                      former var had been defined, then the other vars would be ignored.'
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in
+                            the container and any service environment variables. If
+                            a variable cannot be resolved, the reference in the input
+                            string will be unchanged. Double $$ are reduced to a single
+                            $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    image:
+                      description: Image is a container image with Python SDK and auto-instrumentation.
+                      type: string
+                    resourceRequirements:
+                      description: Resources describes the compute resource requirements.
+                      properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                          in spec.resourceClaims, that are used by this container.
+                          \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                          feature gate. \n This field is immutable. It can only be
+                          set for containers."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry in
+                                  pod.spec.resourceClaims of the Pod where this field
+                                  is used. It makes that resource available inside a
+                                  container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. Requests cannot exceed
+                          Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    volumeLimitSize:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: VolumeSizeLimit defines size limit for volume used
+                        for auto-instrumentation. The default size is 200Mi.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                resource:
+                  description: Resource defines the configuration for the resource attributes,
+                    as defined by the OpenTelemetry specification.
+                  properties:
+                    addK8sUIDAttributes:
+                      description: AddK8sUIDAttributes defines whether K8s UID attributes
+                        should be collected (e.g. k8s.deployment.uid).
+                      type: boolean
+                    resourceAttributes:
+                      additionalProperties:
+                        type: string
+                      description: 'Attributes defines attributes that are added to
+                      the resource. For example environment: dev'
+                      type: object
+                  type: object
+                sampler:
+                  description: Sampler defines sampling configuration.
+                  properties:
+                    argument:
+                      description: Argument defines sampler argument. The value depends
+                        on the sampler type. For instance for parentbased_traceidratio
+                        sampler type it is a number in range [0..1] e.g. 0.25. The value
+                        will be set in the OTEL_TRACES_SAMPLER_ARG env var.
+                      type: string
+                    type:
+                      description: Type defines sampler type. The value will be set
+                        in the OTEL_TRACES_SAMPLER env var. The value can be for instance
+                        parentbased_always_on, parentbased_always_off, parentbased_traceidratio...
+                      enum:
+                        - always_on
+                        - always_off
+                        - traceidratio
+                        - parentbased_always_on
+                        - parentbased_always_off
+                        - parentbased_traceidratio
+                        - jaeger_remote
+                        - xray
+                      type: string
+                  type: object
+              type: object
+            status:
+              description: InstrumentationStatus defines status of the instrumentation.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
*Issue #, if available:*
CRDs in helm folder were different from `config/crd/bases`.
This difference in crds caused problem in applying podSecurityContext in Windows helm charts.

*Description of changes:*
Copy crd from `config/crd/bases` to `helm/crds/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
