### PR TITLE
Rename app_signals to application_signals in cwa config

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -182,12 +182,12 @@ agent:
           "kubernetes": {
             "enhanced_container_insights": true
           },
-          "app_signals": { }
+          "application_signals": { }
         }
       },
       "traces": {
         "traces_collected": {
-          "app_signals": { }
+          "application_signals": { }
         }
       }
     }

--- a/internal/manifests/collector/configmap_test.go
+++ b/internal/manifests/collector/configmap_test.go
@@ -23,7 +23,7 @@ func TestDesiredConfigMap(t *testing.T) {
 		expectedLables["app.kubernetes.io/version"] = "0.0.0"
 
 		expectedData := map[string]string{
-			"cwagentconfig.json": `{"logs":{"metrics_collected":{"app_signals":{},"kubernetes":{"enhanced_container_insights":true}}},"traces":{"traces_collected":{"app_signals":{}}}}`,
+			"cwagentconfig.json": `{"logs":{"metrics_collected":{"application_signals":{},"kubernetes":{"enhanced_container_insights":true}}},"traces":{"traces_collected":{"application_signals":{}}}}`,
 		}
 
 		param := deploymentParams()

--- a/internal/manifests/collector/testdata/test.json
+++ b/internal/manifests/collector/testdata/test.json
@@ -4,12 +4,12 @@
       "kubernetes": {
         "enhanced_container_insights": true
       },
-      "app_signals": { }
+      "application_signals": { }
     }
   },
   "traces": {
     "traces_collected": {
-      "app_signals": { }
+      "application_signals": { }
     }
   }
 }


### PR DESCRIPTION
Do Not Merge This Until Amazon CloudWatch Agent 1.300037.0 Is Released!!!

*Issue #, if available:*
N/A

*Description of changes:*
Rename app_signals to application_signals


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
