### PR TITLE
Udpate list of supported GPU instances

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,7 +19,7 @@ region:
 
 gpuNodeLabelKey: node.kubernetes.io/instance-type
 ## NVIDIA GPU instance types
-gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3s.4xlarge, g3s.8xlarge, g3s.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal ]
+gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal ]
 
 containerLogs:
   enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,7 +19,7 @@ region:
 
 gpuNodeLabelKey: node.kubernetes.io/instance-type
 ## NVIDIA GPU instance types
-gpuInstances: [ p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, g3s.xlarge, g3s.4xlarge, g3s.8xlarge, g3s.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal ]
+gpuInstances: [ p2.xlarge, p2.8xlarge, p2.16xlarge, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge, g3s.xlarge, g3s.4xlarge, g3s.8xlarge, g3s.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal ]
 
 containerLogs:
   enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,7 +19,7 @@ region:
 
 gpuNodeLabelKey: node.kubernetes.io/instance-type
 ## NVIDIA GPU instance types
-gpuInstances: [ g3s.xlarge, g3.4xlarge, g3.8xlarge, g3.16xlarge, g4dn.12xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.metal, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.24xlarge, g5.48xlarge, g5.8xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal, p2.xlarge, p2.8xlarge, p2.16xlarg, p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, p5.48xlarge ]
+gpuInstances: [ p3.2xlarge, p3.8xlarge, p3.16xlarge, p3dn.24xlarge, p4d.24xlarge, p4de.24xlarge, g3s.xlarge, g3s.4xlarge, g3s.8xlarge, g3s.16xlarge, g4dn.xlarge, g4dn.2xlarge, g4dn.4xlarge, g4dn.8xlarge, g4dn.16xlarge, g4dn.12xlarge, g4dn.metal, g4ad.xlarge, g4ad.2xlarge, g4ad.4xlarge, g4ad.8xlarge, g4ad.16xlarge, g5.xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g5.16xlarge, g5.12xlarge, g5.24xlarge, g5.48xlarge, g5g.xlarge, g5g.2xlarge, g5g.4xlarge, g5g.8xlarge, g5g.16xlarge, g5g.metal ]
 
 containerLogs:
   enabled: true


### PR DESCRIPTION
*Description of changes:*
The allowlist for GPU metrics is missing supported NVIDIA GPU instance types by AWS. Currently supported GPU instances can be found here: 
- https://aws.amazon.com/ec2/instance-types/#Accelerated_Computing
- https://docs.aws.amazon.com/dlami/latest/devguide/gpu.html


Compiled list:
```
p2.xlarge
p2.8xlarge
p2.16xlarge

p3.2xlarge
p3.8xlarge
p3.16xlarge
p3dn.24xlarge

p4d.24xlarge
p4de.24xlarge

p5.48xlarge

g3s.xlarge
g3.4xlarge
g3.8xlarge
g3.16xlarge

g4dn.xlarge
g4dn.2xlarge
g4dn.4xlarge
g4dn.8xlarge
g4dn.16xlarge
g4dn.12xlarge
g4dn.metal
g4ad.xlarge
g4ad.2xlarge
g4ad.4xlarge
g4ad.8xlarge
g4ad.16xlarge

g5.xlarge
g5.2xlarge
g5.4xlarge
g5.8xlarge
g5.16xlarge
g5.12xlarge
g5.24xlarge
g5.48xlarge

g5g.xlarge
g5g.2xlarge
g5g.4xlarge
g5g.8xlarge
g5g.16xlarge
g5g.metal
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
