### PR TITLE
Passing cluster-name as a string in the fluentbit daemon-set

### DIFF
--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.agent.enabled }}
-{{- if empty .Values.region }}
-{{- fail "region is a required field" }}
-{{- end }}
+{{- $region := .Values.region | required ".Values.region is required." -}}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
 metadata:
@@ -12,9 +10,9 @@ spec:
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   {{- if .Values.agent.config }}
-  config: {{ template "cloudwatch-agent.supplied-config" . }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.config) . ) }}
   {{- else }}
-  config: {{ template "cloudwatch-agent.modify-default-config" . }}
+  config: {{ include "cloudwatch-agent.modify-config" (merge (dict "Config" .Values.agent.defaultConfig) . ) }}
   {{- end }}
   resources:
     requests:

--- a/helm/templates/fluent-bit-daemonset.yaml
+++ b/helm/templates/fluent-bit-daemonset.yaml
@@ -31,7 +31,7 @@ spec:
         - name: AWS_REGION
           value: {{ .Values.region }}
         - name: CLUSTER_NAME
-          value: {{ include "kubernetes-cluster.name" . }}
+          value: {{ (include "kubernetes-cluster.name" .) | quote }}
         - name: READ_FROM_HEAD
           value: "Off"
         - name: READ_FROM_TAIL

--- a/helm/templates/fluent-bit-daemonset.yaml
+++ b/helm/templates/fluent-bit-daemonset.yaml
@@ -1,6 +1,4 @@
-{{- if empty .Values.region }}
-{{- fail "region is a required field" }}
-{{- end }}
+{{- $region := .Values.region | required ".Values.region is required." -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -11,10 +11,10 @@ nameOverride: ""
 ## Reference one or more secrets to be used when pulling images from authenticated repositories.
 imagePullSecrets: [ ]
 
-## Provide the ClusterName
+## Provide the ClusterName (optional parameter, if not provided, a generated name will be used)
 clusterName:
 
-## Provide the Region
+## Provide the Region (this is a required parameter)
 region:
 
 containerLogs:


### PR DESCRIPTION
*Description of changes:*
Fixing cluster-name as a string to accomodate numeric only strings in fluentbit daemonset
```
helm template --namespace testing -s templates/fluent-bit-daemonset.yaml ./helm --set region=us-east-1 
---
# Source: amazon-cloudwatch-observability/templates/fluent-bit-daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: fluent-bit
  namespace: testing
  labels:
    k8s-app: fluent-bit
    version: v1
    kubernetes.io/cluster-service: "true"
spec:
  selector:
    matchLabels:
      k8s-app: fluent-bit
  template:
    metadata:
      annotations:
        checksum/config: e75de7fae063d5317a3c8b7d93f6ee013203d395f89be449d36f3f406b20f837
      labels:
        k8s-app: fluent-bit
        version: v1
        kubernetes.io/cluster-service: "true"
    spec:
      containers:
      - name: fluent-bit
        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.31.12.20230911
        imagePullPolicy: Always
        env:
        - name: AWS_REGION
          value: us-east-1
        - name: CLUSTER_NAME
          value: "k8s-cluster-90b19a1"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
