### PR TITLE
Compare Support EKS Versions VS The K8S GO Client Version

### DIFF
--- a/.github/workflows/eks-add-on-integ-test.yml
+++ b/.github/workflows/eks-add-on-integ-test.yml
@@ -76,6 +76,22 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
+      - name: Confirm EKS Version Support
+        run: |
+          if [[ 
+            $(go list -m k8s.io/client-go | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+            || $(go list -m k8s.io/apimachinery | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+            || $(go list -m k8s.io/component-base | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+            || $(go list -m k8s.io/kubectl | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+          ]]; then 
+          echo k8s.io/client-go $(go list -m k8s.io/client-go) is less than ${{ matrix.arrays.k8sVersion }}
+          echo or k8s.io/apimachinery $(go list -m k8s.io/apimachinery) is less than ${{ matrix.arrays.k8sVersion }}
+          echo or k8s.io/component-base $(go list -m k8s.io/component-base) is less than ${{ matrix.arrays.k8sVersion }}
+          echo or k8s.io/kubectl $(go list -m k8s.io/kubectl) is less than ${{ matrix.arrays.k8sVersion }}, fail test
+          echo "please run go get -u && go mod tidy"
+          exit 1; 
+          fi
+
       - name: Verify Terraform version
         run: terraform --version
 

--- a/.github/workflows/eks-beta-add-on-integ-test.yml
+++ b/.github/workflows/eks-beta-add-on-integ-test.yml
@@ -76,6 +76,22 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
+      - name: Confirm EKS Version Support
+        run: |
+          if [[ 
+            $(go list -m k8s.io/client-go | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+            || $(go list -m k8s.io/apimachinery | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+            || $(go list -m k8s.io/component-base | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+            || $(go list -m k8s.io/kubectl | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo ${{ matrix.arrays.k8sVersion }} | cut -d '.' -f 2)
+          ]]; then 
+          echo k8s.io/client-go $(go list -m k8s.io/client-go) is less than ${{ matrix.arrays.k8sVersion }}
+          echo or k8s.io/apimachinery $(go list -m k8s.io/apimachinery) is less than ${{ matrix.arrays.k8sVersion }}
+          echo or k8s.io/component-base $(go list -m k8s.io/component-base) is less than ${{ matrix.arrays.k8sVersion }}
+          echo or k8s.io/kubectl $(go list -m k8s.io/kubectl) is less than ${{ matrix.arrays.k8sVersion }}, fail test
+          echo "please run go get -u && go mod tidy"
+          exit 1; 
+          fi
+
       - name: Verify Terraform version
         run: terraform --version
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Compare the minor versions of k8s go client to EKS version supported by beta

integ test workflow
https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/8299991448/job/22716936891

local terminal tests 

Exit
```
if [[              
            $(go list -m k8s.io/client-go | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.30 | cut -d '.' -f 2)
            || $(go list -m k8s.io/apimachinery | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.29 | cut -d '.' -f 2)
            || $(go list -m k8s.io/component-base | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.29 | cut -d '.' -f 2)
            || $(go list -m k8s.io/kubectl | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.29 | cut -d '.' -f 2)
          ]]; then
          echo k8s.io/client-go $(go list -m k8s.io/client-go) is less than 1.29
          echo or k8s.io/apimachinery $(go list -m k8s.io/apimachinery) is less than 1.29
          echo or k8s.io/component-base $(go list -m k8s.io/component-base) is less than 1.29
          echo or k8s.io/kubectl $(go list -m k8s.io/kubectl) is less than 1.29, fail test
          echo "please run go get -u && go mod tidy"
          exit 1;
          fi
```

No exit 
```
if [[              
            $(go list -m k8s.io/client-go | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.28 | cut -d '.' -f 2)
            || $(go list -m k8s.io/apimachinery | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.29 | cut -d '.' -f 2)
            || $(go list -m k8s.io/component-base | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.29 | cut -d '.' -f 2)
            || $(go list -m k8s.io/kubectl | cut -d ' ' -f 2 | cut -d '.' -f 2) -lt $( echo 1.29 | cut -d '.' -f 2)
          ]]; then
          echo k8s.io/client-go $(go list -m k8s.io/client-go) is less than 1.29
          echo or k8s.io/apimachinery $(go list -m k8s.io/apimachinery) is less than 1.29
          echo or k8s.io/component-base $(go list -m k8s.io/component-base) is less than 1.29
          echo or k8s.io/kubectl $(go list -m k8s.io/kubectl) is less than 1.29, fail test
          echo "please run go get -u && go mod tidy"
          exit 1;
          fi
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
