### PR TITLE
Remove code for overriding validation templates

### DIFF
--- a/.github/workflows/appsignals-java-e2e-test.yml
+++ b/.github/workflows/appsignals-java-e2e-test.yml
@@ -46,44 +46,6 @@ jobs:
           repository: aws-observability/aws-application-signals-test-framework
           ref: main
 
-      - name: Update validation template with new changes
-        run: |
-          sed -i "s#e2e-test-bucket-name#::s3:::e2e-test-bucket-name#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
-
-          sed -i "s#aws_local_service#aws.local.service#g" ./validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
-          sed -i "s#aws_local_service#aws.local.service#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
-          sed -i "s#aws_local_service#aws.local.service#g" ./validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
-          sed -i "s#aws_local_service#aws.local.service#g" ./validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
-
-          sed -i "s#aws_remote_service#aws.remote.service#g" ./validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
-          sed -i "s#aws_remote_service#aws.remote.service#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
-          sed -i "s#aws_remote_service#aws.remote.service#g" ./validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
-          sed -i "s#aws_remote_service#aws.remote.service#g" ./validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
-
-          sed -i "s#aws_local_operation#aws.local.operation#g" ./validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
-          sed -i "s#aws_local_operation#aws.local.operation#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
-          sed -i "s#aws_local_operation#aws.local.operation#g" ./validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
-          sed -i "s#aws_local_operation#aws.local.operation#g" ./validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
-
-          sed -i "s#aws_remote_operation#aws.remote.operation#g" ./validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
-          sed -i "s#aws_remote_operation#aws.remote.operation#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
-          sed -i "s#aws_remote_operation#aws.remote.operation#g" ./validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
-          sed -i "s#aws_remote_operation#aws.remote.operation#g" ./validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
-
-          sed -i "s#HostedIn_EKS_Cluster#HostedIn.EKS.Cluster#g" ./validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
-          sed -i "s#HostedIn_EKS_Cluster#HostedIn.EKS.Cluster#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
-          sed -i "s#HostedIn_EKS_Cluster#HostedIn.EKS.Cluster#g" ./validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
-          sed -i "s#HostedIn_EKS_Cluster#HostedIn.EKS.Cluster#g" ./validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
-
-          sed -i "s#HostedIn_K8s_Namespace#HostedIn.K8s.Namespace#g" ./validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
-          sed -i "s#HostedIn_K8s_Namespace#HostedIn.K8s.Namespace#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
-          sed -i "s#HostedIn_K8s_Namespace#HostedIn.K8s.Namespace#g" ./validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
-          sed -i "s#HostedIn_K8s_Namespace#HostedIn.K8s.Namespace#g" ./validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
-
-          cat ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
-
-          sed -i "s#aws_remote_target#aws.remote.target#g" ./validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
-
       - name: Download enablement script
         uses: actions/checkout@v4
         with:
@@ -170,7 +132,7 @@ jobs:
 
       - name: Patch the CloudWatch Agent Operator image and restart CloudWatch pods
         run: |
-          kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}"}, {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Always"}, {"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": ["--auto-instrumentation-java-image=611364707713.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-java-operator-staging:1.33.0-SNAPSHOT-93870a5"]}]]'
+          kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}"}, {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Always"}]]'
           kubectl delete pods --all -n amazon-cloudwatch
           kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
 
@@ -243,10 +205,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/outgoing-http-call/
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/aws-sdk-call/
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/client-call/
+          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/outgoing-http-call/; echo
+          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/aws-sdk-call/; echo
+          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/; echo
+          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/client-call/; echo
 
       - name: Build Gradle
         run: ./gradlew
@@ -287,22 +249,22 @@ jobs:
           --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
           --rollup'
 
-      # - name: Call endpoints and validate generated traces
-      #   id: trace-validation
-      #   if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
-      #   run: ./gradlew validator:run --args='-c eks/trace-validation.yml
-      #     --testing-id ${{ env.TESTING_ID }}
-      #     --endpoint http://${{ env.APP_ENDPOINT }}
-      #     --region ${{ env.AWS_DEFAULT_REGION }}
-      #     --account-id ${{ env.TEST_ACCOUNT }}
-      #     --metric-namespace ${{ env.METRIC_NAMESPACE }}
-      #     --log-group ${{ env.LOG_GROUP }}
-      #     --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-      #     --platform-info ${{ inputs.test-java-cluster-name }}
-      #     --service-name sample-application-${{ env.TESTING_ID }}
-      #     --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-      #     --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
-      #     --rollup'
+      - name: Call endpoints and validate generated traces
+        id: trace-validation
+        if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c eks/trace-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.APP_ENDPOINT }}
+          --region ${{ env.AWS_DEFAULT_REGION }}
+          --account-id ${{ env.TEST_ACCOUNT }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP }}
+          --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+          --platform-info ${{ inputs.test-java-cluster-name }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
+          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --rollup'
 
       # Clean up Procedures
 


### PR DESCRIPTION
The validators have been updated in the framework repository. Removing overriding validation template code.

Test run: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/8529786385/job/23366271660

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
