### PR TITLE
Add namespace webhook for annotations

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -70,6 +70,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /mutate-v1-namespace
+  failurePolicy: Ignore
+  name: mnamespace.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - namespaces
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /mutate-v1-workload
   failurePolicy: Ignore
   name: mworkload.kb.io

--- a/internal/webhook/namespacemutation/webhookhandler.go
+++ b/internal/webhook/namespacemutation/webhookhandler.go
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package namespacemutation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/auto"
+)
+
+// +kubebuilder:webhook:path=/mutate-v1-namespace,mutating=true,failurePolicy=ignore,groups="",resources=namespaces,verbs=create;update,versions=v1,name=mnamespace.kb.io,sideEffects=none,admissionReviewVersions=v1
+
+var _ admission.Handler = (*handler)(nil)
+
+type handler struct {
+	decoder            *admission.Decoder
+	annotationMutators *auto.AnnotationMutators
+}
+
+func NewWebhookHandler(decoder *admission.Decoder, annotationMutators *auto.AnnotationMutators) admission.Handler {
+	return &handler{
+		decoder:            decoder,
+		annotationMutators: annotationMutators,
+	}
+}
+
+func (h *handler) Handle(_ context.Context, req admission.Request) admission.Response {
+	namespace := &corev1.Namespace{}
+	err := h.decoder.Decode(req, namespace)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	h.annotationMutators.MutateObject(namespace)
+	marshaledNamespace, err := json.Marshal(namespace)
+	if err != nil {
+		res := admission.Errored(http.StatusInternalServerError, err)
+		res.Allowed = true
+		return res
+	}
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledNamespace)
+}

--- a/internal/webhook/namespacemutation/webhookhandler_test.go
+++ b/internal/webhook/namespacemutation/webhookhandler_test.go
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package namespacemutation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
+	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/auto"
+)
+
+func TestHandle(t *testing.T) {
+	// prepare
+	client := fake.NewFakeClient()
+	decoder := admission.NewDecoder(scheme.Scheme)
+	autoAnnotationConfig := auto.AnnotationConfig{
+		Java: auto.AnnotationResources{
+			Namespaces: []string{"auto-java"},
+		},
+	}
+	mutators := auto.NewAnnotationMutators(
+		client,
+		client,
+		logr.Logger{},
+		autoAnnotationConfig,
+		instrumentation.NewTypeSet(instrumentation.TypeJava),
+	)
+	h := NewWebhookHandler(decoder, mutators)
+	for _, testCase := range []struct {
+		req      admission.Request
+		name     string
+		expected int32
+		allowed  bool
+	}{
+		{
+			name:     "empty payload",
+			req:      admission.Request{},
+			expected: http.StatusBadRequest,
+			allowed:  false,
+		},
+		{
+			name: "valid workload payload",
+			req: func() admission.Request {
+				ns := corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "auto-java",
+					},
+				}
+				encoded, err := json.Marshal(ns)
+				require.NoError(t, err)
+
+				return admission.Request{
+					AdmissionRequest: admv1.AdmissionRequest{
+						Object: runtime.RawExtension{
+							Raw: encoded,
+						},
+					},
+				}
+			}(),
+			expected: http.StatusOK,
+			allowed:  true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// test
+			res := h.Handle(context.Background(), testCase.req)
+
+			// verify
+			assert.Equal(t, testCase.allowed, res.Allowed)
+			if !testCase.allowed {
+				assert.NotNil(t, res.AdmissionResponse.Result)
+				assert.Equal(t, testCase.expected, res.AdmissionResponse.Result.Code)
+			}
+		})
+	}
+}

--- a/internal/webhook/workloadmutation/webhookhandler.go
+++ b/internal/webhook/workloadmutation/webhookhandler.go
@@ -10,12 +10,10 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/auto"
 )
 
@@ -31,20 +29,14 @@ type WebhookHandler interface {
 
 // the implementation.
 type workloadMutationWebhook struct {
-	client             client.Client
 	decoder            *admission.Decoder
-	logger             logr.Logger
-	config             config.Config
 	annotationMutators *auto.AnnotationMutators
 }
 
 // NewWebhookHandler creates a new WorkloadWebhookHandler.
-func NewWebhookHandler(cfg config.Config, logger logr.Logger, decoder *admission.Decoder, cl client.Client, annotationMutators *auto.AnnotationMutators) WebhookHandler {
+func NewWebhookHandler(decoder *admission.Decoder, annotationMutators *auto.AnnotationMutators) WebhookHandler {
 	return &workloadMutationWebhook{
-		config:             cfg,
 		decoder:            decoder,
-		logger:             logger,
-		client:             cl,
 		annotationMutators: annotationMutators,
 	}
 }

--- a/internal/webhook/workloadmutation/webhookhandler_test.go
+++ b/internal/webhook/workloadmutation/webhookhandler_test.go
@@ -19,17 +19,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/auto"
 )
 
 var (
 	k8sClient client.Client
-	logger    = logf.Log.WithName("unit-tests")
 )
 
 func TestHandle(t *testing.T) {
@@ -119,7 +116,6 @@ func TestHandle(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// prepare
-			cfg := config.New()
 			decoder := admission.NewDecoder(scheme.Scheme)
 			autoAnnotationConfig := auto.AnnotationConfig{
 				Java: auto.AnnotationResources{
@@ -133,7 +129,7 @@ func TestHandle(t *testing.T) {
 				autoAnnotationConfig,
 				instrumentation.NewTypeSet(instrumentation.TypeJava),
 			)
-			injector := NewWebhookHandler(cfg, logger, decoder, k8sClient, mutators)
+			injector := NewWebhookHandler(decoder, mutators)
 
 			// test
 			res := injector.Handle(context.Background(), tt.req)

--- a/main.go
+++ b/main.go
@@ -11,8 +11,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/namespacemutation"
-
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/spf13/pflag"
@@ -34,6 +32,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-operator/controllers"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/version"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/namespacemutation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/podmutation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/workloadmutation"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/featuregate"

--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/namespacemutation"
+
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/spf13/pflag"
@@ -206,7 +208,10 @@ func main() {
 				),
 			)
 			mgr.GetWebhookServer().Register("/mutate-v1-workload", &webhook.Admission{
-				Handler: workloadmutation.NewWebhookHandler(cfg, ctrl.Log.WithName("workload-webhook"), decoder, mgr.GetClient(), autoAnnotationMutators)})
+				Handler: workloadmutation.NewWebhookHandler(decoder, autoAnnotationMutators)})
+			mgr.GetWebhookServer().Register("/mutate-v1-namespace", &webhook.Admission{
+				Handler: namespacemutation.NewWebhookHandler(decoder, autoAnnotationMutators),
+			})
 			setupLog.Info("Starting auto-annotation")
 			go autoAnnotationMutators.MutateAndPatchAll(ctx)
 		}

--- a/pkg/instrumentation/auto/annotation.go
+++ b/pkg/instrumentation/auto/annotation.go
@@ -23,7 +23,8 @@ const (
 	defaultAnnotationValue = "true"
 )
 
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;watch;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;patch
+// +kubebuilder:rbac:groups="apps",resources=daemonsets;deployments;statefulsets,verbs=list;patch
 
 // AnnotationMutators contains functions that can be used to mutate annotations
 // on all supported objects based on the configured mutators.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds a webhook to handle creates/updates to namespaces. If a namespace that is configured for auto-annotation is created or modified, the webhook will attempt to update the annotations on it.

*Testing:*
Set the auto-annotation configuration.
```
> kubectl set env deployment/cloudwatch-controller-manager AUTO_ANNOTATION_CONFIG="{\"java\":{\"namespaces\":[\"coffee-shop\"]},\"python\":{\"namespaces\":[\"snake-skin\"]}}" -n amazon-cloudwatch
deployment.apps/cloudwatch-controller-manager env updated
```
Created namespace.
```
> kubectl create ns snake-skin
namespace/snake-skin created
```
Namespace was annotated.
```
kubectl describe ns snake-skin
Name:         snake-skin
Labels:       kubernetes.io/metadata.name=snake-skin
Annotations:  cloudwatch.aws.amazon.com/auto-annotate-python: true
              instrumentation.opentelemetry.io/inject-python: true
Status:       Active

No resource quota.

No LimitRange resource.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
