### PR TITLE
fix template value subs for auto inst images

### DIFF
--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -27,8 +27,8 @@ spec:
       - image: {{ template "cloudwatch-agent-operator.image" . }}
         args:
         - {{ printf "--auto-annotation-config=%s" (.Values.manager.autoAnnotateAutoInstrumentation | toJson) | quote }}
-        - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" }}"
-        - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" }}"
+        - "--auto-instrumentation-java-image={{ template "auto-instrumentation-java.image" . }}"
+        - "--auto-instrumentation-python-image={{ template "auto-instrumentation-python.image" . }}"
         - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
         command:
         - /manager


### PR DESCRIPTION
*Description of changes:*
Add missing "." to correctly substitute auto instrumentation images URIs with template values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
