### PR TITLE
Updated resource counts to account for neuron monitor resources

### DIFF
--- a/integration-tests/eks/resourceCount_linuxonly_test.go
+++ b/integration-tests/eks/resourceCount_linuxonly_test.go
@@ -12,7 +12,7 @@ const (
 	serviceCountWindows = 3
 
 	// DaemonSet count for CW agent on Linux and Windows
-	daemonsetCountLinux   = 6
+	daemonsetCountLinux   = 4
 	daemonsetCountWindows = 2
 
 	// Pods count for CW agent on Linux and Windows

--- a/integration-tests/eks/resourceCount_linuxonly_test.go
+++ b/integration-tests/eks/resourceCount_linuxonly_test.go
@@ -8,11 +8,11 @@ package eks_addon
 
 const (
 	// Services count for CW agent on Linux and Windows
-	serviceCountLinux   = 5
+	serviceCountLinux   = 6
 	serviceCountWindows = 3
 
 	// DaemonSet count for CW agent on Linux and Windows
-	daemonsetCountLinux   = 3
+	daemonsetCountLinux   = 6
 	daemonsetCountWindows = 2
 
 	// Pods count for CW agent on Linux and Windows

--- a/integration-tests/eks/resourceCount_windowslinux_test.go
+++ b/integration-tests/eks/resourceCount_windowslinux_test.go
@@ -8,11 +8,11 @@ package eks_addon
 
 const (
 	// Services count for CW agent on Linux and Windows
-	serviceCountLinux   = 5
+	serviceCountLinux   = 6
 	serviceCountWindows = 3
 
 	// DaemonSet count for CW agent on Linux and Windows
-	daemonsetCountLinux   = 3
+	daemonsetCountLinux   = 4
 	daemonsetCountWindows = 2
 
 	// Pods count for CW agent on Linux and Windows


### PR DESCRIPTION
*Description of changes:* The EKS add-on tests are failing due to a mismatch in the expected counts of resources deployed to the cluster. We are not accounting for the recent neuron-monitor changes.
Updated resource counts to account for neuron monitor resources to fix the tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
