### PR TITLE
Fix CI Windows issue with containerd 1.7

### DIFF
--- a/apis/v1alpha1/amazoncloudwatchagent_types.go
+++ b/apis/v1alpha1/amazoncloudwatchagent_types.go
@@ -153,6 +153,8 @@ type AmazonCloudWatchAgentSpec struct {
 	// Image indicates the container image to use for the OpenTelemetry Collector.
 	// +optional
 	Image string `json:"image,omitempty"`
+	// WorkingDir represents Container's working directory.
+	WorkingDir string `json:"workingDir,omitempty"`
 	// UpgradeStrategy represents how the operator will handle upgrades to the CR when a newer version of the operator is deployed
 	// +optional
 	UpgradeStrategy UpgradeStrategy `json:"upgradeStrategy"`

--- a/apis/v1alpha1/amazoncloudwatchagent_types.go
+++ b/apis/v1alpha1/amazoncloudwatchagent_types.go
@@ -153,7 +153,10 @@ type AmazonCloudWatchAgentSpec struct {
 	// Image indicates the container image to use for the OpenTelemetry Collector.
 	// +optional
 	Image string `json:"image,omitempty"`
-	// WorkingDir represents Container's working directory.
+	// WorkingDir represents Container's working directory. If not specified,
+	// the container runtime's default will be used, which might
+	// be configured in the container image. Cannot be updated.
+	// +optional
 	WorkingDir string `json:"workingDir,omitempty"`
 	// UpgradeStrategy represents how the operator will handle upgrades to the CR when a newer version of the operator is deployed
 	// +optional

--- a/apis/v1alpha2/amazoncloudwatchagent_types.go
+++ b/apis/v1alpha2/amazoncloudwatchagent_types.go
@@ -78,6 +78,11 @@ type AmazonCloudWatchAgentSpec struct {
 	// Image indicates the container image to use for the OpenTelemetry Collector.
 	// +optional
 	Image string `json:"image,omitempty"`
+	// WorkingDir represents Container's working directory. If not specified,
+	// the container runtime's default will be used, which might
+	// be configured in the container image. Cannot be updated.
+	// +optional
+	WorkingDir string `json:"workingDir,omitempty"`
 	// UpgradeStrategy represents how the operator will handle upgrades to the CR when a newer version of the operator is deployed
 	// +optional
 	UpgradeStrategy v1alpha1.UpgradeStrategy `json:"upgradeStrategy"`

--- a/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -7458,6 +7458,11 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              workingDir:
+                description: Container's working directory. If not specified,
+                  the container runtime's default will be used, which might
+                  be configured in the container image. Cannot be updated.
+                type: string
             type: object
           status:
             description: AmazonCloudWatchAgentStatus defines the observed state of

--- a/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -7459,9 +7459,9 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               workingDir:
-                description: Container's working directory. If not specified,
-                  the container runtime's default will be used, which might
-                  be configured in the container image. Cannot be updated.
+                description: WorkingDir represents Container's working directory.
+                  If not specified, the container runtime's default will be used,
+                  which might be configured in the container image. Cannot be updated.
                 type: string
             type: object
           status:

--- a/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -7460,6 +7460,11 @@ spec:
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic
+                workingDir:
+                  description: Container's working directory. If not specified,
+                    the container runtime's default will be used, which might
+                    be configured in the container image. Cannot be updated.
+                  type: string
               type: object
             status:
               description: AmazonCloudWatchAgentStatus defines the observed state of

--- a/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/helm/crds/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -7461,10 +7461,9 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 workingDir:
-                  description: Container's working directory. If not specified,
-                    the container runtime's default will be used, which might
-                    be configured in the container image. Cannot be updated.
-                  type: string
+                  description: WorkingDir represents Container's working directory.
+                    If not specified, the container runtime's default will be used,
+                    which might be configured in the container image. Cannot be updated.
               type: object
             status:
               description: AmazonCloudWatchAgentStatus defines the observed state of

--- a/helm/templates/windows/cloudwatch-agent-windows-daemonset.yaml
+++ b/helm/templates/windows/cloudwatch-agent-windows-daemonset.yaml
@@ -12,6 +12,7 @@ spec:
       runAsUserName: "NT AUTHORITY\\System"
   hostNetwork: true
   image: {{ template "cloudwatch-agent.image" . }}
+  workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
   mode: daemonset
   serviceAccount: {{ template "cloudwatch-agent.serviceAccountName" . }}
   nodeSelector:

--- a/internal/manifests/collector/container.go
+++ b/internal/manifests/collector/container.go
@@ -97,6 +97,7 @@ func Container(cfg config.Config, logger logr.Logger, agent v1alpha1.AmazonCloud
 		Name:            naming.Container(),
 		Image:           image,
 		ImagePullPolicy: agent.Spec.ImagePullPolicy,
+		WorkingDir:      agent.Spec.WorkingDir,
 		VolumeMounts:    volumeMounts,
 		Args:            args,
 		Env:             envVars,


### PR DESCRIPTION
*Issue #, if available:*
Behaviour of `WorkDir` changed with containerd 1.7. This caused Windows CI DS to fail. This fix is backward compatible with both containerd `1.6` and `1.7`. EKS Windows only supports containerd runtime.

*Description of changes:*
Add workingDir field in podSpec of container in CloudWatch Agent Windows DaemonSet

*Testing*
https://github.com/aws/amazon-cloudwatch-agent-operator/pull/158/files

I tested this change locally for both 2019 and 2022 Windows and for both containerd `1.6` and `1.7`.
<img width="1290" alt="Screenshot 2024-04-23 at 6 33 23 AM" src="https://github.com/aws/amazon-cloudwatch-agent-operator/assets/10296556/f8e3a273-d8a6-4a60-bd85-71afca9a8603">
<img width="1488" alt="Screenshot 2024-04-23 at 6 31 45 AM" src="https://github.com/aws/amazon-cloudwatch-agent-operator/assets/10296556/2407c0a8-5351-4d48-bc75-f50cd1df2b3e">
<img width="1488" alt="Screenshot 2024-04-23 at 6 31 30 AM" src="https://github.com/aws/amazon-cloudwatch-agent-operator/assets/10296556/6e06692b-fb45-4518-8c87-b9abd9fa2b59">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
