### PR TITLE
Helm updates to add autoAnnotationConfig and Namespace/Workload Webhooks

### DIFF
--- a/helm/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
+++ b/helm/templates/admission-webhooks/operator-webhook-with-cert-manager.yaml
@@ -95,6 +95,66 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-namespace
+  failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
+  name: mnamespace.kb.io
+    {{- if .Values.admissionWebhooks.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml .Values.admissionWebhooks.namespaceSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.admissionWebhooks.objectSelector }}
+  objectSelector:
+    {{- toYaml .Values.admissionWebhooks.objectSelector | nindent 6 }}
+    {{- end }}
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - namespaces
+  sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-workload
+  failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
+  name: mworkload.kb.io
+    {{- if .Values.admissionWebhooks.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml .Values.admissionWebhooks.namespaceSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.admissionWebhooks.objectSelector }}
+  objectSelector:
+    {{- toYaml .Values.admissionWebhooks.objectSelector | nindent 6 }}
+    {{- end }}
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - daemonsets
+    - deployments
+    - statefulsets
+  sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/helm/templates/admission-webhooks/operator-webhook.yaml
+++ b/helm/templates/admission-webhooks/operator-webhook.yaml
@@ -111,6 +111,68 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-namespace
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
+  name: mnamespace.kb.io
+  {{- if .Values.admissionWebhooks.namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml .Values.admissionWebhooks.namespaceSelector | nindent 6 }}
+  {{- end }}
+  {{- if .Values.admissionWebhooks.objectSelector }}
+  objectSelector:
+  {{- toYaml .Values.admissionWebhooks.objectSelector | nindent 6 }}
+  {{- end }}
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - namespaces
+  sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: {{ template "amazon-cloudwatch-observability.webhookServiceName" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-workload
+    caBundle: {{ $ca.Cert | b64enc }}
+  failurePolicy: {{ .Values.admissionWebhooks.pods.failurePolicy }}
+  name: mworkload.kb.io
+  {{- if .Values.admissionWebhooks.namespaceSelector }}
+  namespaceSelector:
+  {{- toYaml .Values.admissionWebhooks.namespaceSelector | nindent 6 }}
+  {{- end }}
+  {{- if .Values.admissionWebhooks.objectSelector }}
+  objectSelector:
+  {{- toYaml .Values.admissionWebhooks.objectSelector | nindent 6 }}
+  {{- end }}
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - daemonsets
+    - deployments
+    - statefulsets
+  sideEffects: None
+  timeoutSeconds: {{ .Values.admissionWebhooks.timeoutSeconds }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/helm/templates/operator-clusterrole.yaml
+++ b/helm/templates/operator-clusterrole.yaml
@@ -11,7 +11,7 @@ rules:
   verbs: [ "create", "patch" ]
 - apiGroups: [ "" ]
   resources: [ "namespaces" ]
-  verbs: [ "list","watch" ]
+  verbs: [ "get","list","patch","update","watch" ]
 - apiGroups: [ "" ]
   resources: [ "serviceaccounts" ]
   verbs: [ "create","delete","get","list","patch","update","watch" ]

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
-        - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotation | toJson) | quote }}
+        - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
         - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
         command:

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       containers:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
+        - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
         - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
         command:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,7 +50,7 @@ manager:
     python:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python
       tag: 0.43b0
-  autoAnnotation:
+  autoAnnotateAutoInstrumentation:
     java:
       namespaces: [ ]
       deployments: [ ]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,6 +50,17 @@ manager:
     python:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-python
       tag: 0.43b0
+  autoAnnotation:
+    java:
+      namespaces: [ ]
+      deployments: [ ]
+      daemonsets: [ ]
+      statefulsets: [ ]
+    python:
+      namespaces: [ ]
+      deployments: [ ]
+      daemonsets: [ ]
+      statefulsets: [ ]
   ports:
     containerPort: 9443
     metricsPort: 8080


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes:* Updates to helm chart:
* Add mutating webhook definitions for namespace and workload mutators
* Add autoAnnotation config and pass it to the controller manager
* Update RBAC permissions to allow mutating namespaces

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
