### PR TITLE
stop running pre-release action on changes to main

### DIFF
--- a/.github/workflows/build-and-upload-staging.yml
+++ b/.github/workflows/build-and-upload-staging.yml
@@ -8,9 +8,6 @@ env:
   ECR_OPERATOR_STAGING_IMAGE: ${{ secrets.ECR_OPERATOR_STAGING_IMAGE }}
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
*Description of changes:*
Currently, every pushes or merges onto main branch will trigger staging-release GHA which will overwrite the latest image in the staging ECR repo. Going forward, we will make this a manual action to limit unnecessary image overwrites. The idea is to trigger staging release action only during a deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
