### PR TITLE
Use domain map when constructing image URI for DCGM

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -118,12 +118,7 @@ Get the current recommended fluent-bit image for a region
 Get the current recommended dcgm-exporter image for a region
 */}}
 {{- define "dcgm-exporter.image" -}}
-{{- $imageDomain := "" -}}
-{{- $imageDomain = index .Values.containerLogs.dcgmExporter.image.repositoryDomainMap .Values.region -}}
-{{- if not $imageDomain -}}
-{{- $imageDomain = .Values.containerLogs.dcgmExporter.image.repositoryDomainMap.public -}}
-{{- end -}}
-{{- printf "%s/%s:%s" $imageDomain .Values.containerLogs.dcgmExporter.image.repository .Values.containerLogs.dcgmExporter.image.tag -}}
+{{- printf "%s/%s:%s" .Values.dcgmExporter.image.repositoryDomain .Values.dcgmExporter.image.repository .Values.dcgmExporter.image.tag -}}
 {{- end -}}
 
 {{/*

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -118,7 +118,13 @@ Get the current recommended fluent-bit image for a region
 Get the current recommended dcgm-exporter image for a region
 */}}
 {{- define "dcgm-exporter.image" -}}
-{{- printf "%s/%s:%s" .Values.dcgmExporter.image.repositoryDomain .Values.dcgmExporter.image.repository .Values.dcgmExporter.image.tag -}}
+{{- $region := .Values.region | required ".Values.region is required." -}}
+{{- $imageDomain := "" -}}
+{{- $imageDomain = index .Values.dcgmExporter.image.repositoryDomainMap .Values.region -}}
+{{- if not $imageDomain -}}
+{{- $imageDomain = .Values.dcgmExporter.image.repositoryDomainMap.public -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $imageDomain .Values.dcgmExporter.image.repository .Values.dcgmExporter.image.tag -}}
 {{- end -}}
 
 {{/*

--- a/helm/templates/dcgm-exporter-daemonset.yaml
+++ b/helm/templates/dcgm-exporter-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
                 values: {{ .Values.gpuInstances | toYaml | nindent 16 }}
       containers:
       - name: dcgm-exporter
-        image: "{{ .Values.dcgmExporter.image.repository }}:{{ .Values.dcgmExporter.image.tag }}"
+        image: {{ template "dcgm-exporter.image" . }}
         args:
         {{- range $.Values.dcgmExporter.arguments }}
         - {{ . }}

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
-        # - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
+        - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
         - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
-        - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
+        # - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -40,7 +40,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.1.0
+    tag: 1.0.4
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -194,7 +194,12 @@ dcgmExporter:
   image:
     repository: dcgm-exporter
     tag: 3.3.3-3.3.1-ubuntu22.04
-    repositoryDomain: nvcr.io/nvidia/k8s
+    repositoryDomainMap:
+      public: nvcr.io/nvidia/k8s
+      cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
+      cn-northwest-1: 934860584483.dkr.ecr.cn-northwest-1.amazonaws.com.cn
+      us-gov-east-1: 743662458514.dkr.ecr.us-gov-east-1.amazonaws.com
+      us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
   service:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -40,7 +40,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.0.4
+    tag: 1.1.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -192,8 +192,9 @@ agent:
 dcgmExporter:
   name:
   image:
-    repository: nvcr.io/nvidia/k8s/dcgm-exporter
+    repository: dcgm-exporter
     tag: 3.3.3-3.3.1-ubuntu22.04
+    repositoryDomain: nvcr.io/nvidia/k8s
   configmap: dcgm-exporter-config-map
   arguments: ["--web-config-file=/etc/dcgm-exporter/web-config.yaml"]
   service:


### PR DESCRIPTION
*Description of changes:*
Use domain map structure in dcgm image configuration to dynamically build image URI based on region values. The public/commercial regions will still use the public image from Nvidia, but other regions would use vended images. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
