### PR TITLE
Fix issues in helm charts during e2e testing

### DIFF
--- a/helm/templates/cloudwatch-agent-daemonset-windows.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset-windows.yaml
@@ -5,13 +5,12 @@ metadata:
   name: {{ template "cloudwatch-agent.name" . }}-windows
   namespace: {{ .Release.Namespace }}
 spec:
-  securityContext:
+  podSecurityContext:
     windowsOptions:
       hostProcess: true
       runAsUserName: "NT AUTHORITY\\System"
   hostNetwork: true
   image: {{ template "cloudwatch-agent-windows.image" . }}
-  command: ["%CONTAINER_SANDBOX_MOUNT_POINT%/Program Files/Amazon/AmazonCloudWatchAgent/start-amazon-cloudwatch-agent.exe"]
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   nodeSelector:
@@ -45,6 +44,8 @@ spec:
     valueFrom:
       fieldRef:
         fieldPath: metadata.namespace
+  - name: RUN_IN_CONTAINER
+    value: "True"
   - name: RUN_AS_HOST_PROCESS_CONTAINER
     value: "True"
 {{- end }}

--- a/helm/templates/fluent-bit-windows-configmap.yaml
+++ b/helm/templates/fluent-bit-windows-configmap.yaml
@@ -63,21 +63,6 @@ data:
         Refresh_Interval    10
         Read_from_Head      ${READ_FROM_HEAD}
 
-    [FILTER]
-        Name                kubernetes
-        Match               application.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_Tag_Prefix     application.C.var.log.containers.
-        Merge_Log           On
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
-        Labels              Off
-        Annotations         Off
-        Use_Kubelet         On
-        Kubelet_Port        10250
-        Buffer_Size         0
-
     [OUTPUT]
         Name                cloudwatch_logs
         Match               application.*
@@ -133,17 +118,17 @@ data:
     [INPUT]
         Name                winlog
         Channels            EKS, System
-        DB                  /var/fluent-bit/state/flb_system_winlog.db
+        DB                  C:\\var\\fluent-bit\\state\\flb_system_winlog.db
         Interval_Sec        10
 
     [FILTER]
         Name                aws
-        Match               host.*
+        Match               winlog.*
         imds_version        v2
 
     [OUTPUT]
         Name                cloudwatch_logs
-        Match               host.*
+        Match               winlog.*
         region              ${AWS_REGION}
         log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
         log_stream_prefix   ${HOST_NAME}.

--- a/helm/templates/fluent-bit-windows-daemonset.yaml
+++ b/helm/templates/fluent-bit-windows-daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       securityContext:
         windowsOptions:
           hostProcess: true
-          runAsUserName: "NT AUTHORITY\\Local service"
+          runAsUserName: "NT AUTHORITY\\System"
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: windows
@@ -31,7 +31,7 @@ spec:
       - name: fluent-bit
         image: {{ template "fluent-bit-windows.image" . }}
         imagePullPolicy: Always
-        command: ["%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/bin/fluent-bit.exe", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/kinesis.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/firehose.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/cloudwatch.dll", "-c", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/etc/fluent-bit.conf"]
+        command: ["%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/bin/fluent-bit.exe", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/kinesis.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/firehose.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/cloudwatch.dll", "-c", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/configuration/fluent-bit.conf"]
         env:
         - name: AWS_REGION
           value: {{ .Values.region }}
@@ -62,6 +62,13 @@ spec:
           requests:
             cpu: 50m
             memory: 25Mi
+        volumeMounts:
+          - name: fluent-bit-config
+            mountPath: fluent-bit\configuration\
+      volumes:
+        - name: fluent-bit-config
+          configMap:
+            name: fluent-bit-windows-config
       terminationGracePeriodSeconds: 10
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ template "cloudwatch-agent.serviceAccountName" . }}


### PR DESCRIPTION
*Description of changes:*
These updates fix issues found during e2e testing.

1. securityContext is not parsed by operator rather podSecurityContext is parsed and used by operator.
2. Add ENV variable RUN_IN_CONTAINER is set to true
3. `Local service` failed to colect vpc-bridge logs
4. Add missing fluent bit configuration on Windows 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
