### PR TITLE
Fix role conflict.

### DIFF
--- a/.github/workflows/appsignals-python-e2e-test.yml
+++ b/.github/workflows/appsignals-python-e2e-test.yml
@@ -79,7 +79,7 @@ jobs:
           --name srvc-acc-${{ env.TESTING_ID }} \
           --namespace ${{ env.SAMPLE_APP_NAMESPACE }} \
           --cluster ${{ inputs.test-python-cluster-name }} \
-          --role-name eks-s3-access-${{ env.TESTING_ID }} \
+          --role-name eks-s3-access-python-${{ env.TESTING_ID }} \
           --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess \
           --region ${{ env.AWS_DEFAULT_REGION }} \
           --approve

--- a/.github/workflows/build-and-upload-integration.yml
+++ b/.github/workflows/build-and-upload-integration.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - python_e2e_role
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/build-and-upload-integration.yml
+++ b/.github/workflows/build-and-upload-integration.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - python_e2e_role
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true


### PR DESCRIPTION
Fix E2E test Java & python service account role conflict.

An example that test passed:
https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/8424510803

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
