### PR TITLE
Logic to generate default cluster_name if not supplied

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Test case for AmazonCloudWatchAgent pod creation
         run: |
-          helm template --namespace amazon-cloudwatch -s templates/cloudwatch-agent-daemonset.yaml ./helm | kubectl apply --namespace amazon-cloudwatch -f -
+          helm template --namespace amazon-cloudwatch -s templates/cloudwatch-agent-daemonset.yaml ./helm --set region=us-west-2 | kubectl apply --namespace amazon-cloudwatch -f -
           sleep 60
           kubectl describe pods -n amazon-cloudwatch
           pod_name="$(kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/component=amazon-cloudwatch-agent,app.kubernetes.io/instance=amazon-cloudwatch.cloudwatch-agent -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -116,7 +116,7 @@ Common labels
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: EKS
+app.kubernetes.io/managed-by: "AmazonCloudWatchAgentOperator"
 {{- end }}
 
 {{/*

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -22,6 +22,11 @@ Helper function to modify cloudwatch-agent config
 {{- define "cloudwatch-agent.config-modifier" -}}
 {{- $configCopy := deepCopy .Values.agent.config }}
 
+{{- $agent := pluck "agent" $configCopy | first }}
+{{- if and (empty $agent) (empty $agent.region) }}
+{{- $agent := set $agent "region" .Values.region }}
+{{- end }}
+
 {{- $appSignals := pluck "app_signals" $configCopy.logs.metrics_collected | first }}
 {{- if empty $appSignals.hosted_in }}
 {{- $appSignals := set $appSignals "hosted_in" (include "kubernetes-cluster.name" .) }}
@@ -51,6 +56,8 @@ Helper function to modify default agent config
 */}}
 {{- define "cloudwatch-agent.modify-default-config" -}}
 {{- $configCopy := deepCopy .Values.agent.defaultConfig }}
+{{- $agent := pluck "agent" $configCopy | first }}
+{{- $agent := set $agent "region" .Values.region }}
 {{- $appSignals := pluck "app_signals" $configCopy.logs.metrics_collected | first }}
 {{- $appSignals := set $appSignals "hosted_in" (include "kubernetes-cluster.name" .) }}
 {{- $containerInsights := pluck "kubernetes" $configCopy.logs.metrics_collected | first }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -56,8 +56,8 @@ Helper function to modify default agent config
 */}}
 {{- define "cloudwatch-agent.modify-default-config" -}}
 {{- $configCopy := deepCopy .Values.agent.defaultConfig }}
-{{- $agent := pluck "agent" $configCopy | first }}
-{{- $agent := set $agent "region" .Values.region }}
+{{- $agentRegion := dict "region" .Values.region }}
+{{- $agent := set $configCopy "agent" $agentRegion }}
 {{- $appSignals := pluck "app_signals" $configCopy.logs.metrics_collected | first }}
 {{- $appSignals := set $appSignals "hosted_in" (include "kubernetes-cluster.name" .) }}
 {{- $containerInsights := pluck "kubernetes" $configCopy.logs.metrics_collected | first }}
@@ -116,7 +116,7 @@ Common labels
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: "AmazonCloudWatchAgentOperator"
+app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
 {{- end }}
 
 {{/*

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -9,7 +9,7 @@ Expand the name of the chart.
 Name of k8s cluster
 */}}
 {{- define "kubernetes-cluster.name" -}}
-{{- if eq .Values.clusterName "EKS_CLUSTER_NAME" }}
+{{- if empty .Values.clusterName }}
 {{- default "" (printf "k8s-cluster-%s" (sha256sum .Release.Name | trunc 7)) }}
 {{- else }}
 {{- default "" .Values.clusterName }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -6,6 +6,59 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Name of k8s cluster
+*/}}
+{{- define "kubernetes-cluster.name" -}}
+{{- if eq .Values.clusterName "EKS_CLUSTER_NAME" }}
+{{- default "" (printf "k8s-cluster-%s" (sha256sum .Release.Name | trunc 7)) }}
+{{- else }}
+{{- default "" .Values.clusterName }}
+{{- end }}
+{{- end }}
+
+{{/*
+Helper function to modify cloudwatch-agent config
+*/}}
+{{- define "cloudwatch-agent.config-modifier" -}}
+{{- $configCopy := deepCopy .Values.agent.config }}
+
+{{- $appSignals := pluck "app_signals" $configCopy.logs.metrics_collected | first }}
+{{- if empty $appSignals.hosted_in }}
+{{- $appSignals := set $appSignals "hosted_in" (include "kubernetes-cluster.name" .) }}
+{{- end }}
+
+{{- $containerInsights := pluck "kubernetes" $configCopy.logs.metrics_collected | first }}
+{{- if empty $containerInsights.cluster_name }}
+{{- $containerInsights := set $containerInsights "cluster_name" (include "kubernetes-cluster.name" .) }}
+{{- end }}
+
+{{- default ""  $configCopy | toJson | quote }}
+{{- end }}
+
+{{/*
+Helper function to modify customer supplied agent config if ContainerInsights or ApplicationSignals is enabled
+*/}}
+{{- define "cloudwatch-agent.supplied-config" -}}
+{{- if or (hasKey .Values.agent.config.logs "app_signals") (and (hasKey .Values.agent.config.logs "metrics_collected") (hasKey .Values.agent.config.logs.metrics_collected "kubernetes")) }}
+{{- include "cloudwatch-agent.config-modifier" . }}
+{{- else }}
+{{- default "" .Values.agent.config | toJson | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Helper function to modify default agent config
+*/}}
+{{- define "cloudwatch-agent.modify-default-config" -}}
+{{- $configCopy := deepCopy .Values.agent.defaultConfig }}
+{{- $appSignals := pluck "app_signals" $configCopy.logs.metrics_collected | first }}
+{{- $appSignals := set $appSignals "hosted_in" (include "kubernetes-cluster.name" .) }}
+{{- $containerInsights := pluck "kubernetes" $configCopy.logs.metrics_collected | first }}
+{{- $containerInsights := set $containerInsights "cluster_name" (include "kubernetes-cluster.name" .) }}
+{{- default ""  $configCopy | toJson | quote }}
+{{- end }}
+
+{{/*
 Name for cloudwatch-agent
 */}}
 {{- define "cloudwatch-agent.name" -}}

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.agent.enabled }}
-{{- if eq .Values.region "AWS_REGION_NAME" }}
+{{- if empty .Values.region }}
 {{- fail "region is a required field" }}
 {{- end }}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.agent.enabled }}
+{{- if eq .Values.region "AWS_REGION_NAME" }}
+{{- fail "region is a required field" }}
+{{- end }}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -9,9 +9,9 @@ spec:
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   {{- if .Values.agent.config }}
-  config: {{ .Values.agent.config | toJson | quote }}
+  config: {{ template "cloudwatch-agent.supplied-config" . }}
   {{- else }}
-  config: {{ .Values.agent.defaultConfig | toJson | quote }}
+  config: {{ template "cloudwatch-agent.modify-default-config" . }}
   {{- end }}
   resources:
     requests:

--- a/helm/templates/fluent-bit-daemonset.yaml
+++ b/helm/templates/fluent-bit-daemonset.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.region "AWS_REGION_NAME" }}
+{{- if empty .Values.region }}
 {{- fail "region is a required field" }}
 {{- end }}
 apiVersion: apps/v1

--- a/helm/templates/fluent-bit-daemonset.yaml
+++ b/helm/templates/fluent-bit-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         - name: AWS_REGION
           value: {{ .Values.region }}
         - name: CLUSTER_NAME
-          value: {{ .Values.clusterName | quote }}
+          value: {{ include "kubernetes-cluster.name" . | quote }}
         - name: READ_FROM_HEAD
           value: "Off"
         - name: READ_FROM_TAIL

--- a/helm/templates/fluent-bit-daemonset.yaml
+++ b/helm/templates/fluent-bit-daemonset.yaml
@@ -1,3 +1,6 @@
+{{- if eq .Values.region "AWS_REGION_NAME" }}
+{{- fail "region is a required field" }}
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -28,7 +31,7 @@ spec:
         - name: AWS_REGION
           value: {{ .Values.region }}
         - name: CLUSTER_NAME
-          value: {{ include "kubernetes-cluster.name" . | quote }}
+          value: {{ include "kubernetes-cluster.name" . }}
         - name: READ_FROM_HEAD
           value: "Off"
         - name: READ_FROM_TAIL

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,11 +11,11 @@ nameOverride: ""
 ## Reference one or more secrets to be used when pulling images from authenticated repositories.
 imagePullSecrets: [ ]
 
-## Provide the ClusterName (optional when installing via EKS add-on)
-clusterName: EKS_CLUSTER_NAME
+## Provide the ClusterName
+clusterName:
 
-## Provide the Region (optional when installing via EKS add-on)
-region: AWS_REGION_NAME
+## Provide the Region
+region:
 
 containerLogs:
   enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -137,6 +137,8 @@ agent:
   config: # optional config that can be provided to override the defaultConfig
   defaultConfig:
     {
+      "agent": {
+      },
       "logs": {
         "metrics_collected": {
           "kubernetes": {

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -137,8 +137,6 @@ agent:
   config: # optional config that can be provided to override the defaultConfig
   defaultConfig:
     {
-      "agent": {
-      },
       "logs": {
         "metrics_collected": {
           "kubernetes": {

--- a/integration-tests/terraform/helm/main.tf
+++ b/integration-tests/terraform/helm/main.tf
@@ -115,7 +115,11 @@ resource "helm_release" "this" {
   name = "amazon-cloudwatch-observability"
   namespace = "amazon-cloudwatch"
   create_namespace = true
-  chart      = "${var.helm_dir}" 
+  chart      = "${var.helm_dir}"
+  set {
+    name  = "region"
+    value = "${var.region}"
+  }
 }
 
 resource "null_resource" "validator" {


### PR DESCRIPTION
*Description of changes:*
1. Implement logic to generate a default cluster-name (generated using the release name) if not supplied in Helm chart. This cluster name will be passed down to the cloudwatch-agent and fluent-bit config
2. Marking region as a required field. this region will be passed down to both the CWA and fluent-bit config

*Testing*
cluster_name is not provided, attaching snippets rather than the entire YAML
```
CWA --
  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300031.1b317
  mode: daemonset
  serviceAccount: cloudwatch-agent
  config: "{\"agent\":{\"region\":\"us-east-1\"},\"logs\":{\"metrics_collected\":{\"app_signals\":{\"hosted_in\":\"k8s-cluster-0ba3ba5\"},\"kubernetes\":{\"cluster_name\":\"k8s-cluster-0ba3ba5\",\"enhanced_container_insights\":true}}},\"traces\":{\"traces_collected\":{\"app_signals\":{}}}}"

FluentBit --
        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.31.12.20230911
        imagePullPolicy: Always
        env:
        - name: AWS_REGION
          value: us-east-1
        - name: CLUSTER_NAME
          value: k8s-cluster-0ba3ba5
```

cluster_name is provided via the helm chart, attaching snippets rather than the entire YAML
```
helm upgrade --install  --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set clusterName=cloudwatchagent-operator --set region=us-east-1


CWA --
  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300031.1b317
  mode: daemonset
  serviceAccount: cloudwatch-agent
  config: "{\"logs\":{\"metrics_collected\":{\"app_signals\":{\"hosted_in\":\"k8s-cluster-0ba3ba5\"},\"kubernetes\":{\"cluster_name\":\"k8s-cluster-0ba3ba5\",\"enhanced_container_insights\":true}}},\"traces\":{\"traces_collected\":{\"app_signals\":{}}}}"

FluentBit --
        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.31.12.20230911
        imagePullPolicy: Always
        env:
        - name: AWS_REGION
          value: us-east-1
        - name: CLUSTER_NAME
          value: "k8s-cluster-0ba3ba5"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
