### PR TITLE
Fixing integration-test validator for mutating webhook count

### DIFF
--- a/integration-tests/eks/validateResources_test.go
+++ b/integration-tests/eks/validateResources_test.go
@@ -169,7 +169,7 @@ func TestOperatorOnEKs(t *testing.T) {
 	//Validating MutatingWebhookConfiguration
 	mutatingWebhookConfigurations, err := ListMutatingWebhookConfigurations(clientSet)
 	assert.NoError(t, err)
-	assert.Len(t, mutatingWebhookConfigurations.Items[0].Webhooks, 3)
+	assert.Len(t, mutatingWebhookConfigurations.Items[0].Webhooks, 5)
 	// searches
 	// - amazon-cloudwatch-observability-mutating-webhook-configuration
 	assert.Equal(t, addOnName+"-mutating-webhook-configuration", mutatingWebhookConfigurations.Items[0].Name)


### PR DESCRIPTION
*Description of changes:*
1. Operator deploys 5 mutating webhooks - see list here - https://github.com/aws/amazon-cloudwatch-agent-operator/blob/main/config/webhook/manifests.yaml
2. This test update the mutating webhook count in the validator for integration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
