### PR TITLE
Update build and upload to only run on main branch

### DIFF
--- a/.github/workflows/build-and-upload-staging.yml
+++ b/.github/workflows/build-and-upload-staging.yml
@@ -10,7 +10,7 @@ env:
 on:
   push:
     branches:
-      - main*
+      - main
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
Build and upload workflow is run on any main* branch. This causes the image to be overridden with main-windowsci which is troublesome for testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
