### PR TITLE
Use template variables for auto instrumentation images

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -128,6 +128,20 @@ Get the current recommended dcgm-exporter image for a region
 {{- end -}}
 
 {{/*
+Get the current recommended auto instrumentation java image
+*/}}
+{{- define "auto-instrumentation-java.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.java.repositoryDomain .Values.manager.autoInstrumentationImage.java.repository .Values.manager.autoInstrumentationImage.java.tag -}}
+{{- end -}}
+
+{{/*
+Get the current recommended auto instrumentation python image
+*/}}
+{{- define "auto-instrumentation-python.image" -}}
+{{- printf "%s/%s:%s" .Values.manager.autoInstrumentationImage.python.repositoryDomain .Values.manager.autoInstrumentationImage.python.repository .Values.manager.autoInstrumentationImage.python.tag -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "amazon-cloudwatch-observability.labels" -}}

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -27,8 +27,8 @@ spec:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
-        - "--auto-instrumentation-java-image={{ .Values.manager.autoInstrumentationImage.java.repository }}:{{ .Values.manager.autoInstrumentationImage.java.tag }}"
-        - "--auto-instrumentation-python-image={{ .Values.manager.autoInstrumentationImage.python.repository }}:{{ .Values.manager.autoInstrumentationImage.python.tag }}"
+        - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" }}"
+        - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -49,10 +49,12 @@ manager:
       us-gov-west-1: 743662458514.dkr.ecr.us-gov-west-1.amazonaws.com
   autoInstrumentationImage:
     java:
-      repository: public.ecr.aws/aws-observability/adot-autoinstrumentation-java
+      repositoryDomain: public.ecr.aws/aws-observability
+      repository: adot-autoinstrumentation-java
       tag: v1.31.1
     python:
-      repository: public.ecr.aws/aws-observability/adot-autoinstrumentation-python
+      repositoryDomain: public.ecr.aws/aws-observability
+      repository: adot-autoinstrumentation-python
       tag: v0.0.1
   autoAnnotateAutoInstrumentation:
     java:


### PR DESCRIPTION
*Description of changes:*
Currently, auto instrumentation image (java and python) URIs are hard-coded to use the public domain. This change will break the hard-coded URIs into domain and repository fields then build a full URI in the template file `_helpers.tpl`. The operator deployment spec then uses that built full URI. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
