### PR TITLE
Fix dns resolver

### DIFF
--- a/helm/templates/fluent-bit-windows-configmap.yaml
+++ b/helm/templates/fluent-bit-windows-configmap.yaml
@@ -16,6 +16,7 @@ data:
         storage.path              /var/fluent-bit/state/flb-storage/
         storage.sync              normal
         storage.checksum          off
+        net.dns.resolver          LEGACY
         storage.backlog.mem_limit 5M
 
 {{- if .Values.containerLogs.enabled }}


### PR DESCRIPTION
Issue #, if available:
During e2e testing, found that fluenbit crashes when customer applications are deployed.

Description of changes:
Fixed fluentbit configuration to don't use DNS resolver which stopped crashes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
