### PR TITLE
Adding Extra Use Cases for Enablement Experience Integration test 

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -152,16 +152,17 @@ jobs:
           kubectl apply -f integration-tests/manifests/sample-deployment.yaml
           kubectl get pods -A
           kubectl describe pods -n default
-          sleep 10
+          sleep 5
           go test -v -run TestJavaAndPythonDeployment ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestJavaOnlyDeployment ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestPythonOnlyDeployment ./integration-tests/manifests/annotations -timeout 30m
-          kubectl get pods -A
-          kubectl describe pods -n default
-
- 
+          sleep 5
+          go test -v -run TestAnnotationsOnMultipleResources ./integration-tests/manifests/annotations -timeout 30m
+  
+  
+  
 
   DaemonsetAnnotationsTest:
     name: DaemonsetAnnotationsTest
@@ -200,18 +201,18 @@ jobs:
       - name: Test Annotations
         run: |
           kubectl apply -f integration-tests/manifests/sample-daemonset.yaml
+          sleep 5
           kubectl get pods -A
           kubectl describe pods -n default
-          sleep 10
           go test -v -run TestJavaAndPythonDaemonSet ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestJavaOnlyDaemonSet ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestPythonOnlyDaemonSet ./integration-tests/manifests/annotations -timeout 30m
-          kubectl get pods -A
-          kubectl describe pods -n default
-          
-          
+          sleep 5
+          go test -v -run TestAutoAnnotationForManualAnnotationRemoval ./integration-tests/manifests/annotations -timeout 30m
+  
+  
 
   StatefulsetAnnotationsTest:
     name: StatefulsetAnnotationsTest
@@ -250,16 +251,17 @@ jobs:
       - name: Test Annotations
         run: |
           kubectl apply -f integration-tests/manifests/sample-statefulset.yaml
+          sleep 5
           kubectl get pods -A
           kubectl describe pods -n default
-          sleep 10
           go test -v -run TestJavaAndPythonStatefulSet ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestJavaOnlyStatefulSet ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestPythonOnlyStatefulSet ./integration-tests/manifests/annotations -timeout 30m
-          kubectl get pods -A
-          kubectl describe pods -n default
+          sleep 5
+          go test -v -run TestOnlyNonAnnotatedAppsShouldBeRestarted ./integration-tests/manifests/annotations -timeout 30m
+
 
 
   NamespaceAnnotationsTest:
@@ -283,7 +285,6 @@ jobs:
 
       - name: Verify minikube and cert-manager
         run: |
-          sleep 10
           kubectl get pods -A
 
       - name: Build image
@@ -301,11 +302,14 @@ jobs:
           kubectl get pods -A
           kubectl describe pods -n default
           go test -v -run TestJavaAndPythonNamespace ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestJavaOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
-          sleep 10
+          sleep 5
           go test -v -run TestPythonOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
+          sleep 5
+          go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 30m
           kubectl get pods -A
           kubectl describe pods -n default
+
 
 

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -259,7 +259,7 @@ jobs:
           go test -v -run TestJavaOnlyStatefulSet ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
           go test -v -run TestPythonOnlyStatefulSet ./integration-tests/manifests/annotations -timeout 30m
-          sleep 15
+          sleep 5
           go test -v -run TestOnlyNonAnnotatedAppsShouldBeRestarted ./integration-tests/manifests/annotations -timeout 30m
 
 

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -259,7 +259,7 @@ jobs:
           go test -v -run TestJavaOnlyStatefulSet ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
           go test -v -run TestPythonOnlyStatefulSet ./integration-tests/manifests/annotations -timeout 30m
-          sleep 5
+          sleep 15
           go test -v -run TestOnlyNonAnnotatedAppsShouldBeRestarted ./integration-tests/manifests/annotations -timeout 30m
 
 

--- a/integration-tests/eks/validateResources_test.go
+++ b/integration-tests/eks/validateResources_test.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	nameSpace            = "amazon-cloudwatch"
-	addOnName            = "cloudwatch"
+	addOnName            = "amazon-cloudwatch-observability"
 	agentName            = "cloudwatch-agent"
 	agentNameWindows     = "cloudwatch-agent-windows"
 	operatorName         = addOnName + "-controller-manager"

--- a/integration-tests/eks/validateResources_test.go
+++ b/integration-tests/eks/validateResources_test.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	nameSpace            = "amazon-cloudwatch"
-	addOnName            = "amazon-cloudwatch-observability"
+	addOnName            = "cloudwatch"
 	agentName            = "cloudwatch-agent"
 	agentNameWindows     = "cloudwatch-agent-windows"
 	operatorName         = addOnName + "-controller-manager"

--- a/integration-tests/manifests/annotations/validate_annotation_daemonset_test.go
+++ b/integration-tests/manifests/annotations/validate_annotation_daemonset_test.go
@@ -44,7 +44,7 @@ func TestJavaAndPythonDaemonSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlName, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 
@@ -80,7 +80,7 @@ func TestJavaOnlyDaemonSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlName, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 
@@ -115,7 +115,7 @@ func TestPythonOnlyDaemonSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlName, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 

--- a/integration-tests/manifests/annotations/validate_annotation_daemonset_test.go
+++ b/integration-tests/manifests/annotations/validate_annotation_daemonset_test.go
@@ -44,7 +44,7 @@ func TestJavaAndPythonDaemonSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 
@@ -80,7 +80,7 @@ func TestJavaOnlyDaemonSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 
@@ -115,7 +115,7 @@ func TestPythonOnlyDaemonSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -37,7 +37,7 @@ const (
 
 	daemonSetName = "sample-daemonset"
 
-	amazonControllerManager = "amazon-cloudwatch-observability-controller-manager"
+	amazonControllerManager = "cloudwatch-controller-manager"
 
 	sampleDaemonsetYamlRelPath      = "../sample-daemonset.yaml"
 	sampleDeploymentYamlNameRelPath = "../sample-deployment.yaml"
@@ -390,12 +390,10 @@ func setupFunction(t *testing.T, namespace string, apps []string) (*kubernetes.C
 	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, apps); err != nil {
 		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
 	}
-	fmt.Println("setupfunction", namespace, apps)
 	t.Cleanup(func() {
 		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, apps); err != nil {
 			t.Fatalf("Failed to delete namespaces/resources: %v", err)
 		}
-		fmt.Println("HIIII")
 	})
 
 	return clientSet, uniqueNamespace

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -35,7 +35,7 @@ const (
 
 	daemonSetName = "sample-daemonset"
 
-	amazonControllerManager = "amazon-cloudwatch-observability-controller-manager"
+	amazonControllerManager = "cloudwatch-controller-manager"
 
 	sampleDaemonsetYamlRelPath      = "../sample-daemonset.yaml"
 	sampleDeploymentYamlNameRelPath = "../sample-deployment.yaml"

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -37,7 +37,7 @@ const (
 
 	daemonSetName = "sample-daemonset"
 
-	amazonControllerManager = "cloudwatch-controller-manager"
+	amazonControllerManager = "amazon-cloudwatch-observability-controller-manager"
 
 	sampleDaemonsetYamlRelPath      = "../sample-daemonset.yaml"
 	sampleDeploymentYamlNameRelPath = "../sample-deployment.yaml"
@@ -383,12 +383,20 @@ func annotationExists(annotations map[string]string, key string) bool {
 }
 
 func setupFunction(t *testing.T, namespace string, apps []string) (*kubernetes.Clientset, string) {
+	t.Helper()
 	clientSet := setupTest(t)
 	newUUID := uuid.New()
 	uniqueNamespace := fmt.Sprintf(namespace+"-%s", newUUID.String())
 	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, apps); err != nil {
 		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
 	}
+	fmt.Println("setupfunction", namespace, apps)
+	t.Cleanup(func() {
+		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, apps); err != nil {
+			t.Fatalf("Failed to delete namespaces/resources: %v", err)
+		}
+		fmt.Println("HIIII")
+	})
 
 	return clientSet, uniqueNamespace
 }

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -37,7 +37,7 @@ const (
 
 	daemonSetName = "sample-daemonset"
 
-	amazonControllerManager = "amazon-cloudwatch-observability-controller-manager"
+	amazonControllerManager = "cloudwatch-controller-manager"
 
 	sampleDaemonsetYamlRelPath      = "../sample-daemonset.yaml"
 	sampleDeploymentYamlNameRelPath = "../sample-deployment.yaml"

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -385,7 +385,7 @@ func annotationExists(annotations map[string]string, key string) bool {
 func setupFunction(t *testing.T, namespace string, apps []string) (*kubernetes.Clientset, string) {
 	clientSet := setupTest(t)
 	newUUID := uuid.New()
-	uniqueNamespace := fmt.Sprintf(namespace+"-%v", fmt.Sprint(newUUID))
+	uniqueNamespace := fmt.Sprintf(namespace+"-%s", newUUID.String())
 	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, apps); err != nil {
 		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
 	}

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -35,7 +35,7 @@ const (
 
 	daemonSetName = "sample-daemonset"
 
-	amazonControllerManager = "cloudwatch-controller-manager"
+	amazonControllerManager = "amazon-cloudwatch-observability-controller-manager"
 
 	sampleDaemonsetYamlRelPath      = "../sample-daemonset.yaml"
 	sampleDeploymentYamlNameRelPath = "../sample-deployment.yaml"
@@ -313,7 +313,7 @@ func updateTheOperator(t *testing.T, clientSet *kubernetes.Clientset, jsonStr st
 	}
 	deployment = updateAnnotationConfig(deployment, jsonStr)
 
-	if !updateOperator(t, clientSet, deployment, time.Now().Add(-time.Second)) {
+	if !updateOperator(t, clientSet, deployment, time.Now().Add(-3*time.Second)) {
 		t.Error("Failed to update Operator", deployment, deployment.Name, deployment.Spec.Template.Spec.Containers[0].Args)
 	}
 }

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -63,8 +63,7 @@ func createNamespaceAndApplyResources(t *testing.T, clientset *kubernetes.Client
 	for _, file := range resourceFiles {
 		err = applyYAMLWithKubectl(file, name)
 		if err != nil {
-			fmt.Println(name, file)
-			t.Error("Could not apply resources")
+			t.Errorf("Could not apply resources %s/%s", name, file)
 			return err
 		}
 	}

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -313,7 +313,7 @@ func updateTheOperator(t *testing.T, clientSet *kubernetes.Clientset, jsonStr st
 	}
 	deployment = updateAnnotationConfig(deployment, jsonStr)
 
-	if !updateOperator(t, clientSet, deployment, time.Now().Add(-3*time.Second)) {
+	if !updateOperator(t, clientSet, deployment, time.Now().Add(-time.Second)) {
 		t.Error("Failed to update Operator", deployment, deployment.Name, deployment.Spec.Template.Spec.Containers[0].Args)
 	}
 }

--- a/integration-tests/manifests/annotations/validate_annotation_methods.go
+++ b/integration-tests/manifests/annotations/validate_annotation_methods.go
@@ -35,7 +35,7 @@ const (
 
 	daemonSetName = "sample-daemonset"
 
-	amazonControllerManager = "cloudwatch-controller-manager"
+	amazonControllerManager = "amazon-cloudwatch-observability-controller-manager"
 
 	sampleDaemonsetYamlRelPath      = "../sample-daemonset.yaml"
 	sampleDeploymentYamlNameRelPath = "../sample-deployment.yaml"

--- a/integration-tests/manifests/annotations/validate_annotations_deployment_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_deployment_test.go
@@ -43,7 +43,7 @@ func TestJavaAndPythonDeployment(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlName, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 
@@ -80,7 +80,7 @@ func TestJavaOnlyDeployment(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlName, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }
@@ -120,7 +120,7 @@ func TestPythonOnlyDeployment(t *testing.T) {
 		t.Errorf("Failed to get deployment app: %s", err.Error())
 	}
 
-	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlName, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 

--- a/integration-tests/manifests/annotations/validate_annotations_deployment_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_deployment_test.go
@@ -43,7 +43,7 @@ func TestJavaAndPythonDeployment(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 
@@ -80,7 +80,7 @@ func TestJavaOnlyDeployment(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }
@@ -120,7 +120,7 @@ func TestPythonOnlyDeployment(t *testing.T) {
 		t.Errorf("Failed to get deployment app: %s", err.Error())
 	}
 
-	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 

--- a/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
@@ -269,7 +269,6 @@ func TestOnlyNonAnnotatedAppsShouldBeRestarted(t *testing.T) {
 	}
 	randomNumber.Add(randomNumber, big.NewInt(1000)) //adding a hash to namespace
 	uniqueNamespace := fmt.Sprintf("multiple-resources-%d", randomNumber)
-	nginxStartTime := time.Now()
 	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
 		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
 	}
@@ -323,11 +322,6 @@ func TestOnlyNonAnnotatedAppsShouldBeRestarted(t *testing.T) {
 	}
 
 	err = util.WaitForNewPodCreation(clientSet, deployment, startTime)
-	if err != nil {
-		fmt.Printf("Error waiting for pod creation: %v\n", err)
-		os.Exit(1)
-	}
-	err = util.WaitForNewPodCreation(clientSet, nginxDeployment, nginxStartTime)
 	if err != nil {
 		fmt.Printf("Error waiting for pod creation: %v\n", err)
 		os.Exit(1)

--- a/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
@@ -139,7 +139,7 @@ func TestAnnotationsOnMultipleResources(t *testing.T) {
 
 	clientSet := setupTest(t)
 	newUUID := uuid.New()
-	uniqueNamespace := fmt.Sprintf("multiple-resources-%s", uuid.NewString())
+	uniqueNamespace := fmt.Sprintf("multiple-resources-%s", newUUID.String())
 
 	annotationConfig := auto.AnnotationConfig{
 		Java: auto.AnnotationResources{

--- a/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
@@ -139,7 +139,7 @@ func TestAnnotationsOnMultipleResources(t *testing.T) {
 
 	clientSet := setupTest(t)
 	newUUID := uuid.New()
-	uniqueNamespace := fmt.Sprintf("multiple-resources-%v", fmt.Sprint(newUUID))
+	uniqueNamespace := fmt.Sprintf("multiple-resources-%s", uuid.NewString())
 
 	annotationConfig := auto.AnnotationConfig{
 		Java: auto.AnnotationResources{

--- a/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
@@ -176,12 +176,6 @@ func TestAnnotationsOnMultipleResources(t *testing.T) {
 func TestAutoAnnotationForManualAnnotationRemoval(t *testing.T) {
 
 	clientSet, uniqueNamespace := setupFunction(t, "manual-annotation-removal", []string{sampleDeploymentYamlNameRelPath})
-	t.Cleanup(func() {
-		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
-			t.Fatalf("Failed to delete namespaces/resources: %v", err)
-		}
-	})
-
 	annotationConfig := auto.AnnotationConfig{
 		Java: auto.AnnotationResources{
 			Deployments: []string{filepath.Join(uniqueNamespace, deploymentName)},
@@ -238,11 +232,6 @@ func TestAutoAnnotationForManualAnnotationRemoval(t *testing.T) {
 func TestOnlyNonAnnotatedAppsShouldBeRestarted(t *testing.T) {
 
 	clientSet, uniqueNamespace := setupFunction(t, "non-annotated", []string{sampleDeploymentYamlNameRelPath, sampleNginxAppYamlNameRelPath})
-	t.Cleanup(func() {
-		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath, sampleNginxAppYamlNameRelPath}); err != nil {
-			t.Fatalf("Failed to delete namespaces/resources: %v", err)
-		}
-	})
 	startTime := time.Now()
 	annotationConfig := auto.AnnotationConfig{
 		Java: auto.AnnotationResources{
@@ -294,11 +283,7 @@ func TestOnlyNonAnnotatedAppsShouldBeRestarted(t *testing.T) {
 func TestAlreadyAutoAnnotatedResourceShouldNotRestart(t *testing.T) {
 
 	clientSet, uniqueNamespace := setupFunction(t, "already-annotated", []string{sampleDeploymentYamlNameRelPath})
-	t.Cleanup(func() {
-		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
-			t.Fatalf("Failed to delete namespaces/resources: %v", err)
-		}
-	})
+
 	startTime := time.Now()
 	annotationConfig := auto.AnnotationConfig{
 		Java: auto.AnnotationResources{

--- a/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
@@ -283,7 +283,6 @@ func TestOnlyNonAnnotatedAppsShouldBeRestarted(t *testing.T) {
 func TestAlreadyAutoAnnotatedResourceShouldNotRestart(t *testing.T) {
 
 	clientSet, uniqueNamespace := setupFunction(t, "already-annotated", []string{sampleDeploymentYamlNameRelPath})
-
 	startTime := time.Now()
 	annotationConfig := auto.AnnotationConfig{
 		Java: auto.AnnotationResources{

--- a/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
@@ -3,11 +3,16 @@
 package annotations
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"github.com/aws/amazon-cloudwatch-agent-operator/integration-tests/util"
 	"github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/auto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"math/big"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -126,4 +131,305 @@ func TestPythonOnlyNamespace(t *testing.T) {
 	if !checkNameSpaceAnnotations(t, clientSet, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}, uniqueNamespace, startTime) {
 		t.Error("Missing Python annotations")
 	}
+}
+
+// Multiple resources on the same namespace should all get annotations
+func TestAnnotationsOnMultipleResources(t *testing.T) {
+
+	clientSet := setupTest(t)
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(9000))
+	if err != nil {
+		panic(err)
+	}
+	randomNumber.Add(randomNumber, big.NewInt(1000)) //adding a hash to namespace
+	uniqueNamespace := fmt.Sprintf("multiple-resources-%d", randomNumber)
+
+	annotationConfig := auto.AnnotationConfig{
+		Java: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{filepath.Join(uniqueNamespace, daemonSetName)},
+			Deployments:  []string{filepath.Join(uniqueNamespace, deploymentName)},
+			StatefulSets: []string{filepath.Join(uniqueNamespace, statefulSetName)},
+		},
+		Python: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{""},
+			Deployments:  []string{""},
+			StatefulSets: []string{""},
+		},
+	}
+	jsonStr, err := json.Marshal(annotationConfig)
+	if err != nil {
+		t.Error("Error:", err)
+	}
+
+	startTime := time.Now()
+	updateTheOperator(t, clientSet, string(jsonStr))
+	if err != nil {
+		t.Errorf("Failed to get deployment app: %s", err.Error())
+	}
+
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+		t.Fatalf("Failed annotation check: %s", err.Error())
+	}
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+		t.Fatalf("Failed annotation check: %s", err.Error())
+	}
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+		t.Fatalf("Failed annotation check: %s", err.Error())
+	}
+
+}
+
+// This tests a resource that is auto annotated is manually patched to remove the annotations, our mutator adds back the annotations
+func TestAutoAnnotationForManualAnnotationRemoval(t *testing.T) {
+
+	clientSet := setupTest(t)
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(9000))
+	if err != nil {
+		panic(err)
+	}
+	randomNumber.Add(randomNumber, big.NewInt(1000)) //adding a hash to namespace
+	uniqueNamespace := fmt.Sprintf("manual-annotation-removal-%d", randomNumber)
+
+	annotationConfig := auto.AnnotationConfig{
+		Java: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{filepath.Join(uniqueNamespace, daemonSetName)},
+			Deployments:  []string{filepath.Join(uniqueNamespace, deploymentName)},
+			StatefulSets: []string{filepath.Join(uniqueNamespace, statefulSetName)},
+		},
+		Python: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{""},
+			Deployments:  []string{""},
+			StatefulSets: []string{""},
+		},
+	}
+	jsonStr, err := json.Marshal(annotationConfig)
+	if err != nil {
+		t.Error("Error:", err)
+	}
+
+	startTime := time.Now()
+	updateTheOperator(t, clientSet, string(jsonStr))
+	if err != nil {
+		t.Errorf("Failed to get deployment app: %s", err.Error())
+	}
+
+	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
+		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
+	}
+	defer func() {
+		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
+			t.Fatalf("Failed to delete namespaces/resources: %v", err)
+		}
+	}()
+	deployment, err := clientSet.AppsV1().Deployments(uniqueNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Printf("Error retrieving deployment: %v\n", err)
+		os.Exit(1)
+	}
+
+	//Removing all annotations
+	deployment.ObjectMeta.Annotations = nil
+	_, err = clientSet.AppsV1().Deployments(uniqueNamespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+	if err != nil {
+		fmt.Printf("Error updating deployment: %v\n", err)
+		os.Exit(1)
+	}
+	err = util.WaitForNewPodCreation(clientSet, deployment, startTime)
+	if err != nil {
+		fmt.Printf("Error waiting for pod creation: %v\n", err)
+		os.Exit(1)
+	}
+	deploymentPods, err := clientSet.CoreV1().Pods(uniqueNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		fmt.Printf("Error listing pods: %v\n", err)
+		os.Exit(1)
+	}
+	//Check if operator has added back the annotations
+	checkIfAnnotationExists(clientSet, deploymentPods, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation})
+
+}
+
+// Creating two apps - First app is annotated
+// Second app is not annotated but on the same namespace as the first app
+// Annotate the namespace of the apps and make sure only the non annotated app was restarted
+// Also tests if a resource is manually annotated and now its namespace is added for auto annotation
+// the resource should not be modified and should not be restarted (auto-annotation annotation does not exist)
+func TestOnlyNonAnnotatedAppsShouldBeRestarted(t *testing.T) {
+
+	clientSet := setupTest(t)
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(9000))
+	if err != nil {
+		panic(err)
+	}
+	randomNumber.Add(randomNumber, big.NewInt(1000)) //adding a hash to namespace
+	uniqueNamespace := fmt.Sprintf("multiple-resources-%d", randomNumber)
+	nginxStartTime := time.Now()
+	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
+		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
+	}
+	defer func() {
+		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
+			t.Fatalf("Failed to delete namespaces/resources: %v", err)
+		}
+	}()
+	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, []string{sampleNginxAppYamlNameRelPath}); err != nil {
+		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
+	}
+	defer func() {
+		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, []string{sampleNginxAppYamlNameRelPath}); err != nil {
+			t.Fatalf("Failed to delete namespaces/resources: %v", err)
+		}
+	}()
+
+	annotationConfig := auto.AnnotationConfig{
+		Java: auto.AnnotationResources{
+			Namespaces:   []string{uniqueNamespace},
+			DaemonSets:   []string{""},
+			Deployments:  []string{""},
+			StatefulSets: []string{""},
+		},
+		Python: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{""},
+			Deployments:  []string{""},
+			StatefulSets: []string{""},
+		},
+	}
+	jsonStr, err := json.Marshal(annotationConfig)
+	if err != nil {
+		t.Error("Error:", err)
+	}
+
+	startTime := time.Now()
+	updateTheOperator(t, clientSet, string(jsonStr))
+	if err != nil {
+		t.Errorf("Failed to get deployment app: %s", err.Error())
+	}
+	deployment, err := clientSet.AppsV1().Deployments(uniqueNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Printf("Error retrieving deployment: %v\n", err)
+		os.Exit(1)
+	}
+	nginxDeployment, err := clientSet.AppsV1().Deployments(uniqueNamespace).Get(context.TODO(), nginxDeploymentName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Printf("Error retrieving deployment: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = util.WaitForNewPodCreation(clientSet, deployment, startTime)
+	if err != nil {
+		fmt.Printf("Error waiting for pod creation: %v\n", err)
+		os.Exit(1)
+	}
+	err = util.WaitForNewPodCreation(clientSet, nginxDeployment, nginxStartTime)
+	if err != nil {
+		fmt.Printf("Error waiting for pod creation: %v\n", err)
+		os.Exit(1)
+	}
+
+	if annotationExists(nginxDeployment.Annotations, autoAnnotateJavaAnnotation) {
+		t.Fatal("Auto-annotation annotation should not exist")
+	}
+
+	numOfRevisions, err := numberOfRevisions(nginxDeploymentName, uniqueNamespace)
+	if numOfRevisions > 1 || err != nil {
+		t.Fatal("Nginx was restarted") //should not be restarted since it already had annotations
+	}
+	numOfRevisions, err = numberOfRevisions(deploymentName, uniqueNamespace)
+	if numOfRevisions != 2 || err != nil {
+		t.Fatal("Sample-deployment should have been restarted") //should not be restarted since it already had annotations
+	}
+
+}
+
+// Test if a resource is auto annotated and now its namespace is added for auto annotation
+// the resource should not be restarted
+func TestAlreadyAutoAnnotatedResourceShouldNotRestart(t *testing.T) {
+
+	clientSet := setupTest(t)
+	randomNumber, err := rand.Int(rand.Reader, big.NewInt(9000))
+	if err != nil {
+		panic(err)
+	}
+	randomNumber.Add(randomNumber, big.NewInt(1000)) //adding a hash to namespace
+	uniqueNamespace := fmt.Sprintf("multiple-resources-%d", randomNumber)
+	startTime := time.Now()
+	if err := createNamespaceAndApplyResources(t, clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
+		t.Fatalf("Failed to create/apply resoures on namespace: %v", err)
+	}
+	defer func() {
+		if err := deleteNamespaceAndResources(clientSet, uniqueNamespace, []string{sampleDeploymentYamlNameRelPath}); err != nil {
+			t.Fatalf("Failed to delete namespaces/resources: %v", err)
+		}
+	}()
+
+	annotationConfig := auto.AnnotationConfig{
+		Java: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{""},
+			Deployments:  []string{filepath.Join(uniqueNamespace, deploymentName)},
+			StatefulSets: []string{""},
+		},
+		Python: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{""},
+			Deployments:  []string{""},
+			StatefulSets: []string{""},
+		},
+	}
+	jsonStr, err := json.Marshal(annotationConfig)
+	if err != nil {
+		t.Error("Error:", err)
+	}
+
+	startTime = time.Now()
+	updateTheOperator(t, clientSet, string(jsonStr))
+	if err != nil {
+		t.Errorf("Failed to get deployment app: %s", err.Error())
+	}
+	deployment, err := clientSet.AppsV1().Deployments(uniqueNamespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		fmt.Printf("Error retrieving deployment: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = util.WaitForNewPodCreation(clientSet, deployment, startTime)
+	if err != nil {
+		fmt.Printf("Error waiting for pod creation: %v\n", err)
+		os.Exit(1)
+	}
+
+	//adding deployment's namespace to get auto annotated
+	annotationConfig = auto.AnnotationConfig{
+		Java: auto.AnnotationResources{
+			Namespaces:   []string{uniqueNamespace},
+			DaemonSets:   []string{""},
+			Deployments:  []string{filepath.Join(uniqueNamespace, deploymentName)},
+			StatefulSets: []string{""},
+		},
+		Python: auto.AnnotationResources{
+			Namespaces:   []string{""},
+			DaemonSets:   []string{""},
+			Deployments:  []string{""},
+			StatefulSets: []string{""},
+		},
+	}
+	jsonStr, err = json.Marshal(annotationConfig)
+	if err != nil {
+		t.Error("Error:", err)
+	}
+
+	updateTheOperator(t, clientSet, string(jsonStr))
+
+	//number of revisions should not be greater than 2
+	//first one is for creation second one is for the first operator change and third one should not exist (even with the second operator change)
+	numOfRevisions, err := numberOfRevisions(deploymentName, uniqueNamespace)
+	if numOfRevisions > 2 || err != nil {
+		t.Fatal("Sample-deployment should not have been restarted after second operator update") //should not be restarted since it already had annotations
+	}
+
 }

--- a/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_namespace_test.go
@@ -169,13 +169,13 @@ func TestAnnotationsOnMultipleResources(t *testing.T) {
 		t.Errorf("Failed to get deployment app: %s", err.Error())
 	}
 
-	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}, true); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
-	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "daemonset", uniqueNamespace, daemonSetName, sampleDaemonsetYamlRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}, true); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
-	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 

--- a/integration-tests/manifests/annotations/validate_annotations_statefulset_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_statefulset_test.go
@@ -42,7 +42,7 @@ func TestJavaAndPythonStatefulSet(t *testing.T) {
 	}
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
-	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlName, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }
@@ -77,7 +77,7 @@ func TestJavaOnlyStatefulSet(t *testing.T) {
 	}
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
-	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlName, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }
@@ -113,7 +113,7 @@ func TestPythonOnlyStatefulSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlName, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }

--- a/integration-tests/manifests/annotations/validate_annotations_statefulset_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_statefulset_test.go
@@ -42,7 +42,7 @@ func TestJavaAndPythonStatefulSet(t *testing.T) {
 	}
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
-	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation, injectPythonAnnotation, autoAnnotatePythonAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }
@@ -77,7 +77,7 @@ func TestJavaOnlyStatefulSet(t *testing.T) {
 	}
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
-	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }
@@ -113,7 +113,7 @@ func TestPythonOnlyStatefulSet(t *testing.T) {
 	startTime := time.Now()
 	updateTheOperator(t, clientSet, string(jsonStr))
 
-	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}); err != nil {
+	if err := checkResourceAnnotations(t, clientSet, "statefulset", uniqueNamespace, statefulSetName, sampleStatefulsetYamlNameRelPath, startTime, []string{injectPythonAnnotation, autoAnnotatePythonAnnotation}, false); err != nil {
 		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }

--- a/integration-tests/util/util.go
+++ b/integration-tests/util/util.go
@@ -49,7 +49,6 @@ func WaitForNewPodCreation(clientSet *kubernetes.Clientset, resource interface{}
 				fmt.Printf("Operator pod %s created after start time and is running\n", pod.Name)
 				return nil
 			} else if pod.CreationTimestamp.Time.After(startTime) {
-
 				fmt.Printf("Operator pod %s created after start time but is not in running stage\n", pod.Name)
 			}
 		}


### PR DESCRIPTION
*Issue #, if available:*

The Enablement experience integration test needed some extra use cases to make sure proper auto annotations behavior is occuring. So in order to satisfy this, more test cases were added to ensure correct behavior.

*Description of changes:*

## Below are the functions that were added and what tests the satisfy:
### TestAnnotationsOnMultipleResources
- If there are multiple resources on the same namespace, all of non-annotated resources should be annotated.

### TestAutoAnnotationForManualAnnotationRemoval
-  If a resource that is auto annotated is manually patched to remove the annotations, our mutator should add back the annotations.

### TestOnlyNonAnnotatedAppsShouldBeRestarted
-  If a resource is manually annotated and now its namespace is added for auto annotation, the resource should not be modified and should not be restarted.
- If a namespace is annotated, confirm that only apps that are not already annotated get restarted and now have annotations. Existing annotated apps should NOT be restarted.

### TestAlreadyAutoAnnotatedResourceShouldNotRestart

- If a resource is already annotated and then operator adds annotation, auto-annotation annotation is not added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
