### PR TITLE
Update CW agent and CW operator version tags

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,7 +41,7 @@ manager:
   name:
   image:
     repository: cloudwatch-agent-operator
-    tag: 1.1.0
+    tag: 1.2.0
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn
@@ -145,7 +145,7 @@ agent:
   name:
   image:
     repository: cloudwatch-agent
-    tag: 1.300034.0b498
+    tag: 1.300036.0b573
     repositoryDomainMap:
       public: public.ecr.aws/cloudwatch-agent
       cn-north-1: 934860584483.dkr.ecr.cn-north-1.amazonaws.com.cn

--- a/versions.txt
+++ b/versions.txt
@@ -1,5 +1,5 @@
 # Represents the latest stable release of the CloudWatch Agent
-cloudwatch-agent=1.300035.0b547
+cloudwatch-agent=1.300036.0b573
 
 # Represents the current release of the CloudWatch Agent Operator.
 operator=1.2.0


### PR DESCRIPTION
*Issue #, if available:*
CW agent operator and CW agent versions are not latest that includes Windows CI.

*Description of changes:*
Update CW agent and CW operator tag versions that has Windows CI feature enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
