### PR TITLE
Added option create dcgm tls certs w Cert-Manager

### DIFF
--- a/helm/templates/certmanager.yaml
+++ b/helm/templates/certmanager.yaml
@@ -44,13 +44,13 @@ spec:
 {{- end }}
 {{- end }}
 ---
-{{- if ( .Values.dcgmExporter.certManager.enabled) -}}
+{{- if ( .Values.agent.certManager.enabled) -}}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "amazon-cloudwatch-observability-dcgm-cert"
+  name: "amazon-cloudwatch-observability-agent-cert"
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
@@ -59,21 +59,21 @@ spec:
     - "dcgm-exporter-service.amazon-cloudwatch.svc"
   issuerRef:
     kind: Issuer
-    name: "dcgm-exporter-service-ca"
-  secretName: "amazon-cloudwatch-observability-dcgm-cert"
+    name: "agent-ca"
+  secretName: "amazon-cloudwatch-observability-agent-cert"
 
 ---
-{{- if not .Values.dcgmExporter.certManager.issuerRef }}
+{{- if not .Values.agent.certManager.issuerRef }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  {{- if .Values.dcgmExporter.certManager.issuerAnnotations }}
+  {{- if .Values.agent.certManager.issuerAnnotations }}
   annotations:
-  {{- toYaml .Values.dcgmExporter.certManager.issuerAnnotations | nindent 4 }}
+  {{- toYaml .Values.agent.certManager.issuerAnnotations | nindent 4 }}
   {{- end }}
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "dcgm-exporter-service-ca"
+  name: "agent-ca"
   namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: { }
@@ -84,7 +84,7 @@ kind: Secret
 metadata:
   labels:
     {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "amazon-cloudwatch-observability-dcgm-cert"
+  name: "amazon-cloudwatch-observability-agent-cert"
   namespace: {{ .Release.Namespace }}
 {{- end }}
 

--- a/helm/templates/certmanager.yaml
+++ b/helm/templates/certmanager.yaml
@@ -26,8 +26,8 @@ spec:
   subject:
     organizationalUnits:
     - {{ template "amazon-cloudwatch-observability.name" . }}
-{{- if not .Values.admissionWebhooks.certManager.issuerRef }}
 ---
+{{- if not .Values.admissionWebhooks.certManager.issuerRef }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -43,3 +43,48 @@ spec:
   selfSigned: { }
 {{- end }}
 {{- end }}
+---
+{{- if ( .Values.dcgmExporter.certManager.enabled) -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-dcgm-cert"
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+    - "dcgm-exporter-service"
+    - {{ (include "amazon-cloudwatch-observability.name" .)}}
+    - "dcgm-exporter-service.amazon-cloudwatch.svc"
+  issuerRef:
+    kind: Issuer
+    name: "dcgm-exporter-service-ca"
+  secretName: "amazon-cloudwatch-observability-dcgm-cert"
+
+---
+{{- if not .Values.dcgmExporter.certManager.issuerRef }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  {{- if .Values.dcgmExporter.certManager.issuerAnnotations }}
+  annotations:
+  {{- toYaml .Values.dcgmExporter.certManager.issuerAnnotations | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "dcgm-exporter-service-ca"
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: { }
+{{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-dcgm-cert"
+  namespace: {{ .Release.Namespace }}
+{{- end }}
+

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -1,4 +1,23 @@
 {{- if .Values.agent.enabled }}
+{{- if and (.Values.agent.autoGenerateCert.enabled) (not .Values.agent.certManager.enabled) -}}
+{{$altNames := list ("dcgm-exporter-service") ("dcgm-exporter-service.amazon-cloudwatch.svc")  (include "amazon-cloudwatch-observability.name" .)  }}
+{{- $ca := genCA ( printf "%s-ca" ("agent") )  ( .Values.agent.autoGenerateCert.expiryDays | int ) -}}
+{{- $cert := genSignedCert ("agent") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+      {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
+  name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: {{ .Release.Namespace }}
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+---
+{{- end -}}
+
+
 {{- $region := .Values.region | required ".Values.region is required." -}}
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: AmazonCloudWatchAgent
@@ -64,7 +83,7 @@ spec:
     name: devdisk
   - name: agenttls
     secret:
-      secretName: amazon-cloudwatch-observability-dcgm-cert
+      secretName: amazon-cloudwatch-observability-agent-cert
       items:
         - key: ca.crt
           path: tls-ca.crt

--- a/helm/templates/cloudwatch-agent-daemonset.yaml
+++ b/helm/templates/cloudwatch-agent-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
     name: devdisk
     readOnly: true
   - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
-    name: appsignalstls
+    name: agenttls
     readOnly: true
 
   volumes:
@@ -62,9 +62,12 @@ spec:
   - hostPath:
       path: /dev/disk/
     name: devdisk
-  - name: appsignalstls
+  - name: agenttls
     secret:
-      secretName: amazon-cloudwatch-observability-agent-cert
+      secretName: amazon-cloudwatch-observability-dcgm-cert
+      items:
+        - key: ca.crt
+          path: tls-ca.crt
   env:
   - name: K8S_NODE_NAME
     valueFrom:

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -1,20 +1,3 @@
-{{- if and (.Values.dcgmExporter.autoGenerateCert.enabled) (not .Values.dcgmExporter.certManager.enabled) -}}
-{{$altNames := list ("dcgm-exporter-service") ("dcgm-exporter-service.amazon-cloudwatch.svc")  (include "amazon-cloudwatch-observability.name" .)  }}
-{{- $ca := genCA ( printf "%s-ca" ("dcgm-exporter-service") )  ( .Values.dcgmExporter.autoGenerateCert.expiryDays | int ) -}}
-{{- $cert := genSignedCert ("dcgm-exporter-service") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "amazon-cloudwatch-observability-dcgm-cert"
-  namespace: {{ .Release.Namespace }}
-data:
-  ca.crt: {{ $ca.Cert | b64enc }}
-  tls.crt: {{ $cert.Cert | b64enc }}
-  tls.key: {{ $cert.Key | b64enc }}
----
-{{- end -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -82,7 +65,7 @@ spec:
       volumes:
       - name: dcgmtls
         secret:
-          secretName: amazon-cloudwatch-observability-dcgm-cert
+          secretName: amazon-cloudwatch-observability-agent-cert
           items:
             - key: tls.crt
               path: server.crt

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -1,16 +1,7 @@
+{{- if and (.Values.dcgmExporter.autoGenerateCert.enabled) (not .Values.dcgmExporter.certManager.enabled) -}}
 {{$altNames := list ("dcgm-exporter-service") ("dcgm-exporter-service.amazon-cloudwatch.svc")  (include "amazon-cloudwatch-observability.name" .)  }}
-{{- $ca := genCA ( printf "%s-ca" ("dcgm-exporter-service") )  ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) -}}
+{{- $ca := genCA ( printf "%s-ca" ("dcgm-exporter-service") )  ( .Values.dcgmExporter.autoGenerateCert.expiryDays | int ) -}}
 {{- $cert := genSignedCert ("dcgm-exporter-service") nil $altNames ( .Values.admissionWebhooks.autoGenerateCert.expiryDays | int ) $ca -}}
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    {{- include "amazon-cloudwatch-observability.labels" . | nindent 4}}
-  name: "amazon-cloudwatch-observability-agent-cert"
-  namespace: {{ .Release.Namespace }}
-data:
-  tls-ca.crt: {{ $ca.Cert | b64enc }}
----
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,9 +10,11 @@ metadata:
   name: "amazon-cloudwatch-observability-dcgm-cert"
   namespace: {{ .Release.Namespace }}
 data:
-  server.crt: {{ $cert.Cert | b64enc }}
-  server.key: {{ $cert.Key | b64enc }}
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
 ---
+{{- end -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -90,6 +83,11 @@ spec:
       - name: dcgmtls
         secret:
           secretName: amazon-cloudwatch-observability-dcgm-cert
+          items:
+            - key: tls.crt
+              path: server.crt
+            - key:  tls.key
+              path: server.key
       - name: "pod-gpu-resources"
         hostPath:
           path: /var/lib/kubelet/pod-resources

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -150,6 +150,25 @@ agent:
       us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   enabled: true
+  ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
+  ## autoGenerateCert must be enabled. This is the default option.
+  ## If true, Helm will automatically create a self-signed cert and secret for you.
+  autoGenerateCert:
+    enabled: true
+    expiryDays: 3650 # 10 years
+
+  ## TLS Certificate Option 2: Use certManager to generate self-signed certificate.
+  ## certManager must be enabled. If enabled, it takes precedence over option 1.
+  certManager:
+    enabled:  false
+    ## Provide the issuer kind and name to do the cert auth job.
+    ## By default, OpenTelemetry Operator will use self-signer issuer.
+    issuerRef: { }
+    # kind:
+    # name:
+    ## Annotations for the cert and issuer if cert-manager is enabled.
+    certificateAnnotations: { }
+    issuerAnnotations: { }
   serviceAccount:
     name: # override agent service account name
   config: # optional config that can be provided to override the defaultConfig
@@ -177,25 +196,6 @@ dcgmExporter:
     tag: 3.3.3-3.3.1-ubuntu22.04
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
-  ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
-  ## autoGenerateCert must be enabled. This is the default option.
-  ## If true, Helm will automatically create a self-signed cert and secret for you.
-  autoGenerateCert:
-    enabled: true
-    expiryDays: 3650 # 10 years
-
-  ## TLS Certificate Option 2: Use certManager to generate self-signed certificate.
-  ## certManager must be enabled. If enabled, it takes precedence over option 1.
-  certManager:
-    enabled: false
-    ## Provide the issuer kind and name to do the cert auth job.
-    ## By default, OpenTelemetry Operator will use self-signer issuer.
-    issuerRef: { }
-    # kind:
-    # name:
-    ## Annotations for the cert and issuer if cert-manager is enabled.
-    certificateAnnotations: { }
-    issuerAnnotations: { }
   service:
     enable: true
     type: ClusterIP

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -177,6 +177,25 @@ dcgmExporter:
     tag: 3.3.3-3.3.1-ubuntu22.04
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
+  ## TLS Certificate Option 1: Use Helm to automatically generate self-signed certificate.
+  ## autoGenerateCert must be enabled. This is the default option.
+  ## If true, Helm will automatically create a self-signed cert and secret for you.
+  autoGenerateCert:
+    enabled: true
+    expiryDays: 3650 # 10 years
+
+  ## TLS Certificate Option 2: Use certManager to generate self-signed certificate.
+  ## certManager must be enabled. If enabled, it takes precedence over option 1.
+  certManager:
+    enabled: false
+    ## Provide the issuer kind and name to do the cert auth job.
+    ## By default, OpenTelemetry Operator will use self-signer issuer.
+    issuerRef: { }
+    # kind:
+    # name:
+    ## Annotations for the cert and issuer if cert-manager is enabled.
+    certificateAnnotations: { }
+    issuerAnnotations: { }
   service:
     enable: true
     type: ClusterIP


### PR DESCRIPTION
*Description of changes:*
* Added cert manager support to dcgm-exporter tls generation 
* Changed it so that now we are only using one secret and that is `amazon-cloudwatch-observability-dcgm-cert`
* Remapped the agent-cert secret to find the ca bundle from dcgm secret, so that both cert manager and auto generation handled the same way.
> [!IMPORTANT]
> Cert Manager does not support custom certification names, so I had to use path to create these custom names to support our current code. 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
## Testing 
### Auto-Generation 
* Creds Generated
![image (4)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/d087b008-b85a-4b6a-a40e-6a9fffad91c6)

* DCGM exporter can read the TLS
![image (5)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/d28dcbd4-750c-409a-a553-edc90cdecbb7)

* Agent Scraper establishes TLS connection
![image (6)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/c50f6c44-f9a0-4d35-897a-8f210e4f23a2)

* Metrics Show on Console
![image (7)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/cb05432c-a4ab-4194-abdb-3b48702a22f9)

### Cert-Manager
* DCGM exporter can read the TLS
![image (4)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/e2bc3735-b6c0-49de-abbf-72d76a8a303f)

* Agent Scraper establishes TLS connection
![image (5)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/3d8d5133-0931-49a0-b018-12bbbfd3dbe2)

* Metrics Show on Console
![image](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/84c9db99-6613-4ca2-80f8-092c7d105246)
### Both true ( it favours Cert-Manager)  
* DCGM exporter can read the TLS
![image (4)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/8bf3bd6f-3a0b-4847-a1db-6aed4e929337)

* Agent Scraper establishes TLS connection
![image (5)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/f5210489-a7f8-45d9-aa53-2a377ee20d3f)

* Metrics Show on Console
![image (6)](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/fafdcea0-cf27-4ff9-be3c-e7f8009825bb)
