### PR TITLE
Add workflow_dispatch to e2e test. Use e2e test for release workflow

### DIFF
--- a/.github/workflows/appsignals-e2e-test.yml
+++ b/.github/workflows/appsignals-e2e-test.yml
@@ -7,6 +7,7 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: App Signals Enablement E2E Testing
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       # Ensure two tests do not run on the same cluster at the same time through GitHub Action concurrency

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   integ-test:
-    uses: ./.github/workflows/eks-add-on-integ-test.yml
+    uses: ./.github/workflows/appsignals-e2e-test.yml
     secrets: inherit
 
   push-release-ecr:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Uses the appsignals e2e test before uploading the release artifact
- Adds workflow_dispatch to the e2e test so we can run the action manually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
