### PR TITLE
add dcgm daemonset for nvidia

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -70,6 +70,13 @@ Name for cloudwatch-agent
 {{- end }}
 
 {{/*
+Name for dcgm-exporter
+*/}}
+{{- define "dcgm-exporter.name" -}}
+{{- default "dcgm-exporter" .Values.dcgmExporter.name }}
+{{- end }}
+
+{{/*
 Get the current recommended cloudwatch agent image for a region
 */}}
 {{- define "cloudwatch-agent.image" -}}
@@ -105,6 +112,18 @@ Get the current recommended fluent-bit image for a region
 {{- $imageDomain = .Values.containerLogs.fluentBit.image.repositoryDomainMap.public -}}
 {{- end -}}
 {{- printf "%s/%s:%s" $imageDomain .Values.containerLogs.fluentBit.image.repository .Values.containerLogs.fluentBit.image.tag -}}
+{{- end -}}
+
+{{/*
+Get the current recommended dcgm-exporter image for a region
+*/}}
+{{- define "dcgm-exporter.image" -}}
+{{- $imageDomain := "" -}}
+{{- $imageDomain = index .Values.containerLogs.dcgmExporter.image.repositoryDomainMap .Values.region -}}
+{{- if not $imageDomain -}}
+{{- $imageDomain = .Values.containerLogs.dcgmExporter.image.repositoryDomainMap.public -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $imageDomain .Values.containerLogs.dcgmExporter.image.repository .Values.containerLogs.dcgmExporter.image.tag -}}
 {{- end -}}
 
 {{/*
@@ -146,6 +165,13 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.agent.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use fro dcgm exporter
+*/}}
+{{- define "dcgm-exporter.serviceAccountName" -}}
+{{- default "dcgm-exporter-service-acct" .Values.dcgmExporter.serviceAccount.name }}
 {{- end }}
 
 {{- define "amazon-cloudwatch-observability.podAnnotations" -}}

--- a/helm/templates/certmanager.yaml
+++ b/helm/templates/certmanager.yaml
@@ -26,8 +26,8 @@ spec:
   subject:
     organizationalUnits:
     - {{ template "amazon-cloudwatch-observability.name" . }}
-{{- if not .Values.admissionWebhooks.certManager.issuerRef }}
 ---
+{{- if not .Values.admissionWebhooks.certManager.issuerRef }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -43,3 +43,48 @@ spec:
   selfSigned: { }
 {{- end }}
 {{- end }}
+---
+{{- if ( .Values.agent.certManager.enabled) -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+    - "dcgm-exporter-service"
+    - {{ (include "amazon-cloudwatch-observability.name" .)}}
+    - "dcgm-exporter-service.amazon-cloudwatch.svc"
+  issuerRef:
+    kind: Issuer
+    name: "agent-ca"
+  secretName: "amazon-cloudwatch-observability-agent-cert"
+
+---
+{{- if not .Values.agent.certManager.issuerRef }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  {{- if .Values.agent.certManager.issuerAnnotations }}
+  annotations:
+  {{- toYaml .Values.agent.certManager.issuerAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "agent-ca"
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: { }
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
   - mountPath: /dev/disk
     name: devdisk
     readOnly: true
-  - mountPath: /etc/amazon-cloudwatch-observability-appsignals-cert
+  - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
     name: appsignalstls
     readOnly: true
 
@@ -64,7 +64,7 @@ spec:
     name: devdisk
   - name: appsignalstls
     secret:
-      secretName: amazon-cloudwatch-observability-appsignals-cert
+      secretName: amazon-cloudwatch-observability-agent-cert
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -39,6 +39,10 @@ spec:
   - mountPath: /dev/disk
     name: devdisk
     readOnly: true
+  - mountPath: /etc/amazon-cloudwatch-observability-appsignals-cert
+    name: appsignalstls
+    readOnly: true
+
   volumes:
   - name: rootfs
     hostPath:
@@ -58,6 +62,9 @@ spec:
   - hostPath:
       path: /dev/disk/
     name: devdisk
+  - name: appsignalstls
+    secret:
+      secretName: amazon-cloudwatch-observability-appsignals-cert
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -1,4 +1,23 @@
 {{- if .Values.agent.enabled }}
+{{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
+{{$altNames := list ("dcgm-exporter-service") ("dcgm-exporter-service.amazon-cloudwatch.svc")  (include "amazon-cloudwatch-observability.name" .)  }}
+{{- $ca := genCA ( printf "%s-ca" ("agent") )  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
+{{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+      {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+---
+{{- end -}}
+
+
 {{- $region := .Values.region | required ".Values.region is required." -}}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
@@ -40,7 +59,7 @@ spec:
     name: devdisk
     readOnly: true
   - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
-    name: appsignalstls
+    name: agenttls
     readOnly: true
 
   volumes:
@@ -62,9 +81,12 @@ spec:
   - hostPath:
       path: /dev/disk/
     name: devdisk
-  - name: appsignalstls
+  - name: agenttls
     secret:
       secretName: amazon-cloudwatch-observability-agent-cert
+      items:
+        - key: ca.crt
+          path: tls-ca.crt
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/helm/templates/dcgm-exporter-configmap.yaml
+++ b/helm/templates/dcgm-exporter-configmap.yaml
@@ -1,88 +1,17 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: dcgm-exporter-config-map
+  name: {{ .Values.dcgmExporter.configmap }}
   namespace: {{ .Release.Namespace }}
 data:
   dcp-metrics-included.csv: |
-    # Format
-    # If line starts with a '#' it is considered a comment
-    # DCGM FIELD, Prometheus metric type, help message
-    
-    # Clocks
-    DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
-    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
-    
-    # Temperature
-    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
-    DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
-    
-    # Power
-    DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
-    DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
-    
-    # PCIE
-    # DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
-    # DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
-    DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
-    
-    # Utilization (the sample period varies depending on the product)
     DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
     DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
-    DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
-    DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
-    
-    # Errors and violations
-    DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
-    # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
-    # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
-    # DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
-    # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
-    # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
-    # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
-    
-    # Memory usage
     DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
     DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
-    
-    # ECC
-    # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
-    # DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
-    # DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
-    # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
-    
-    # Retired pages
-    # DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
-    # DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
-    # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
-    
-    # NVLink
-    # DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
-    # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
-    # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
-    # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
-    DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
-    # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
-    
-    # VGPU License status
-    DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
-    
-    # Remapped rows
-    DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
-    DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
-    DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
-    
-    # DCP metrics
-    DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active (in %).
-    # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).
-    # DCGM_FI_PROF_SM_OCCUPANCY,       gauge, The ratio of number of warps resident on an SM (in %).
-    DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active (in %).
-    DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data (in %).
-    # DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active (in %).
-    # DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active (in %).
-    # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active (in %).
-    DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
-    DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
-  web-config.yaml: |
-    basic_auth_users:
-      cwagent: $2a$12$QMxvDp/Pfw7q4oaWzqyXxOgVEJMfiwrOk7Ezdf8SPquzYXhzr9NJi
+    DCGM_FI_DEV_FB_TOTAL, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_USED_PERCENT, gauge, Percentage used of Frame Buffer: Used/(Total - Reserved).
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
+    DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
+    DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+    DCGM_FI_DEV_FAN_SPEED, gauge, Fan speed for the device in percent 0-100.

--- a/helm/templates/dcgm-exporter-configmap.yaml
+++ b/helm/templates/dcgm-exporter-configmap.yaml
@@ -14,3 +14,7 @@ data:
     DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
     DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
     DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+  web-config.yaml: |
+    tls_server_config:
+      cert_file: /etc/amazon-cloudwatch-observability-dcgm-cert/server.crt
+      key_file: /etc/amazon-cloudwatch-observability-dcgm-cert/server.key

--- a/helm/templates/dcgm-exporter-configmap.yaml
+++ b/helm/templates/dcgm-exporter-configmap.yaml
@@ -14,4 +14,3 @@ data:
     DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
     DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
     DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
-    DCGM_FI_DEV_FAN_SPEED, gauge, Fan speed for the device in percent 0-100.

--- a/helm/templates/dcgm-exporter-configmap.yaml
+++ b/helm/templates/dcgm-exporter-configmap.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dcgm-exporter-config-map
+  namespace: {{ .Release.Namespace }}
+data:
+  dcp-metrics-included.csv: |
+    # Format
+    # If line starts with a '#' it is considered a comment
+    # DCGM FIELD, Prometheus metric type, help message
+    
+    # Clocks
+    DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+    
+    # Temperature
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
+    DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
+    
+    # Power
+    DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+    DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
+    
+    # PCIE
+    # DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
+    # DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
+    DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
+    
+    # Utilization (the sample period varies depending on the product)
+    DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
+    DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
+    DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
+    
+    # Errors and violations
+    DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
+    # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
+    # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
+    # DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
+    # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
+    # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
+    # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
+    
+    # Memory usage
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    
+    # ECC
+    # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
+    # DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
+    # DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
+    # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
+    
+    # Retired pages
+    # DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
+    # DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
+    # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
+    
+    # NVLink
+    # DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
+    # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
+    # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
+    # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
+    DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
+    # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
+    
+    # VGPU License status
+    DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
+    
+    # Remapped rows
+    DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
+    DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
+    DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
+    
+    # DCP metrics
+    DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).
+    # DCGM_FI_PROF_SM_OCCUPANCY,       gauge, The ratio of number of warps resident on an SM (in %).
+    DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active (in %).
+    DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data (in %).
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active (in %).
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active (in %).
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active (in %).
+    DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
+    DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+  web-config.yaml: |
+    basic_auth_users:
+      cwagent: $2a$12$QMxvDp/Pfw7q4oaWzqyXxOgVEJMfiwrOk7Ezdf8SPquzYXhzr9NJi

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: dcgm-exporter
+  name: {{ include "dcgm-exporter.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    k8s-app: dcgm-exporter
+    k8s-app: {{ include "dcgm-exporter.name" . }}
     version: v1
 spec:
   selector:
     matchLabels:
-      k8s-app: dcgm-exporter
+      k8s-app: {{ include "dcgm-exporter.name" . }}
   template:
     metadata:
       labels:
-        k8s-app: dcgm-exporter
+        k8s-app: {{ include "dcgm-exporter.name" . }}
         version: v1
     spec:
       serviceAccountName: {{ template "dcgm-exporter.serviceAccountName" . }}

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dcgm-exporter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: dcgm-exporter
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: dcgm-exporter
+  template:
+    metadata:
+      labels:
+        k8s-app: dcgm-exporter
+        version: v1
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: {{ template "dcgm-exporter.serviceAccountName" . }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: {{ .Values.gpuNodeLabelKey }}
+                operator: In
+                values: {{ .Values.gpuInstances | toYaml | nindent 16 }}
+      containers:
+      - name: dcgm-exporter
+        securityContext:
+          privileged: true
+        image: "{{ .Values.dcgmExporter.image.repository }}:{{ .Values.dcgmExporter.image.tag }}"
+        args:
+        {{- range $.Values.dcgmExporter.arguments }}
+        - {{ . }}
+        {{- end }}
+        env:
+        - name: "DCGM_EXPORTER_KUBERNETES"
+          value: "true"
+        - name: "DCGM_EXPORTER_LISTEN"
+          value: "{{ .Values.dcgmExporter.service.address }}"
+        - name: "DCGM_EXPORTER_COLLECTORS"
+          value: "/etc/dcgm-exporter/dcp-metrics-included.csv"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        ports:
+        - name: "metrics"
+          containerPort: {{ .Values.dcgmExporter.service.port }}
+        volumeMounts:
+        - name: "pod-gpu-resources"
+          readOnly: true
+          mountPath: "/var/lib/kubelet/pod-resources"
+        - name: "dcgm-config"
+          mountPath: /etc/dcgm-exporter/
+      volumes:
+      - name: "pod-gpu-resources"
+        hostPath:
+          path: /var/lib/kubelet/pod-resources
+      - name: "dcgm-config"
+        configMap:
+          name: dcgm-exporter-config-map
+      resources:
+        requests:
+          cpu: 250m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 250Mi

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -6,7 +6,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "amazon-cloudwatch-observability-appsignals-cert"
+  name: "amazon-cloudwatch-observability-agent-cert"
   namespace: {{ .Release.Namespace }}
 data:
   tls-ca.crt: {{ $ca.Cert | b64enc }}

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -58,7 +58,7 @@ spec:
           path: /var/lib/kubelet/pod-resources
       - name: "dcgm-config"
         configMap:
-          name: dcgm-exporter-config-map
+          name: {{ .Values.dcgmExporter.configmap }}
       resources:
         requests:
           cpu: 250m

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -1,3 +1,27 @@
+{{$altNames := list ("dcgm-exporter-service") ("dcgm-exporter-service.amazon-cloudwatch.svc")  (include "amazon-cloudwatch-observability.name" .)  }}
+{{- $ca := genCA ( printf "%s-ca" ("dcgm-exporter-service") )  ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) -}}
+{{- $cert := genSignedCert ("dcgm-exporter-service") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-appsignals-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  tls-ca.crt: {{ $ca.Cert | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-dcgm-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  server.crt: {{ $cert.Cert | b64enc }}
+  server.key: {{ $cert.Key | b64enc }}
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -52,7 +76,13 @@ spec:
           mountPath: "/var/lib/kubelet/pod-resources"
         - name: "dcgm-config"
           mountPath: /etc/dcgm-exporter/
+        - mountPath: /etc/amazon-cloudwatch-observability-dcgm-cert
+          name: dcgmtls
+          readOnly: true
       volumes:
+      - name: dcgmtls
+        secret:
+          secretName: amazon-cloudwatch-observability-dcgm-cert
       - name: "pod-gpu-resources"
         hostPath:
           path: /var/lib/kubelet/pod-resources

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -16,7 +16,6 @@ spec:
         k8s-app: dcgm-exporter
         version: v1
     spec:
-      priorityClassName: system-node-critical
       serviceAccountName: {{ template "dcgm-exporter.serviceAccountName" . }}
       affinity:
         nodeAffinity:
@@ -28,8 +27,6 @@ spec:
                 values: {{ .Values.gpuInstances | toYaml | nindent 16 }}
       containers:
       - name: dcgm-exporter
-        securityContext:
-          privileged: true
         image: "{{ .Values.dcgmExporter.image.repository }}:{{ .Values.dcgmExporter.image.tag }}"
         args:
         {{- range $.Values.dcgmExporter.arguments }}

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -56,6 +56,13 @@ spec:
         {{- range $.Values.dcgmExporter.arguments }}
         - {{ . }}
         {{- end }}
+        resources:
+          requests:
+            cpu: 250m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 250Mi
         env:
         - name: "DCGM_EXPORTER_KUBERNETES"
           value: "true"
@@ -89,10 +96,3 @@ spec:
       - name: "dcgm-config"
         configMap:
           name: {{ .Values.dcgmExporter.configmap }}
-      resources:
-        requests:
-          cpu: 250m
-          memory: 128Mi
-        limits:
-          cpu: 500m
-          memory: 250Mi

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -1,27 +1,3 @@
-{{$altNames := list ("dcgm-exporter-service") ("dcgm-exporter-service.amazon-cloudwatch.svc")  (include "amazon-cloudwatch-observability.name" .)  }}
-{{- $ca := genCA ( printf "%s-ca" ("dcgm-exporter-service") )  ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) -}}
-{{- $cert := genSignedCert ("dcgm-exporter-service") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "amazon-cloudwatch-observability-agent-cert"
-  namespace: {{ .Release.Namespace }}
-data:
-  tls-ca.crt: {{ $ca.Cert | b64enc }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "amazon-cloudwatch-observability-dcgm-cert"
-  namespace: {{ .Release.Namespace }}
-data:
-  server.crt: {{ $cert.Cert | b64enc }}
-  server.key: {{ $cert.Key | b64enc }}
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -89,7 +65,12 @@ spec:
       volumes:
       - name: dcgmtls
         secret:
-          secretName: amazon-cloudwatch-observability-dcgm-cert
+          secretName: amazon-cloudwatch-observability-agent-cert
+          items:
+            - key: tls.crt
+              path: server.crt
+            - key:  tls.key
+              path: server.key
       - name: "pod-gpu-resources"
         hostPath:
           path: /var/lib/kubelet/pod-resources

--- a/helm/templates/dcgm-exporter-role.yaml
+++ b/helm/templates/dcgm-exporter-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: {{ template "dcgm-exporter.name" . }}-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["exporter-metrics-config-map"]
+  verbs: ["get"]

--- a/helm/templates/dcgm-exporter-role.yaml
+++ b/helm/templates/dcgm-exporter-role.yaml
@@ -1,11 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: "{{ template "dcgm-exporter.name" . }}-role"
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: {{ template "dcgm-exporter.name" . }}-role
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  resourceNames: ["exporter-metrics-config-map"]
+  resourceNames: ["{{ .Release.Namespace }}:{{ .Values.dcgmExporter.configmap }}"]
   verbs: ["get"]

--- a/helm/templates/dcgm-exporter-role.yaml
+++ b/helm/templates/dcgm-exporter-role.yaml
@@ -8,5 +8,5 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  resourceNames: ["{{ .Release.Namespace }}:{{ .Values.dcgmExporter.configmap }}"]
+  resourceNames: ["{{ .Values.dcgmExporter.configmap }}"]
   verbs: ["get"]

--- a/helm/templates/dcgm-exporter-rolebinding.yaml
+++ b/helm/templates/dcgm-exporter-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ template "dcgm-exporter.name" . }}-role-binding
+  labels:
+      {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+roleRef:
+  kind: Role
+  name: {{ template "dcgm-exporter.name" . }}-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "dcgm-exporter.name" . }}-service
+  namespace: {{ .Release.Namespace }}

--- a/helm/templates/dcgm-exporter-rolebinding.yaml
+++ b/helm/templates/dcgm-exporter-rolebinding.yaml
@@ -7,9 +7,9 @@ metadata:
       {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
 roleRef:
   kind: Role
-  name: {{ template "dcgm-exporter.name" . }}-role
+  name: "{{ template "dcgm-exporter.name" . }}-role"
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ template "dcgm-exporter.name" . }}-service
+  name: {{ template "dcgm-exporter.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/helm/templates/dcgm-exporter-service.yaml
+++ b/helm/templates/dcgm-exporter-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.dcgmExporter.service.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dcgm-exporter.name" . }}-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
+    k8s-app: {{ include "dcgm-exporter.name" . }}-service
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  type: {{ .Values.dcgmExporter.service.type }}
+  ports:
+  - name: "metrics"
+    port: {{ .Values.dcgmExporter.service.port }}
+    targetPort: {{ .Values.dcgmExporter.service.port }}
+    protocol: TCP
+  selector:
+    k8s-app: dcgm-exporter
+  internalTrafficPolicy: Local
+{{- end }}

--- a/helm/templates/dcgm-exporter-service.yaml
+++ b/helm/templates/dcgm-exporter-service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "dcgm-exporter.name" . }}-service
+  name: dcgm-exporter-service
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4 }}
-    k8s-app: {{ include "dcgm-exporter.name" . }}-service
+    k8s-app: dcgm-exporter-service
   annotations:
     prometheus.io/scrape: "true"
 spec:
@@ -17,6 +17,6 @@ spec:
     targetPort: {{ .Values.dcgmExporter.service.port }}
     protocol: TCP
   selector:
-    k8s-app: dcgm-exporter
+    k8s-app: {{ include "dcgm-exporter.name" . }}
   internalTrafficPolicy: Local
 {{- end }}

--- a/helm/templates/dcgm-exporter-serviceaccount.yaml
+++ b/helm/templates/dcgm-exporter-serviceaccount.yaml
@@ -1,13 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  labels:
-    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: {{ template "amazon-cloudwatch-observability.managerServiceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-
-metadata:
-  name: {{ include "dcgm-exporter.serviceAccountName" . }}
+  name: {{ template "dcgm-exporter.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}

--- a/helm/templates/dcgm-exporter-serviceaccount.yaml
+++ b/helm/templates/dcgm-exporter-serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: {{ template "amazon-cloudwatch-observability.managerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+
+metadata:
+  name: {{ include "dcgm-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
-        - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
+        # - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -144,7 +144,7 @@ agent:
     repository: cloudwatch-agent
     tag: 1.300031.1b317
     repositoryDomainMap:
-      # public: public.ecr.aws/cloudwatch-agent
+      public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
@@ -175,6 +175,7 @@ dcgmExporter:
   image:
     repository: nvcr.io/nvidia/k8s/dcgm-exporter
     tag: 3.3.3-3.3.1-ubuntu22.04
+  configmap: dcgm-exporter-config-map
   # arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
   service:
     enable: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -176,7 +176,7 @@ dcgmExporter:
     repository: nvcr.io/nvidia/k8s/dcgm-exporter
     tag: 3.3.3-3.3.1-ubuntu22.04
   configmap: dcgm-exporter-config-map
-  # arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
+  arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
   service:
     enable: true
     type: ClusterIP

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -150,6 +150,25 @@ agent:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   enabled: true
+  ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
+  ## autoGenerateCert must be enabled. This is the default option.
+  ## If true, Helm will automatically create a self-signed cert and secret for you.
+  autoGenerateCert:
+    enabled: true
+    expiryDays: 3650 # 10 years
+
+  ## TLS Certificate Option 2: Use certManager to generate self-signed certificate.
+  ## certManager must be enabled. If enabled, it takes precedence over option 1.
+  certManager:
+    enabled:  false
+    ## Provide the issuer kind and name to do the cert auth job.
+    ## By default, OpenTelemetry Operator will use self-signer issuer.
+    issuerRef: { }
+    # kind:
+    # name:
+    ## Annotations for the cert and issuer if cert-manager is enabled.
+    certificateAnnotations: { }
+    issuerAnnotations: { }
   serviceAccount:
     name: # override agent service account name
   config: # optional config that can be provided to override the defaultConfig

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -182,11 +182,6 @@ dcgmExporter:
     type: ClusterIP
     port: 9400
     address: ":9400"
-  securityContext:
-    runAsNonRoot: false
-    runAsUser: 0
-    capabilities:
-      add: ["SYS_ADMIN"]
   kubeletPath: "/var/lib/kubelet/pod-resources"
   serviceAccount:
     name: # override exporter service account name

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -40,7 +40,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.0.2
+    tag: 1.0.4
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -142,7 +142,7 @@ agent:
   name:
   image:
     repository: cloudwatch-agent
-    tag: 1.300031.1b317
+    tag: 1.300034.0b498
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,6 +17,10 @@ clusterName:
 ## Provide the Region (this is a required parameter)
 region:
 
+gpuNodeLabelKey: node.kubernetes.io/instance-type
+## NVIDIA GPU instance types
+gpuInstances: [ g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.12xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.metal, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.24xlarge, g5.48xlarge, g5.8xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, p2.xlarge, p2.8xlarge, p2.16xlarg, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge ]
+
 containerLogs:
   enabled: true
   fluentBit:
@@ -140,7 +144,7 @@ agent:
     repository: cloudwatch-agent
     tag: 1.300031.1b317
     repositoryDomainMap:
-      public: public.ecr.aws/cloudwatch-agent
+      # public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
       cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
@@ -165,3 +169,23 @@ agent:
         }
       }
     }
+
+dcgmExporter:
+  name:
+  image:
+    repository: nvcr.io/nvidia/k8s/dcgm-exporter
+    tag: 3.3.3-3.3.1-ubuntu22.04
+  # arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
+  service:
+    enable: true
+    type: ClusterIP
+    port: 9400
+    address: ":9400"
+  securityContext:
+    runAsNonRoot: false
+    runAsUser: 0
+    capabilities:
+      add: ["SYS_ADMIN"]
+  kubeletPath: "/var/lib/kubelet/pod-resources"
+  serviceAccount:
+    name: # override exporter service account name


### PR DESCRIPTION
*Closed PR: https://github.com/aws/amazon-cloudwatch-agent-operator/pull/81*
*Previous PR has been closed to move changes to a new feature branch by following the branch naming convention.*

*Description of changes:*
- Add new `dcgm-exporter` daemonset to support NVIDIA GPU metrics with k8s
- Add new service that uses `dcgm-exporter` pods where the traffic is limited within node (no cross nodes communication)
- new serviceaccount and role to be used by dcgm-exporter daemonset

The new `dcgm-exporter` pod has `nodeAffinity` config that spins up itself in only GPU nodes. The supported GPU instances are hard coded into `values.yaml` which can be extended when there are more GPU instances/types supported. 

Below is the list of pods in test cluster where 1 GPU and 1 non-gpu nodes are. 
```
NAME                                                              READY   STATUS    RESTARTS   AGE
amazon-cloudwatch-observability-controller-manager-xxxxxx   1/1     Running   0          4m17s
cloudwatch-agent-xxxxxx                                            1/1     Running   0          4m16s
cloudwatch-agent-xxxxxx                                            1/1     Running   0          4m17s
dcgm-exporter-xxxxxx                                               1/1     Running   0          4m18s
fluent-bit-xxxxxx                                                 1/1     Running   0          4m18s
fluent-bit-xxxxxx                                                  1/1     Running   0          4m17s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
