### PR TITLE
Always insert mutations for resources in scope and restart only required resources in namespace scope

### DIFF
--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -18,9 +18,6 @@ type insertAnnotationMutation struct {
 }
 
 func (m *insertAnnotationMutation) Mutate(annotations map[string]string) bool {
-	if !m.shouldMutate(annotations) {
-		return false
-	}
 	var mutated bool
 	for key, value := range m.insert {
 		if _, ok := annotations[key]; !ok {
@@ -29,15 +26,6 @@ func (m *insertAnnotationMutation) Mutate(annotations map[string]string) bool {
 		}
 	}
 	return mutated
-}
-
-func (m *insertAnnotationMutation) shouldMutate(annotations map[string]string) bool {
-	for key := range m.insert {
-		if _, ok := annotations[key]; ok {
-			return false
-		}
-	}
-	return true
 }
 
 // NewInsertAnnotationMutation creates a new mutation that inserts annotations. All provided annotation keys

--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -76,8 +76,7 @@ func NewAnnotationMutator(mutations []AnnotationMutation) AnnotationMutator {
 	return AnnotationMutator{mutations: mutations}
 }
 
-// Mutate modifies the object's annotations based on the mutator's mutations. Returns all the mutated annotations and
-// whether any of the mutations changed the annotations.
+// Mutate modifies the object's annotations based on the mutator's mutations. Returns all the mutated annotations.
 func (m *AnnotationMutator) Mutate(obj metav1.Object) map[string]string {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {

--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -81,8 +81,8 @@ func NewAnnotationMutator(mutations []AnnotationMutation) AnnotationMutator {
 	return AnnotationMutator{mutations: mutations}
 }
 
-// Mutate modifies the object's annotations based on the mutator's mutations. Returns whether any of the
-// mutations changed the annotations.
+// Mutate modifies the object's annotations based on the mutator's mutations. Returns all the mutated annotations and
+// whether any of the mutations changed the annotations.
 func (m *AnnotationMutator) Mutate(obj metav1.Object) (map[string]string, bool) {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {

--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -9,26 +9,23 @@ import (
 
 // AnnotationMutation is used to modify an annotation map.
 type AnnotationMutation interface {
-	// Mutate attempts to modify the annotations map. Returns the mutated annotations if any and whether the function
-	// changed the annotations.
-	Mutate(annotations map[string]string) (map[string]string, bool)
+	// Mutate attempts to modify the annotations map. Returns the mutated annotations if any.
+	Mutate(annotations map[string]string) map[string]string
 }
 
 type insertAnnotationMutation struct {
 	insert map[string]string
 }
 
-func (m *insertAnnotationMutation) Mutate(annotations map[string]string) (map[string]string, bool) {
-	var mutated bool
+func (m *insertAnnotationMutation) Mutate(annotations map[string]string) map[string]string {
 	mutatedAnnotations := make(map[string]string)
 	for key, value := range m.insert {
 		if _, ok := annotations[key]; !ok {
 			annotations[key] = value
 			mutatedAnnotations[key] = value
-			mutated = true
 		}
 	}
-	return mutatedAnnotations, mutated
+	return mutatedAnnotations
 }
 
 // NewInsertAnnotationMutation creates a new mutation that inserts annotations. Any missing annotation key
@@ -41,20 +38,18 @@ type removeAnnotationMutation struct {
 	remove []string
 }
 
-func (m *removeAnnotationMutation) Mutate(annotations map[string]string) (map[string]string, bool) {
-	if !m.shouldMutate(annotations) {
-		return nil, false
-	}
-	var mutated bool
+func (m *removeAnnotationMutation) Mutate(annotations map[string]string) map[string]string {
 	mutatedAnnotations := make(map[string]string)
+	if !m.shouldMutate(annotations) {
+		return mutatedAnnotations
+	}
 	for _, key := range m.remove {
 		if value, ok := annotations[key]; ok {
 			delete(annotations, key)
 			mutatedAnnotations[key] = value
-			mutated = true
 		}
 	}
-	return mutatedAnnotations, mutated
+	return mutatedAnnotations
 }
 
 func (m *removeAnnotationMutation) shouldMutate(annotations map[string]string) bool {
@@ -83,22 +78,18 @@ func NewAnnotationMutator(mutations []AnnotationMutation) AnnotationMutator {
 
 // Mutate modifies the object's annotations based on the mutator's mutations. Returns all the mutated annotations and
 // whether any of the mutations changed the annotations.
-func (m *AnnotationMutator) Mutate(obj metav1.Object) (map[string]string, bool) {
+func (m *AnnotationMutator) Mutate(obj metav1.Object) map[string]string {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	var anyMutated bool
 	allMutatedAnnotations := make(map[string]string)
 	for _, mutation := range m.mutations {
-		mutatedAnnotations, mutated := mutation.Mutate(annotations)
-		anyMutated = anyMutated || mutated
-		if mutated {
-			for k, v := range mutatedAnnotations {
-				allMutatedAnnotations[k] = v
-			}
+		mutatedAnnotations := mutation.Mutate(annotations)
+		for k, v := range mutatedAnnotations {
+			allMutatedAnnotations[k] = v
 		}
 	}
 	obj.SetAnnotations(annotations)
-	return allMutatedAnnotations, anyMutated
+	return allMutatedAnnotations
 }

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -16,7 +16,6 @@ func TestMutateAnnotations(t *testing.T) {
 		mutations              []AnnotationMutation
 		wantAnnotations        map[string]string
 		wantMutatedAnnotations map[string]string
-		wantMutated            bool
 	}{
 		"TestInsert/Conflicts": {
 			annotations: map[string]string{
@@ -37,7 +36,6 @@ func TestMutateAnnotations(t *testing.T) {
 			wantMutatedAnnotations: map[string]string{
 				"keyC": "4",
 			},
-			wantMutated: true,
 		},
 		"TestInsert/NoConflicts": {
 			annotations: nil,
@@ -55,7 +53,6 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyA": "3",
 				"keyC": "4",
 			},
-			wantMutated: true,
 		},
 		"TestInsert/Multiple": {
 			annotations: nil,
@@ -75,7 +72,6 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyA": "3",
 				"keyC": "4",
 			},
-			wantMutated: true,
 		},
 		"TestRemove/Conflicts": {
 			annotations: map[string]string{
@@ -93,7 +89,6 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyB": "2",
 			},
 			wantMutatedAnnotations: map[string]string{},
-			wantMutated:            false,
 		},
 		"TestRemove/NoConflicts": {
 			annotations: map[string]string{
@@ -111,7 +106,6 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyA": "1",
 				"keyB": "2",
 			},
-			wantMutated: true,
 		},
 		"TestRemove/Multiple": {
 			annotations: map[string]string{
@@ -131,7 +125,6 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyA": "1",
 				"keyB": "2",
 			},
-			wantMutated: true,
 		},
 		"TestBoth": {
 			annotations: map[string]string{
@@ -153,7 +146,6 @@ func TestMutateAnnotations(t *testing.T) {
 			wantMutatedAnnotations: map[string]string{
 				"keyA": "3",
 			},
-			wantMutated: true,
 		},
 	}
 	for name, testCase := range testCases {
@@ -162,8 +154,7 @@ func TestMutateAnnotations(t *testing.T) {
 				Annotations: testCase.annotations,
 			}
 			m := NewAnnotationMutator(testCase.mutations)
-			mutatedAnnotations, isMutated := m.Mutate(&obj)
-			assert.Equal(t, testCase.wantMutated, isMutated)
+			mutatedAnnotations := m.Mutate(&obj)
 			assert.Equal(t, testCase.wantMutatedAnnotations, mutatedAnnotations)
 			assert.Equal(t, testCase.wantAnnotations, obj.GetAnnotations())
 		})

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -12,10 +12,11 @@ import (
 
 func TestMutateAnnotations(t *testing.T) {
 	testCases := map[string]struct {
-		annotations     map[string]string
-		mutations       []AnnotationMutation
-		wantAnnotations map[string]string
-		wantMutated     bool
+		annotations            map[string]string
+		mutations              []AnnotationMutation
+		wantAnnotations        map[string]string
+		wantMutatedAnnotations map[string]string
+		wantMutated            bool
 	}{
 		"TestInsert/Conflicts": {
 			annotations: map[string]string{
@@ -33,6 +34,9 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyB": "2",
 				"keyC": "4",
 			},
+			wantMutatedAnnotations: map[string]string{
+				"keyC": "4",
+			},
 			wantMutated: true,
 		},
 		"TestInsert/NoConflicts": {
@@ -44,6 +48,10 @@ func TestMutateAnnotations(t *testing.T) {
 				}),
 			},
 			wantAnnotations: map[string]string{
+				"keyA": "3",
+				"keyC": "4",
+			},
+			wantMutatedAnnotations: map[string]string{
 				"keyA": "3",
 				"keyC": "4",
 			},
@@ -60,6 +68,10 @@ func TestMutateAnnotations(t *testing.T) {
 				}),
 			},
 			wantAnnotations: map[string]string{
+				"keyA": "3",
+				"keyC": "4",
+			},
+			wantMutatedAnnotations: map[string]string{
 				"keyA": "3",
 				"keyC": "4",
 			},
@@ -80,7 +92,8 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyA": "1",
 				"keyB": "2",
 			},
-			wantMutated: false,
+			wantMutatedAnnotations: map[string]string{},
+			wantMutated:            false,
 		},
 		"TestRemove/NoConflicts": {
 			annotations: map[string]string{
@@ -94,7 +107,11 @@ func TestMutateAnnotations(t *testing.T) {
 				}),
 			},
 			wantAnnotations: map[string]string{},
-			wantMutated:     true,
+			wantMutatedAnnotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			wantMutated: true,
 		},
 		"TestRemove/Multiple": {
 			annotations: map[string]string{
@@ -110,7 +127,11 @@ func TestMutateAnnotations(t *testing.T) {
 				}),
 			},
 			wantAnnotations: map[string]string{},
-			wantMutated:     true,
+			wantMutatedAnnotations: map[string]string{
+				"keyA": "1",
+				"keyB": "2",
+			},
+			wantMutated: true,
 		},
 		"TestBoth": {
 			annotations: map[string]string{
@@ -129,6 +150,9 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyA": "3",
 				"keyB": "2",
 			},
+			wantMutatedAnnotations: map[string]string{
+				"keyA": "3",
+			},
 			wantMutated: true,
 		},
 	}
@@ -138,8 +162,9 @@ func TestMutateAnnotations(t *testing.T) {
 				Annotations: testCase.annotations,
 			}
 			m := NewAnnotationMutator(testCase.mutations)
-			_, isMutated := m.Mutate(&obj)
+			mutatedAnnotations, isMutated := m.Mutate(&obj)
 			assert.Equal(t, testCase.wantMutated, isMutated)
+			assert.Equal(t, testCase.wantMutatedAnnotations, mutatedAnnotations)
 			assert.Equal(t, testCase.wantAnnotations, obj.GetAnnotations())
 		})
 	}

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -138,7 +138,8 @@ func TestMutateAnnotations(t *testing.T) {
 				Annotations: testCase.annotations,
 			}
 			m := NewAnnotationMutator(testCase.mutations)
-			assert.Equal(t, testCase.wantMutated, m.Mutate(&obj))
+			_, isMutated := m.Mutate(&obj)
+			assert.Equal(t, testCase.wantMutated, isMutated)
 			assert.Equal(t, testCase.wantAnnotations, obj.GetAnnotations())
 		})
 	}

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -31,8 +31,9 @@ func TestMutateAnnotations(t *testing.T) {
 			wantAnnotations: map[string]string{
 				"keyA": "1",
 				"keyB": "2",
+				"keyC": "4",
 			},
-			wantMutated: false,
+			wantMutated: true,
 		},
 		"TestInsert/NoConflicts": {
 			annotations: nil,

--- a/pkg/instrumentation/auto/callback.go
+++ b/pkg/instrumentation/auto/callback.go
@@ -94,8 +94,8 @@ func (m *AnnotationMutators) patchFunc(ctx context.Context, callback objectCallb
 }
 
 func (m *AnnotationMutators) restartNamespaceFunc(ctx context.Context) objectCallbackFunc {
-	return func(obj client.Object, mutatedAnnotations_ any) (any, bool) {
-		mutatedAnnotations, ok := mutatedAnnotations_.(map[string]string)
+	return func(obj client.Object, previousResult any) (any, bool) {
+		mutatedAnnotations, ok := previousResult.(map[string]string)
 		if !ok {
 			return nil, false
 		}

--- a/pkg/instrumentation/auto/callback.go
+++ b/pkg/instrumentation/auto/callback.go
@@ -19,7 +19,8 @@ import (
 type objectCallbackFunc func(client.Object, any) (any, bool)
 
 // chainCallbacks is a func that invokes functions in a callback chain one after another as long as each function
-// returns true. Eventually returns true if all callbacks in chain are executed and false otherwise.
+// returns true. The result of each function in the callback is passed along to the next. Eventually returns true if
+// all callbacks in chain are executed and false otherwise.
 func chainCallbacks(fns ...objectCallbackFunc) objectCallbackFunc {
 	return func(obj client.Object, passToNext any) (any, bool) {
 		var ok bool

--- a/pkg/instrumentation/auto/restart.go
+++ b/pkg/instrumentation/auto/restart.go
@@ -25,10 +25,10 @@ type restartAnnotationMutation struct {
 
 var _ instrumentation.AnnotationMutation = (*restartAnnotationMutation)(nil)
 
-func (m *restartAnnotationMutation) Mutate(annotations map[string]string) (map[string]string, bool) {
+func (m *restartAnnotationMutation) Mutate(annotations map[string]string) map[string]string {
 	restartedAt := time.Now().Format(time.RFC3339)
 	annotations[restartedAtAnnotation] = restartedAt
-	return map[string]string{restartedAtAnnotation: restartedAt}, true
+	return map[string]string{restartedAtAnnotation: restartedAt}
 }
 
 // restart mutates the object's restartedAtAnnotation with the current time.


### PR DESCRIPTION
*Description of changes:* 
1) If a resource is in scope for auto-annotation per the args passed to the operator and the resource itself on the cluster is in a state such that it has only the auto-annotate annotation or the instr-inject annotation, we would previously skip such resources. Updating this logic to add the missing annotation in such scenarios. Post these changes, the behavior for auto-annotation can be summarized as:
* If a resource is in the operator args and does not already have either auto-instr or auto-annotate annotations, add them
* If a resource is not in the operator args and has both annotations, remove both the annotations
* If a resource is not in the operator args and has only one annotation, it implies it was manually annotated, so leave it untouched

2) When a namespace is auto-annotated, the current logic restarts all the resources in the namespace. Optimizing this logic to only restart resources that do NOT already have the auto-instr annotation.
This prevents an unnecessary restart for:
* Resources in the namespace that were manually tagged with auto-instr annotation
* Resources in the namespace that were explicitly passed in to the operator args and hence was already restarted when the operator added the annotations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
