### PR TITLE
Update Python ADOT Instrumentation to use XRay Sampler as default via Env Var

### DIFF
--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -90,6 +90,7 @@ func getDefaultInstrumentation() (*v1alpha1.Instrumentation, error) {
 				Env: []corev1.EnvVar{
 					{Name: otelAppSignalsEnabledKey, Value: otelAppSignalsEnabledDefaultValue},
 					{Name: otelTracesSamplerArgKey, Value: otelTracesSamplerArgDefaultValue},
+					{Name: otelTracesSamplerKey, Value: otelTracesSamplerDefaultValue},
 					{Name: otelExporterOtlpProtocolKey, Value: otelExporterOtlpProtocolValue},
 					{Name: otelExporterTracesEndpointKey, Value: otelExporterTracesEndpointDefaultValue},
 					{Name: otelExporterAppSignalsEndpointKey, Value: otelExporterAppSignalsEndpointDefaultValue},

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -67,6 +67,7 @@ func TestGetInstrumentationInstanceFromNameSpaceDefault(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: otelAppSignalsEnabledKey, Value: otelAppSignalsEnabledDefaultValue},
 					{Name: otelTracesSamplerArgKey, Value: otelTracesSamplerArgDefaultValue},
+					{Name: otelTracesSamplerKey, Value: otelTracesSamplerDefaultValue},
 					{Name: otelExporterOtlpProtocolKey, Value: otelExporterOtlpProtocolValue},
 					{Name: otelExporterTracesEndpointKey, Value: otelExporterTracesEndpointDefaultValue},
 					{Name: otelExporterAppSignalsEndpointKey, Value: otelExporterAppSignalsEndpointDefaultValue},


### PR DESCRIPTION
*Issue #, if available:*
Like in Java, specify `otelTracesSamplerKey` env var key for Python instrumentation, default to xray

*Description of changes:*
add `{Name: otelTracesSamplerKey, Value: otelTracesSamplerDefaultValue}` env var key pair to pythonInstrumentationImage


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
