### PR TITLE
Add feature flag to skip container name validation for multi-instrumentation

### DIFF
--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
         - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
+        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager
         name: manager

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -79,6 +79,15 @@ var (
 		featuregate.WithRegisterDescription("enables features associated to the Prometheus Operator"),
 		featuregate.WithRegisterFromVersion("v0.82.0"),
 	)
+
+	// SkipMultiInstrumentationContainerValidation is the feature gate that controls whether the operator will skip
+	// container name validation during pod mutation for multi-instrumentation. Enabling this feature allows multiple
+	// instrumentations for pods without specified container name annotations. Does not prevent specification
+	// annotations from being used.
+	SkipMultiInstrumentationContainerValidation = featuregate.GlobalRegistry().MustRegister(
+		"operator.autoinstrumentation.multi-instrumentation.skip-container-validation",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("controls whether the operator validates the container annotations when multi-instrumentation is enabled"))
 )
 
 // Flags creates a new FlagSet that represents the available featuregate flags using the supplied featuregate registry.

--- a/pkg/instrumentation/podmutator.go
+++ b/pkg/instrumentation/podmutator.go
@@ -87,6 +87,10 @@ func (langInsts languageInstrumentations) areContainerNamesConfiguredForMultiple
 	var instrWithContainers int
 	var allContainers []string
 
+	if featuregate.SkipMultiInstrumentationContainerValidation.IsEnabled() {
+		return true, nil
+	}
+
 	// Check for instrumentations with and without containers.
 	if langInsts.Java.Instrumentation != nil {
 		instrWithContainers += isInstrWithContainers(langInsts.Java)


### PR DESCRIPTION
*Description of changes:*
- Set operator feature flag for `operator.autoinstrumentation.multi-instrumentation` to enable multi-instrumentation (e.g. Java & Python) for pods.
- Add a `operator.autoinstrumentation.multi-instrumentation.skip-container-validation` feature flag that will bypass the [validations in place](https://github.com/open-telemetry/opentelemetry-operator/blob/main/README.md#multi-container-pods-with-multiple-instrumentations) that require unique container names provided via `instrumentation.opentelemetry.io/<instrumentation>-container-names` annotations. Allows single-container pods to have multi-instrumentation.

*Testing:*
Without `operator.autoinstrumentation.multi-instrumentation`
```
{"level":"error","ts":"2024-02-21T21:53:18Z","msg":"skipping instrumentation injection","namespace":"coffee-shop","name":"","error":"multiple injection annotations present"}
```

Without `operator.autoinstrumentation.multi-instrumentation.skip-container-validation`
```
{"level":"error","ts":"2024-02-21T23:19:49Z","msg":"skipping instrumentation injection","namespace":"coffee-shop","name":"","error":"incorrect instrumentation configuration - please provide container names for all instrumentations"}
```

Both init containers were injected into the pod.
![image](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/84729962/4528773a-2af2-4798-9f9e-0e203b0a7d35)

![image](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/84729962/3d215cd0-b5bb-4832-a4ae-6413faf9c5ab)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
