### PR TITLE
E2E Test: Add imagePullPolicy to use latest Operator version

### DIFF
--- a/.github/workflows/appsignals-e2e-test.yml
+++ b/.github/workflows/appsignals-e2e-test.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Patch the CloudWatch Agent Operator image and restart CloudWatch pods
         run: |
-          kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${{ env.ECR_OPERATOR_STAGING_IMAGE }}"}]'
+          kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${{ env.ECR_OPERATOR_STAGING_IMAGE }}"}, {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Always"}]]'
           kubectl delete pods --all -n amazon-cloudwatch
           kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
 


### PR DESCRIPTION
Tests have been using the old version of the operator for some time because the cluster already had a version of the ECR from before. During the test we will patch the deployment to use the latest ECR by setting the `imagePullPolicy` to `Always`, which was `IfNotPresent` by default.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
