### PR TITLE
Update SMP config names to AppSignals with backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ metadata:
   namespace: default # use a namespace with pods you'd like to inject
 spec:
   exporter:
-    endpoint: http://cloudwatch-agent.amazon-cloudwatch:4317
+    endpoint: http://cloudwatch-agent.amazon-cloudwatch:4315
   propagators:
     - tracecontext
     - baggage
@@ -134,8 +134,10 @@ spec:
     env:
       - name: OTEL_METRICS_EXPORTER
         value: "none"
-      - name: OTEL_SMP_ENABLED
+      - name: OTEL_AWS_APP_SIGNALS_ENABLED
         value: "true"
+      - name: OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT
+        value: "http://cloudwatch-agent.amazon-cloudwatch:4315"
 EOF
 ```
 

--- a/integration-tests/manifests/cmd/default_instrumentation_env_variables.json
+++ b/integration-tests/manifests/cmd/default_instrumentation_env_variables.json
@@ -1,10 +1,12 @@
 {
   "OTEL_SMP_ENABLED": "true",
+  "OTEL_AWS_APP_SIGNALS_ENABLED": "true",
   "OTEL_TRACES_SAMPLER_ARG": "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000",
   "OTEL_TRACES_SAMPLER": "xray",
   "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
   "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces",
   "OTEL_AWS_SMP_EXPORTER_ENDPOINT": "http://cloudwatch-agent.amazon-cloudwatch:4315",
+  "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT": "http://cloudwatch-agent.amazon-cloudwatch:4315",
   "OTEL_METRICS_EXPORTER": "none",
   "JAVA_TOOL_OPTIONS": "-javaagent:/otel-auto-instrumentation-java/javaagent.jar"
 }

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -19,8 +19,10 @@ const (
 	defaultNamespace      = "default"
 	defaultKind           = "Instrumentation"
 
-	otelSampleEnabledKey                   = "OTEL_SMP_ENABLED"
-	otelSampleEnabledDefaultValue          = "true"
+	otelSampleEnabledKey                   = "OTEL_SMP_ENABLED" //TODO: remove in favor of new name once safe
+	otelSampleEnabledDefaultValue          = "true" //TODO: remove in favor of new name once safe
+	otelAppSignalsEnabledKey               = "OTEL_AWS_APP_SIGNALS_ENABLED"
+	otelAppSignalsEnabledDefaultValue      = "true"
 	otelTracesSamplerArgKey                = "OTEL_TRACES_SAMPLER_ARG"
 	otelTracesSamplerArgDefaultValue       = "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"
 	otelTracesSamplerKey                   = "OTEL_TRACES_SAMPLER"
@@ -29,8 +31,10 @@ const (
 	otelExporterOtlpProtocolValue          = "http/protobuf"
 	otelExporterTracesEndpointKey          = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
 	otelExporterTracesEndpointDefaultValue = "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"
-	otelExporterSmpEndpointKey             = "OTEL_AWS_SMP_EXPORTER_ENDPOINT"
-	otelExporterSmpEndpointDefaultValue    = "http://cloudwatch-agent.amazon-cloudwatch:4315"
+	otelExporterSmpEndpointKey             = "OTEL_AWS_SMP_EXPORTER_ENDPOINT" //TODO: remove in favor of new name once safe
+	otelExporterSmpEndpointDefaultValue    = "http://cloudwatch-agent.amazon-cloudwatch:4315" //TODO: remove in favor of new name once safe
+	otelExporterAppSignalsEndpointKey      = "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT"
+	otelExporterAppSignalsEndpointDefaultValue = "http://cloudwatch-agent.amazon-cloudwatch:4315"
 	otelExporterMetricKey                  = "OTEL_METRICS_EXPORTER"
 	otelExporterMetricDefaultValue         = "none"
 
@@ -70,23 +74,25 @@ func getDefaultInstrumentation() (*v1alpha1.Instrumentation, error) {
 			Java: v1alpha1.Java{
 				Image: javaInstrumentationImage,
 				Env: []corev1.EnvVar{
-					{Name: otelSampleEnabledKey, Value: otelSampleEnabledDefaultValue},
+					{Name: otelSampleEnabledKey, Value: otelSampleEnabledDefaultValue}, //TODO: remove in favor of new name once safe
+					{Name: otelAppSignalsEnabledKey, Value: otelAppSignalsEnabledDefaultValue},
 					{Name: otelTracesSamplerArgKey, Value: otelTracesSamplerArgDefaultValue},
 					{Name: otelTracesSamplerKey, Value: otelTracesSamplerDefaultValue},
 					{Name: otelExporterOtlpProtocolKey, Value: otelExporterOtlpProtocolValue},
 					{Name: otelExporterTracesEndpointKey, Value: otelExporterTracesEndpointDefaultValue},
-					{Name: otelExporterSmpEndpointKey, Value: otelExporterSmpEndpointDefaultValue},
+					{Name: otelExporterSmpEndpointKey, Value: otelExporterSmpEndpointDefaultValue}, //TODO: remove in favor of new name once safe
+					{Name: otelExporterAppSignalsEndpointKey, Value: otelExporterAppSignalsEndpointDefaultValue},
 					{Name: otelExporterMetricKey, Value: otelExporterMetricDefaultValue},
 				},
 			},
 			Python: v1alpha1.Python{
 				Image: pythonInstrumentationImage,
 				Env: []corev1.EnvVar{
-					{Name: otelSampleEnabledKey, Value: otelSampleEnabledDefaultValue},
+					{Name: otelAppSignalsEnabledKey, Value: otelAppSignalsEnabledDefaultValue},
 					{Name: otelTracesSamplerArgKey, Value: otelTracesSamplerArgDefaultValue},
 					{Name: otelExporterOtlpProtocolKey, Value: otelExporterOtlpProtocolValue},
 					{Name: otelExporterTracesEndpointKey, Value: otelExporterTracesEndpointDefaultValue},
-					{Name: otelExporterSmpEndpointKey, Value: otelExporterSmpEndpointDefaultValue},
+					{Name: otelExporterAppSignalsEndpointKey, Value: otelExporterAppSignalsEndpointDefaultValue},
 					{Name: otelExporterMetricKey, Value: otelExporterMetricDefaultValue},
 					{Name: otelPythonDistro, Value: otelPythonDistroDefaultValue},
 					{Name: otelPythonConfigurator, Value: otelPythonConfiguratorDefaultValue},

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -51,23 +51,25 @@ func TestGetInstrumentationInstanceFromNameSpaceDefault(t *testing.T) {
 			Java: v1alpha1.Java{
 				Image: defaultJavaInstrumentationImage,
 				Env: []corev1.EnvVar{
-					{Name: otelSampleEnabledKey, Value: otelSampleEnabledDefaultValue},
+					{Name: otelSampleEnabledKey, Value: otelSampleEnabledDefaultValue}, //TODO: remove in favor of new name once safe
+					{Name: otelAppSignalsEnabledKey, Value: otelAppSignalsEnabledDefaultValue},
 					{Name: otelTracesSamplerArgKey, Value: otelTracesSamplerArgDefaultValue},
 					{Name: otelTracesSamplerKey, Value: otelTracesSamplerDefaultValue},
 					{Name: otelExporterOtlpProtocolKey, Value: otelExporterOtlpProtocolValue},
 					{Name: otelExporterTracesEndpointKey, Value: otelExporterTracesEndpointDefaultValue},
-					{Name: otelExporterSmpEndpointKey, Value: otelExporterSmpEndpointDefaultValue},
+					{Name: otelExporterSmpEndpointKey, Value: otelExporterSmpEndpointDefaultValue}, //TODO: remove in favor of new name once safe
+					{Name: otelExporterAppSignalsEndpointKey, Value: otelExporterAppSignalsEndpointDefaultValue},
 					{Name: otelExporterMetricKey, Value: otelExporterMetricDefaultValue},
 				},
 			},
 			Python: v1alpha1.Python{
 				Image: defaultPythonInstrumentationImage,
 				Env: []corev1.EnvVar{
-					{Name: otelSampleEnabledKey, Value: otelSampleEnabledDefaultValue},
+					{Name: otelAppSignalsEnabledKey, Value: otelAppSignalsEnabledDefaultValue},
 					{Name: otelTracesSamplerArgKey, Value: otelTracesSamplerArgDefaultValue},
 					{Name: otelExporterOtlpProtocolKey, Value: otelExporterOtlpProtocolValue},
 					{Name: otelExporterTracesEndpointKey, Value: otelExporterTracesEndpointDefaultValue},
-					{Name: otelExporterSmpEndpointKey, Value: otelExporterSmpEndpointDefaultValue},
+					{Name: otelExporterAppSignalsEndpointKey, Value: otelExporterAppSignalsEndpointDefaultValue},
 					{Name: otelExporterMetricKey, Value: otelExporterMetricDefaultValue},
 					{Name: otelPythonDistro, Value: otelPythonDistroDefaultValue},
 					{Name: otelPythonConfigurator, Value: otelPythonConfiguratorDefaultValue},


### PR DESCRIPTION
*Issue #, if available:*
We are changing SMP to AppSIgnals. See related PR on ADOT Java: https://github.com/aws-observability/aws-otel-java-instrumentation/pull/744

*Description of changes:*
- Added new AppSignals configs for java *in addition* to existing SMP configs to maintain compatibility with users on older version of ADOT Java.
- Updated SMP config to AppSignal for Python

**Note**: Once we are sure that all users are upgraded to new version of ADOT Java, the SMP configs should be removed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
