### PR TITLE
Fix race condition for auto-annotations on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"flag"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -211,8 +213,15 @@ func main() {
 			mgr.GetWebhookServer().Register("/mutate-v1-namespace", &webhook.Admission{
 				Handler: namespacemutation.NewWebhookHandler(decoder, autoAnnotationMutators),
 			})
-			setupLog.Info("Starting auto-annotation")
-			go autoAnnotationMutators.MutateAndPatchAll(ctx)
+			setupLog.Info("Auto-annotation is enabled")
+			go waitForWebhookServerStart(
+				ctx,
+				mgr.GetWebhookServer().StartedChecker(),
+				func(ctx context.Context) {
+					setupLog.Info("Applying auto-annotation")
+					autoAnnotationMutators.MutateAndPatchAll(ctx)
+				},
+			)
 		}
 	}
 
@@ -250,6 +259,23 @@ func main() {
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+}
+
+func waitForWebhookServerStart(ctx context.Context, checker healthz.Checker, callback func(context.Context)) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := checker(nil); err == nil {
+				setupLog.Info("Webhook server has started")
+				callback(ctx)
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -95,10 +95,11 @@ func (m *AnnotationMutator) Mutate(obj metav1.Object) bool {
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	var mutated bool
+	var anyMutated bool
 	for _, mutation := range m.mutations {
-		mutated = mutated || mutation.Mutate(annotations)
+		mutated := mutation.Mutate(annotations)
+		anyMutated = anyMutated || mutated
 	}
 	obj.SetAnnotations(annotations)
-	return mutated
+	return anyMutated
 }

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -48,6 +48,22 @@ func TestMutateAnnotations(t *testing.T) {
 			},
 			wantMutated: true,
 		},
+		"TestInsert/Multiple": {
+			annotations: nil,
+			mutations: []AnnotationMutation{
+				NewInsertAnnotationMutation(map[string]string{
+					"keyA": "3",
+				}),
+				NewInsertAnnotationMutation(map[string]string{
+					"keyC": "4",
+				}),
+			},
+			wantAnnotations: map[string]string{
+				"keyA": "3",
+				"keyC": "4",
+			},
+			wantMutated: true,
+		},
 		"TestRemove/Conflicts": {
 			annotations: map[string]string{
 				"keyA": "1",
@@ -78,6 +94,41 @@ func TestMutateAnnotations(t *testing.T) {
 			},
 			wantAnnotations: map[string]string{},
 			wantMutated:     true,
+		},
+		"TestRemove/Multiple": {
+			annotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewRemoveAnnotationMutation([]string{
+					"keyA",
+				}),
+				NewRemoveAnnotationMutation([]string{
+					"keyB",
+				}),
+			},
+			wantAnnotations: map[string]string{},
+			wantMutated:     true,
+		},
+		"TestBoth": {
+			annotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewRemoveAnnotationMutation([]string{
+					"keyA",
+				}),
+				NewInsertAnnotationMutation(map[string]string{
+					"keyA": "3",
+				}),
+			},
+			wantAnnotations: map[string]string{
+				"keyA": "3",
+				"keyB": "2",
+			},
+			wantMutated: true,
 		},
 	}
 	for name, testCase := range testCases {

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -19,24 +19,24 @@ const (
 	defaultNamespace      = "default"
 	defaultKind           = "Instrumentation"
 
-	otelSampleEnabledKey                   = "OTEL_SMP_ENABLED" //TODO: remove in favor of new name once safe
-	otelSampleEnabledDefaultValue          = "true" //TODO: remove in favor of new name once safe
-	otelAppSignalsEnabledKey               = "OTEL_AWS_APP_SIGNALS_ENABLED"
-	otelAppSignalsEnabledDefaultValue      = "true"
-	otelTracesSamplerArgKey                = "OTEL_TRACES_SAMPLER_ARG"
-	otelTracesSamplerArgDefaultValue       = "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"
-	otelTracesSamplerKey                   = "OTEL_TRACES_SAMPLER"
-	otelTracesSamplerDefaultValue          = "xray"
-	otelExporterOtlpProtocolKey            = "OTEL_EXPORTER_OTLP_PROTOCOL"
-	otelExporterOtlpProtocolValue          = "http/protobuf"
-	otelExporterTracesEndpointKey          = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
-	otelExporterTracesEndpointDefaultValue = "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"
-	otelExporterSmpEndpointKey             = "OTEL_AWS_SMP_EXPORTER_ENDPOINT" //TODO: remove in favor of new name once safe
-	otelExporterSmpEndpointDefaultValue    = "http://cloudwatch-agent.amazon-cloudwatch:4315" //TODO: remove in favor of new name once safe
-	otelExporterAppSignalsEndpointKey      = "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT"
+	otelSampleEnabledKey                       = "OTEL_SMP_ENABLED" //TODO: remove in favor of new name once safe
+	otelSampleEnabledDefaultValue              = "true"             //TODO: remove in favor of new name once safe
+	otelAppSignalsEnabledKey                   = "OTEL_AWS_APP_SIGNALS_ENABLED"
+	otelAppSignalsEnabledDefaultValue          = "true"
+	otelTracesSamplerArgKey                    = "OTEL_TRACES_SAMPLER_ARG"
+	otelTracesSamplerArgDefaultValue           = "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"
+	otelTracesSamplerKey                       = "OTEL_TRACES_SAMPLER"
+	otelTracesSamplerDefaultValue              = "xray"
+	otelExporterOtlpProtocolKey                = "OTEL_EXPORTER_OTLP_PROTOCOL"
+	otelExporterOtlpProtocolValue              = "http/protobuf"
+	otelExporterTracesEndpointKey              = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+	otelExporterTracesEndpointDefaultValue     = "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"
+	otelExporterSmpEndpointKey                 = "OTEL_AWS_SMP_EXPORTER_ENDPOINT"                 //TODO: remove in favor of new name once safe
+	otelExporterSmpEndpointDefaultValue        = "http://cloudwatch-agent.amazon-cloudwatch:4315" //TODO: remove in favor of new name once safe
+	otelExporterAppSignalsEndpointKey          = "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT"
 	otelExporterAppSignalsEndpointDefaultValue = "http://cloudwatch-agent.amazon-cloudwatch:4315"
-	otelExporterMetricKey                  = "OTEL_METRICS_EXPORTER"
-	otelExporterMetricDefaultValue         = "none"
+	otelExporterMetricKey                      = "OTEL_METRICS_EXPORTER"
+	otelExporterMetricDefaultValue             = "none"
 
 	otelPythonDistro                   = "OTEL_PYTHON_DISTRO"
 	otelPythonDistroDefaultValue       = "aws_distro"


### PR DESCRIPTION
*Description of changes:* Wait until after webhook server has started (by polling [health check](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/webhook/server.go#L273)) to run the auto-annotation mutators. This ensures that the pod mutator is available first. Fix the annotation mutator to run through all mutations instead of short-circuiting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
