### PR TITLE
Disable AppSignal for EKS Windows

### DIFF
--- a/helm/templates/cloudwatch-agent-daemonset-windows.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset-windows.yaml
@@ -18,7 +18,7 @@ spec:
   {{- if .Values.agent.config }}
   config: {{ .Values.agent.config | toJson | quote }}
   {{- else }}
-  config: {{ .Values.agent.defaultConfig | toJson | quote }}
+  config: {{ .Values.agent.windowsDefaultConfig | toJson | quote }}
   {{- end }}
   resources:
     requests:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -152,3 +152,13 @@ agent:
         }
       }
     }
+  windowsDefaultConfig:
+    {
+      "logs": {
+        "metrics_collected": {
+          "kubernetes": {
+            "enhanced_container_insights": true
+          },
+        }
+      }
+    }


### PR DESCRIPTION
*Issue #, if available:*
    AppSignal is having issues around initializing k8s client on EKS Windows
    when running it as Host process container. Similar issues existed for
    CI Windows but workaround was implemented for CI, similar workaround is
    required for AppSignal or We can upgrade container to 1.7 which solves this
    issue.

*Description of changes:*
Removed app_signal configuration from CW config for EKS Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
