### PR TITLE
[DO NOT MERGE] Add TLS certification to operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ ci: test
 # setup-envtest uses KUBEBUILDER_ASSETS which points to a directory with binaries (api-server, etcd and kubectl)
 .PHONY: test
 test: generate fmt vet envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBE_VERSION) -p path)" go test ${GOTEST_OPTS}
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBE_VERSION) -p path)" go test -v ${GOTEST_OPTS}
 
 # Build manager binary
 .PHONY: manager

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ ci: test
 # setup-envtest uses KUBEBUILDER_ASSETS which points to a directory with binaries (api-server, etcd and kubectl)
 .PHONY: test
 test: generate fmt vet envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBE_VERSION) -p path)" go test -v ${GOTEST_OPTS}
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBE_VERSION) -p path)" go test ${GOTEST_OPTS}
 
 # Build manager binary
 .PHONY: manager

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -4,13 +4,13 @@
 package constants
 
 const (
-	EnvOTELServiceName          = "OTEL_SERVICE_NAME"
-	EnvOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
-	EnvOTELResourceAttrs        = "OTEL_RESOURCE_ATTRIBUTES"
-	EnvOTELPropagators          = "OTEL_PROPAGATORS"
-	EnvOTELTracesSampler        = "OTEL_TRACES_SAMPLER"
-	EnvOTELTracesSamplerArg     = "OTEL_TRACES_SAMPLER_ARG"
-
+	EnvOTELServiceName                              = "OTEL_SERVICE_NAME"
+	EnvOTELExporterOTLPEndpoint                     = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	EnvOTELResourceAttrs                            = "OTEL_RESOURCE_ATTRIBUTES"
+	EnvOTELPropagators                              = "OTEL_PROPAGATORS"
+	EnvOTELTracesSampler                            = "OTEL_TRACES_SAMPLER"
+	EnvOTELTracesSamplerArg                         = "OTEL_TRACES_SAMPLER_ARG"
+	EnvOTELExporterOTLPCert                         = "OTEL_EXPORTER_OTLP_CERTIFICATE"
 	InstrumentationPrefix                           = "instrumentation.opentelemetry.io/"
 	AnnotationDefaultAutoInstrumentationJava        = InstrumentationPrefix + "default-auto-instrumentation-java-image"
 	AnnotationDefaultAutoInstrumentationNodeJS      = InstrumentationPrefix + "default-auto-instrumentation-nodejs-image"

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -4,13 +4,13 @@
 package constants
 
 const (
-	EnvOTELServiceName                              = "OTEL_SERVICE_NAME"
-	EnvOTELExporterOTLPEndpoint                     = "OTEL_EXPORTER_OTLP_ENDPOINT"
-	EnvOTELResourceAttrs                            = "OTEL_RESOURCE_ATTRIBUTES"
-	EnvOTELPropagators                              = "OTEL_PROPAGATORS"
-	EnvOTELTracesSampler                            = "OTEL_TRACES_SAMPLER"
-	EnvOTELTracesSamplerArg                         = "OTEL_TRACES_SAMPLER_ARG"
-	EnvOTELExporterOTLPCert                         = "OTEL_EXPORTER_OTLP_CERTIFICATE"
+	EnvOTELServiceName          = "OTEL_SERVICE_NAME"
+	EnvOTELExporterOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	EnvOTELResourceAttrs        = "OTEL_RESOURCE_ATTRIBUTES"
+	EnvOTELPropagators          = "OTEL_PROPAGATORS"
+	EnvOTELTracesSampler        = "OTEL_TRACES_SAMPLER"
+	EnvOTELTracesSamplerArg     = "OTEL_TRACES_SAMPLER_ARG"
+	
 	InstrumentationPrefix                           = "instrumentation.opentelemetry.io/"
 	AnnotationDefaultAutoInstrumentationJava        = InstrumentationPrefix + "default-auto-instrumentation-java-image"
 	AnnotationDefaultAutoInstrumentationNodeJS      = InstrumentationPrefix + "default-auto-instrumentation-nodejs-image"

--- a/pkg/instrumentation/dotnet.go
+++ b/pkg/instrumentation/dotnet.go
@@ -123,7 +123,7 @@ func injectDotNetSDK(dotNetSpec v1alpha1.DotNet, pod corev1.Pod, index int, runt
 			Resources:    dotNetSpec.Resources,
 			VolumeMounts: []corev1.VolumeMount{volumeMount},
 		})
-		err = injectSecret(&pod, dotnetInstrMountPath, dotNetSpec.Resources)
+		err = injectSecret(&pod, dotNetSpec.Resources)
 		if err != nil {
 			return pod, err
 		}

--- a/pkg/instrumentation/dotnet.go
+++ b/pkg/instrumentation/dotnet.go
@@ -97,7 +97,10 @@ func injectDotNetSDK(dotNetSpec v1alpha1.DotNet, pod corev1.Pod, index int, runt
 	setDotNetEnvVar(container, envDotNetOTelAutoHome, dotNetOTelAutoHomePath, doNotConcatEnvValues)
 
 	setDotNetEnvVar(container, envDotNetSharedStore, dotNetSharedStorePath, concatEnvValues)
-
+	err = injectSecret(&pod, index, dotNetSpec.Resources)
+	if err != nil {
+		return pod, err
+	}
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      dotnetVolumeName,
 		MountPath: dotnetInstrMountPath,
@@ -123,10 +126,7 @@ func injectDotNetSDK(dotNetSpec v1alpha1.DotNet, pod corev1.Pod, index int, runt
 			Resources:    dotNetSpec.Resources,
 			VolumeMounts: []corev1.VolumeMount{volumeMount},
 		})
-		err = injectSecret(&pod, dotNetSpec.Resources)
-		if err != nil {
-			return pod, err
-		}
+
 	}
 	return pod, nil
 }

--- a/pkg/instrumentation/dotnet_test.go
+++ b/pkg/instrumentation/dotnet_test.go
@@ -37,7 +37,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-dotnet",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -45,7 +45,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-dotnet",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -54,16 +54,6 @@ func TestInjectDotNetSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-dotnet",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-dotnet",
-								MountPath: "/otel-auto-instrumentation-dotnet",
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -76,17 +66,27 @@ func TestInjectDotNetSDK(t *testing.T) {
 							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-dotnet",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-dotnet",
+								MountPath: "/otel-auto-instrumentation-dotnet",
+							}},
+							Resources: testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-dotnet",
-									MountPath: "/otel-auto-instrumentation-dotnet",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-dotnet",
+									MountPath: "/otel-auto-instrumentation-dotnet",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -166,7 +166,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-dotnet",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -174,7 +174,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-dotnet",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -183,15 +183,6 @@ func TestInjectDotNetSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-dotnet",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-dotnet",
-								MountPath: "/otel-auto-instrumentation-dotnet",
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -203,17 +194,26 @@ func TestInjectDotNetSDK(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-dotnet",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-dotnet",
+								MountPath: "/otel-auto-instrumentation-dotnet",
+							}},
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-dotnet",
-									MountPath: "/otel-auto-instrumentation-dotnet",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-dotnet",
+									MountPath: "/otel-auto-instrumentation-dotnet",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -418,7 +418,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: dotnetVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -426,7 +426,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: dotnetVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -435,16 +435,6 @@ func TestInjectDotNetSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    dotnetInitContainerName,
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: "/otel-auto-instrumentation-dotnet",
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -457,17 +447,27 @@ func TestInjectDotNetSDK(t *testing.T) {
 							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
 						},
+						{
+							Name:    dotnetInitContainerName,
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: "/otel-auto-instrumentation-dotnet",
+							}},
+							Resources: testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: "/otel-auto-instrumentation-dotnet",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: "/otel-auto-instrumentation-dotnet",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -521,7 +521,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: dotnetVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -529,7 +529,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: dotnetVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -538,16 +538,6 @@ func TestInjectDotNetSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    dotnetInitContainerName,
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: "/otel-auto-instrumentation-dotnet",
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -560,17 +550,27 @@ func TestInjectDotNetSDK(t *testing.T) {
 							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
 						},
+						{
+							Name:    dotnetInitContainerName,
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: "/otel-auto-instrumentation-dotnet",
+							}},
+							Resources: testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: "/otel-auto-instrumentation-dotnet",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: "/otel-auto-instrumentation-dotnet",
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/dotnet_test.go
+++ b/pkg/instrumentation/dotnet_test.go
@@ -44,6 +44,14 @@ func TestInjectDotNetSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -56,6 +64,18 @@ func TestInjectDotNetSDK(t *testing.T) {
 							}},
 							Resources: testResourceRequirements,
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+							Resources:  testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -63,6 +83,10 @@ func TestInjectDotNetSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-dotnet",
 									MountPath: "/otel-auto-instrumentation-dotnet",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -149,6 +173,14 @@ func TestInjectDotNetSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -160,6 +192,17 @@ func TestInjectDotNetSDK(t *testing.T) {
 								MountPath: "/otel-auto-instrumentation-dotnet",
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -167,6 +210,10 @@ func TestInjectDotNetSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-dotnet",
 									MountPath: "/otel-auto-instrumentation-dotnet",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -378,6 +425,14 @@ func TestInjectDotNetSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -390,6 +445,18 @@ func TestInjectDotNetSDK(t *testing.T) {
 							}},
 							Resources: testResourceRequirements,
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+							Resources:  testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -397,6 +464,10 @@ func TestInjectDotNetSDK(t *testing.T) {
 								{
 									Name:      dotnetVolumeName,
 									MountPath: "/otel-auto-instrumentation-dotnet",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -457,6 +528,14 @@ func TestInjectDotNetSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -469,6 +548,18 @@ func TestInjectDotNetSDK(t *testing.T) {
 							}},
 							Resources: testResourceRequirements,
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+							Resources:  testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -476,6 +567,10 @@ func TestInjectDotNetSDK(t *testing.T) {
 								{
 									Name:      dotnetVolumeName,
 									MountPath: "/otel-auto-instrumentation-dotnet",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/golang.go
+++ b/pkg/instrumentation/golang.go
@@ -84,7 +84,7 @@ func injectGoSDK(goSpec v1alpha1.Go, pod corev1.Pod) (corev1.Pod, error) {
 			},
 		},
 	})
-	err := injectSecret(&pod, kernelDebugVolumePath, goAgent.Resources)
+	err := injectSecret(&pod, goAgent.Resources)
 	if err != nil {
 		return pod, err
 	}

--- a/pkg/instrumentation/golang_test.go
+++ b/pkg/instrumentation/golang_test.go
@@ -131,6 +131,10 @@ func TestInjectGoSDK(t *testing.T) {
 									MountPath: "/sys/kernel/debug",
 									Name:      kernelDebugVolumeName,
 								},
+								{
+									MountPath: certVolumePath,
+									Name:      certVolumeName,
+								},
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -148,6 +152,28 @@ func TestInjectGoSDK(t *testing.T) {
 									Path: kernelDebugVolumePath,
 								},
 							},
+						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+							Resources:  testResourceRequirements,
 						},
 					},
 				},
@@ -192,6 +218,10 @@ func TestInjectGoSDK(t *testing.T) {
 									MountPath: "/sys/kernel/debug",
 									Name:      kernelDebugVolumeName,
 								},
+								{
+									MountPath: certVolumePath,
+									Name:      certVolumeName,
+								},
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -209,6 +239,27 @@ func TestInjectGoSDK(t *testing.T) {
 									Path: kernelDebugVolumePath,
 								},
 							},
+						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
 						},
 					},
 				},
@@ -246,6 +297,10 @@ func TestInjectGoSDK(t *testing.T) {
 									MountPath: "/sys/kernel/debug",
 									Name:      kernelDebugVolumeName,
 								},
+								{
+									MountPath: certVolumePath,
+									Name:      certVolumeName,
+								},
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -267,6 +322,27 @@ func TestInjectGoSDK(t *testing.T) {
 									Path: kernelDebugVolumePath,
 								},
 							},
+						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
 						},
 					},
 				},

--- a/pkg/instrumentation/golang_test.go
+++ b/pkg/instrumentation/golang_test.go
@@ -128,12 +128,12 @@ func TestInjectGoSDK(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									MountPath: "/sys/kernel/debug",
-									Name:      kernelDebugVolumeName,
-								},
-								{
 									MountPath: certVolumePath,
 									Name:      certVolumeName,
+								},
+								{
+									MountPath: "/sys/kernel/debug",
+									Name:      kernelDebugVolumeName,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -146,18 +146,18 @@ func TestInjectGoSDK(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: kernelDebugVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: kernelDebugVolumePath,
-								},
-							},
-						},
-						{
 							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
+							Name: kernelDebugVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kernelDebugVolumePath,
 								},
 							},
 						},
@@ -215,12 +215,12 @@ func TestInjectGoSDK(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									MountPath: "/sys/kernel/debug",
-									Name:      kernelDebugVolumeName,
-								},
-								{
 									MountPath: certVolumePath,
 									Name:      certVolumeName,
+								},
+								{
+									MountPath: "/sys/kernel/debug",
+									Name:      kernelDebugVolumeName,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -233,18 +233,18 @@ func TestInjectGoSDK(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: kernelDebugVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: kernelDebugVolumePath,
-								},
-							},
-						},
-						{
 							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
+							Name: kernelDebugVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kernelDebugVolumePath,
 								},
 							},
 						},
@@ -294,12 +294,12 @@ func TestInjectGoSDK(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									MountPath: "/sys/kernel/debug",
-									Name:      kernelDebugVolumeName,
-								},
-								{
 									MountPath: certVolumePath,
 									Name:      certVolumeName,
+								},
+								{
+									MountPath: "/sys/kernel/debug",
+									Name:      kernelDebugVolumeName,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -316,18 +316,18 @@ func TestInjectGoSDK(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: kernelDebugVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: kernelDebugVolumePath,
-								},
-							},
-						},
-						{
 							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
+							Name: kernelDebugVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kernelDebugVolumePath,
 								},
 							},
 						},

--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -43,7 +43,10 @@ func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.
 	} else {
 		container.Env[idx].Value = container.Env[idx].Value + javaJVMArgument
 	}
-
+	err = injectSecret(&pod, index, javaSpec.Resources)
+	if err != nil {
+		return pod, err
+	}
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      javaVolumeName,
 		MountPath: javaInstrMountPath,
@@ -69,10 +72,6 @@ func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.
 			Resources:    javaSpec.Resources,
 			VolumeMounts: []corev1.VolumeMount{volumeMount},
 		})
-		err = injectSecret(&pod, javaSpec.Resources)
-		if err != nil {
-			return pod, err
-		}
 	}
 	return pod, err
 }

--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -69,7 +69,7 @@ func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.
 			Resources:    javaSpec.Resources,
 			VolumeMounts: []corev1.VolumeMount{volumeMount},
 		})
-		err = injectSecret(&pod, javaInstrMountPath, javaSpec.Resources)
+		err = injectSecret(&pod, javaSpec.Resources)
 		if err != nil {
 			return pod, err
 		}

--- a/pkg/instrumentation/javaagent_test.go
+++ b/pkg/instrumentation/javaagent_test.go
@@ -42,6 +42,14 @@ func TestInjectJavaagent(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -53,6 +61,17 @@ func TestInjectJavaagent(t *testing.T) {
 								MountPath: "/otel-auto-instrumentation-java",
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -60,6 +79,10 @@ func TestInjectJavaagent(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-java",
 									MountPath: "/otel-auto-instrumentation-java",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -102,6 +125,14 @@ func TestInjectJavaagent(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -114,6 +145,18 @@ func TestInjectJavaagent(t *testing.T) {
 							}},
 							Resources: testResourceRequirements,
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+							Resources:  testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -121,6 +164,10 @@ func TestInjectJavaagent(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-java",
 									MountPath: "/otel-auto-instrumentation-java",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/javaagent_test.go
+++ b/pkg/instrumentation/javaagent_test.go
@@ -35,7 +35,7 @@ func TestInjectJavaagent(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-java",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -43,7 +43,7 @@ func TestInjectJavaagent(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-java",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -52,15 +52,6 @@ func TestInjectJavaagent(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-java",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation-java/javaagent.jar"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-java",
-								MountPath: "/otel-auto-instrumentation-java",
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -72,17 +63,26 @@ func TestInjectJavaagent(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-java",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation-java/javaagent.jar"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-java",
-									MountPath: "/otel-auto-instrumentation-java",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-java",
+									MountPath: "/otel-auto-instrumentation-java",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -118,7 +118,7 @@ func TestInjectJavaagent(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-java",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -126,7 +126,7 @@ func TestInjectJavaagent(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-java",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -135,16 +135,6 @@ func TestInjectJavaagent(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-java",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation-java/javaagent.jar"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-java",
-								MountPath: "/otel-auto-instrumentation-java",
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -157,17 +147,27 @@ func TestInjectJavaagent(t *testing.T) {
 							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-java",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation-java/javaagent.jar"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+							Resources: testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-java",
-									MountPath: "/otel-auto-instrumentation-java",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-java",
+									MountPath: "/otel-auto-instrumentation-java",
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/nodejs.go
+++ b/pkg/instrumentation/nodejs.go
@@ -68,7 +68,7 @@ func injectNodeJSSDK(nodeJSSpec v1alpha1.NodeJS, pod corev1.Pod, index int) (cor
 				MountPath: nodejsInstrMountPath,
 			}},
 		})
-		err = injectSecret(&pod, nodejsInstrMountPath, nodeJSSpec.Resources)
+		err = injectSecret(&pod, nodeJSSpec.Resources)
 		if err != nil {
 			return pod, err
 		}

--- a/pkg/instrumentation/nodejs.go
+++ b/pkg/instrumentation/nodejs.go
@@ -58,7 +58,6 @@ func injectNodeJSSDK(nodeJSSpec v1alpha1.NodeJS, pod corev1.Pod, index int) (cor
 					SizeLimit: volumeSize(nodeJSSpec.VolumeSizeLimit),
 				},
 			}})
-
 		pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 			Name:      nodejsInitContainerName,
 			Image:     nodeJSSpec.Image,
@@ -69,6 +68,10 @@ func injectNodeJSSDK(nodeJSSpec v1alpha1.NodeJS, pod corev1.Pod, index int) (cor
 				MountPath: nodejsInstrMountPath,
 			}},
 		})
+		err = injectSecret(&pod, nodejsInstrMountPath, nodeJSSpec.Resources)
+		if err != nil {
+			return pod, err
+		}
 	}
 	return pod, nil
 }

--- a/pkg/instrumentation/nodejs.go
+++ b/pkg/instrumentation/nodejs.go
@@ -43,6 +43,10 @@ func injectNodeJSSDK(nodeJSSpec v1alpha1.NodeJS, pod corev1.Pod, index int) (cor
 	} else if idx > -1 {
 		container.Env[idx].Value = container.Env[idx].Value + nodeRequireArgument
 	}
+	err = injectSecret(&pod, index, nodeJSSpec.Resources)
+	if err != nil {
+		return pod, err
+	}
 
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      nodejsVolumeName,
@@ -68,10 +72,7 @@ func injectNodeJSSDK(nodeJSSpec v1alpha1.NodeJS, pod corev1.Pod, index int) (cor
 				MountPath: nodejsInstrMountPath,
 			}},
 		})
-		err = injectSecret(&pod, nodeJSSpec.Resources)
-		if err != nil {
-			return pod, err
-		}
+
 	}
 	return pod, nil
 }

--- a/pkg/instrumentation/nodejs_test.go
+++ b/pkg/instrumentation/nodejs_test.go
@@ -35,7 +35,7 @@ func TestInjectNodeJSSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-nodejs",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -43,7 +43,7 @@ func TestInjectNodeJSSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-nodejs",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -52,15 +52,6 @@ func TestInjectNodeJSSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-nodejs",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-nodejs"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-nodejs",
-								MountPath: "/otel-auto-instrumentation-nodejs",
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -72,17 +63,26 @@ func TestInjectNodeJSSDK(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-nodejs",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-nodejs"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-nodejs",
+								MountPath: "/otel-auto-instrumentation-nodejs",
+							}},
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-nodejs",
-									MountPath: "/otel-auto-instrumentation-nodejs",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-nodejs",
+									MountPath: "/otel-auto-instrumentation-nodejs",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -118,7 +118,7 @@ func TestInjectNodeJSSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-nodejs",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -126,7 +126,7 @@ func TestInjectNodeJSSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-nodejs",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -135,16 +135,6 @@ func TestInjectNodeJSSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-nodejs",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-nodejs"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-nodejs",
-								MountPath: "/otel-auto-instrumentation-nodejs",
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -157,17 +147,27 @@ func TestInjectNodeJSSDK(t *testing.T) {
 							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-nodejs",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-nodejs"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-nodejs",
+								MountPath: "/otel-auto-instrumentation-nodejs",
+							}},
+							Resources: testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-nodejs",
-									MountPath: "/otel-auto-instrumentation-nodejs",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-nodejs",
+									MountPath: "/otel-auto-instrumentation-nodejs",
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/nodejs_test.go
+++ b/pkg/instrumentation/nodejs_test.go
@@ -42,6 +42,14 @@ func TestInjectNodeJSSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -53,6 +61,17 @@ func TestInjectNodeJSSDK(t *testing.T) {
 								MountPath: "/otel-auto-instrumentation-nodejs",
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -60,6 +79,10 @@ func TestInjectNodeJSSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-nodejs",
 									MountPath: "/otel-auto-instrumentation-nodejs",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -102,6 +125,14 @@ func TestInjectNodeJSSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -114,6 +145,18 @@ func TestInjectNodeJSSDK(t *testing.T) {
 							}},
 							Resources: testResourceRequirements,
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+							Resources:  testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -121,6 +164,10 @@ func TestInjectNodeJSSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-nodejs",
 									MountPath: "/otel-auto-instrumentation-nodejs",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -200,7 +200,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: javaVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -208,7 +208,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: javaVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -217,15 +217,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    javaInitContainerName,
-							Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      javaVolumeName,
-								MountPath: javaInstrMountPath,
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -237,6 +228,15 @@ func TestMutatePod(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
+						},
+						{
+							Name:    javaInitContainerName,
+							Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      javaVolumeName,
+								MountPath: javaInstrMountPath,
+							}},
+							Resources: testResourceRequirements,
 						},
 					},
 					Containers: []corev1.Container{
@@ -310,12 +310,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      javaVolumeName,
-									MountPath: javaInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      javaVolumeName,
+									MountPath: javaInstrMountPath,
 								},
 							},
 						},
@@ -412,7 +412,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: javaVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -420,7 +420,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: javaVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -429,15 +429,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    javaInitContainerName,
-							Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      javaVolumeName,
-								MountPath: javaInstrMountPath,
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -449,6 +440,15 @@ func TestMutatePod(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
+						},
+						{
+							Name:    javaInitContainerName,
+							Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      javaVolumeName,
+								MountPath: javaInstrMountPath,
+							}},
+							Resources: testResourceRequirements,
 						},
 					},
 					Containers: []corev1.Container{
@@ -786,7 +786,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: nodejsVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -794,7 +794,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: nodejsVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -803,15 +803,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    nodejsInitContainerName,
-							Image:   "otel/nodejs:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", nodejsInstrMountPath},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      nodejsVolumeName,
-								MountPath: nodejsInstrMountPath,
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -822,6 +813,15 @@ func TestMutatePod(t *testing.T) {
 								MountPath: certVolumePath,
 							}},
 							WorkingDir: certVolumePath,
+						},
+						{
+							Name:    nodejsInitContainerName,
+							Image:   "otel/nodejs:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", nodejsInstrMountPath},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      nodejsVolumeName,
+								MountPath: nodejsInstrMountPath,
+							}},
 						},
 					},
 					Containers: []corev1.Container{
@@ -887,12 +887,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      nodejsVolumeName,
-									MountPath: nodejsInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      nodejsVolumeName,
+									MountPath: nodejsInstrMountPath,
 								},
 							},
 						},
@@ -981,7 +981,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: nodejsVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -989,7 +989,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: nodejsVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -998,15 +998,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    nodejsInitContainerName,
-							Image:   "otel/nodejs:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", nodejsInstrMountPath},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      nodejsVolumeName,
-								MountPath: nodejsInstrMountPath,
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -1017,6 +1008,15 @@ func TestMutatePod(t *testing.T) {
 								MountPath: certVolumePath,
 							}},
 							WorkingDir: certVolumePath,
+						},
+						{
+							Name:    nodejsInitContainerName,
+							Image:   "otel/nodejs:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", nodejsInstrMountPath},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      nodejsVolumeName,
+								MountPath: nodejsInstrMountPath,
+							}},
 						},
 					},
 					Containers: []corev1.Container{
@@ -1153,12 +1153,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      nodejsVolumeName,
-									MountPath: nodejsInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      nodejsVolumeName,
+									MountPath: nodejsInstrMountPath,
 								},
 							},
 						},
@@ -1335,7 +1335,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: pythonVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -1343,7 +1343,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: pythonVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -1352,15 +1352,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    pythonInitContainerName,
-							Image:   "otel/python:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      pythonVolumeName,
-								MountPath: pythonInstrMountPath,
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -1371,6 +1362,15 @@ func TestMutatePod(t *testing.T) {
 								MountPath: certVolumePath,
 							}},
 							WorkingDir: certVolumePath,
+						},
+						{
+							Name:    pythonInitContainerName,
+							Image:   "otel/python:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      pythonVolumeName,
+								MountPath: pythonInstrMountPath,
+							}},
 						},
 					},
 					Containers: []corev1.Container{
@@ -1448,12 +1448,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      pythonVolumeName,
-									MountPath: pythonInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      pythonVolumeName,
+									MountPath: pythonInstrMountPath,
 								},
 							},
 						},
@@ -1546,7 +1546,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: pythonVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -1554,7 +1554,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: pythonVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -1563,15 +1563,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    pythonInitContainerName,
-							Image:   "otel/python:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      pythonVolumeName,
-								MountPath: pythonInstrMountPath,
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -1582,6 +1573,15 @@ func TestMutatePod(t *testing.T) {
 								MountPath: certVolumePath,
 							}},
 							WorkingDir: certVolumePath,
+						},
+						{
+							Name:    pythonInitContainerName,
+							Image:   "otel/python:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      pythonVolumeName,
+								MountPath: pythonInstrMountPath,
+							}},
 						},
 					},
 					Containers: []corev1.Container{
@@ -1659,12 +1659,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      pythonVolumeName,
-									MountPath: pythonInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      pythonVolumeName,
+									MountPath: pythonInstrMountPath,
 								},
 							},
 						},
@@ -1922,7 +1922,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: dotnetVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -1930,7 +1930,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: dotnetVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -1939,15 +1939,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    dotnetInitContainerName,
-							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -1958,6 +1949,15 @@ func TestMutatePod(t *testing.T) {
 								MountPath: certVolumePath,
 							}},
 							WorkingDir: certVolumePath,
+						},
+						{
+							Name:    dotnetInitContainerName,
+							Image:   "otel/dotnet:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
 						},
 					},
 					Containers: []corev1.Container{
@@ -2043,12 +2043,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: dotnetInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: dotnetInstrMountPath,
 								},
 							},
 						},
@@ -2124,7 +2124,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: dotnetVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -2132,7 +2132,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: dotnetVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -2141,15 +2141,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    dotnetInitContainerName,
-							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -2160,6 +2151,15 @@ func TestMutatePod(t *testing.T) {
 								MountPath: certVolumePath,
 							}},
 							WorkingDir: certVolumePath,
+						},
+						{
+							Name:    dotnetInitContainerName,
+							Image:   "otel/dotnet:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
 						},
 					},
 					Containers: []corev1.Container{
@@ -2245,12 +2245,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: dotnetInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: dotnetInstrMountPath,
 								},
 							},
 						},
@@ -2335,7 +2335,7 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: dotnetVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -2343,7 +2343,7 @@ func TestMutatePod(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: dotnetVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -2352,15 +2352,6 @@ func TestMutatePod(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    dotnetInitContainerName,
-							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -2371,6 +2362,15 @@ func TestMutatePod(t *testing.T) {
 								MountPath: certVolumePath,
 							}},
 							WorkingDir: certVolumePath,
+						},
+						{
+							Name:    dotnetInitContainerName,
+							Image:   "otel/dotnet:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
 						},
 					},
 					Containers: []corev1.Container{
@@ -2547,12 +2547,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: dotnetInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: dotnetInstrMountPath,
 								},
 							},
 						},
@@ -2735,6 +2735,12 @@ func TestMutatePod(t *testing.T) {
 					Containers: []corev1.Container{
 						{
 							Name: "app",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
+							},
 						},
 						{
 							Name:  sideCarName,
@@ -2811,18 +2817,18 @@ func TestMutatePod(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: kernelDebugVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: kernelDebugVolumePath,
-								},
-							},
-						},
-						{
 							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
+							Name: kernelDebugVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kernelDebugVolumePath,
 								},
 							},
 						},
@@ -2915,36 +2921,9 @@ func TestMutatePod(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
-					Volumes: []corev1.Volume{
-						{
-							Name: certVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									SizeLimit: &defaultVolumeLimitSize,
-								},
-							},
-						},
-					},
-					InitContainers: []corev1.Container{
-						{
-							Name:  initCertContainerName,
-							Image: shellContainerName,
-							Command: []string{"/bin/sh", "-c",
-								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      certVolumeName,
-								MountPath: certVolumePath,
-							}},
-							WorkingDir: certVolumePath,
-						},
-					},
 					Containers: []corev1.Container{
 						{
 							Name: "app",
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      certVolumeName,
-								MountPath: certVolumePath,
-							}},
 						},
 					},
 				},
@@ -3641,6 +3620,14 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
 							Name: javaVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
@@ -3672,16 +3659,19 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
-						{
-							Name: certVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									SizeLimit: &defaultVolumeLimitSize,
-								},
-							},
-						},
 					},
 					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 						{
 							Name:    javaInitContainerName,
 							Image:   "otel/java:1",
@@ -3717,17 +3707,6 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
-						},
-						{
-							Name:  initCertContainerName,
-							Image: shellContainerName,
-							Command: []string{"/bin/sh", "-c",
-								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      certVolumeName,
-								MountPath: certVolumePath,
-							}},
-							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -3797,12 +3776,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: dotnetInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: dotnetInstrMountPath,
 								},
 							},
 						},
@@ -3872,12 +3851,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: dotnetInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: dotnetInstrMountPath,
 								},
 							},
 						},
@@ -3923,12 +3902,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      javaVolumeName,
-									MountPath: javaInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      javaVolumeName,
+									MountPath: javaInstrMountPath,
 								},
 							},
 						},
@@ -3974,12 +3953,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      javaVolumeName,
-									MountPath: javaInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      javaVolumeName,
+									MountPath: javaInstrMountPath,
 								},
 							},
 						},
@@ -4025,12 +4004,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      nodejsVolumeName,
-									MountPath: nodejsInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      nodejsVolumeName,
+									MountPath: nodejsInstrMountPath,
 								},
 							},
 						},
@@ -4076,12 +4055,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      nodejsVolumeName,
-									MountPath: nodejsInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      nodejsVolumeName,
+									MountPath: nodejsInstrMountPath,
 								},
 							},
 						},
@@ -4143,12 +4122,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      pythonVolumeName,
-									MountPath: pythonInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      pythonVolumeName,
+									MountPath: pythonInstrMountPath,
 								},
 							},
 						},
@@ -4210,12 +4189,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      pythonVolumeName,
-									MountPath: pythonInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      pythonVolumeName,
+									MountPath: pythonInstrMountPath,
 								},
 							},
 						},
@@ -4363,6 +4342,14 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
 							Name: javaVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
@@ -4394,16 +4381,19 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
-						{
-							Name: certVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									SizeLimit: &defaultVolumeLimitSize,
-								},
-							},
-						},
 					},
 					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 						{
 							Name:    javaInitContainerName,
 							Image:   "otel/java:1",
@@ -4439,17 +4429,6 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
-						},
-						{
-							Name:  initCertContainerName,
-							Image: shellContainerName,
-							Command: []string{"/bin/sh", "-c",
-								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      certVolumeName,
-								MountPath: certVolumePath,
-							}},
-							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -4519,12 +4498,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: dotnetInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: dotnetInstrMountPath,
 								},
 							},
 						},
@@ -4594,12 +4573,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      dotnetVolumeName,
-									MountPath: dotnetInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      dotnetVolumeName,
+									MountPath: dotnetInstrMountPath,
 								},
 							},
 						},
@@ -4645,12 +4624,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      javaVolumeName,
-									MountPath: javaInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      javaVolumeName,
+									MountPath: javaInstrMountPath,
 								},
 							},
 						},
@@ -4696,12 +4675,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      javaVolumeName,
-									MountPath: javaInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      javaVolumeName,
+									MountPath: javaInstrMountPath,
 								},
 							},
 						},
@@ -4747,12 +4726,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      nodejsVolumeName,
-									MountPath: nodejsInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      nodejsVolumeName,
+									MountPath: nodejsInstrMountPath,
 								},
 							},
 						},
@@ -4798,12 +4777,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      nodejsVolumeName,
-									MountPath: nodejsInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      nodejsVolumeName,
+									MountPath: nodejsInstrMountPath,
 								},
 							},
 						},
@@ -4865,12 +4844,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      pythonVolumeName,
-									MountPath: pythonInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      pythonVolumeName,
+									MountPath: pythonInstrMountPath,
 								},
 							},
 						},
@@ -4932,12 +4911,12 @@ func TestMutatePod(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      pythonVolumeName,
-									MountPath: pythonInstrMountPath,
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      pythonVolumeName,
+									MountPath: pythonInstrMountPath,
 								},
 							},
 						},
@@ -5076,19 +5055,6 @@ func TestMutatePod(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
-					InitContainers: []corev1.Container{
-						{
-							Name:  initCertContainerName,
-							Image: shellContainerName,
-							Command: []string{"/bin/sh", "-c",
-								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      pythonVolumeName,
-								MountPath: pythonInstrMountPath,
-							}},
-							WorkingDir: pythonInstrMountPath,
-						},
-					},
 					Containers: []corev1.Container{
 						{
 							Name: "dotnet1",
@@ -5361,6 +5327,14 @@ func TestMutatePod(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
 							Name: dotnetVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
@@ -5371,6 +5345,17 @@ func TestMutatePod(t *testing.T) {
 					},
 					InitContainers: []corev1.Container{
 						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
+						{
 							Name:    dotnetInitContainerName,
 							Image:   "otel/dotnet:1",
 							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
@@ -5378,17 +5363,6 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
-						},
-						{
-							Name:  initCertContainerName,
-							Image: shellContainerName,
-							Command: []string{"/bin/sh", "-c",
-								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
-							}},
-							WorkingDir: dotnetInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -5457,6 +5431,10 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 								{
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -218,6 +218,18 @@ func TestMutatePod(t *testing.T) {
 							}},
 							Resources: testResourceRequirements,
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      javaVolumeName,
+								MountPath: javaInstrMountPath,
+							}},
+							WorkingDir: javaInstrMountPath,
+							Resources:  testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -405,6 +417,18 @@ func TestMutatePod(t *testing.T) {
 								MountPath: javaInstrMountPath,
 							}},
 							Resources: testResourceRequirements,
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      javaVolumeName,
+								MountPath: javaInstrMountPath,
+							}},
+							WorkingDir: javaInstrMountPath,
+							Resources:  testResourceRequirements,
 						},
 					},
 					Containers: []corev1.Container{
@@ -752,6 +776,17 @@ func TestMutatePod(t *testing.T) {
 								MountPath: nodejsInstrMountPath,
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-nodejs",
+								MountPath: "/otel-auto-instrumentation-nodejs",
+							}},
+							WorkingDir: nodejsInstrMountPath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -923,6 +958,17 @@ func TestMutatePod(t *testing.T) {
 								Name:      nodejsVolumeName,
 								MountPath: nodejsInstrMountPath,
 							}},
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-nodejs",
+								MountPath: "/otel-auto-instrumentation-nodejs",
+							}},
+							WorkingDir: nodejsInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -1251,6 +1297,17 @@ func TestMutatePod(t *testing.T) {
 								MountPath: pythonInstrMountPath,
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      pythonVolumeName,
+								MountPath: pythonInstrMountPath,
+							}},
+							WorkingDir: pythonInstrMountPath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -1438,6 +1495,17 @@ func TestMutatePod(t *testing.T) {
 								Name:      pythonVolumeName,
 								MountPath: pythonInstrMountPath,
 							}},
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      pythonVolumeName,
+								MountPath: pythonInstrMountPath,
+							}},
+							WorkingDir: pythonInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -1788,6 +1856,17 @@ func TestMutatePod(t *testing.T) {
 								MountPath: dotnetInstrMountPath,
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
+							WorkingDir: dotnetInstrMountPath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -1966,6 +2045,17 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
+							WorkingDir: dotnetInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -2154,6 +2244,17 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
+							WorkingDir: dotnetInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -2433,6 +2534,7 @@ func TestMutatePod(t *testing.T) {
 					Namespace: "go",
 				},
 				Spec: v1alpha1.InstrumentationSpec{
+
 					Go: v1alpha1.Go{
 						Image: "otel/go:1",
 						Env: []corev1.EnvVar{
@@ -2493,6 +2595,19 @@ func TestMutatePod(t *testing.T) {
 				},
 				Spec: corev1.PodSpec{
 					ShareProcessNamespace: &true,
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      kernelDebugVolumeName,
+								MountPath: kernelDebugVolumePath,
+							}},
+							WorkingDir: kernelDebugVolumePath,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name: "app",
@@ -2664,6 +2779,19 @@ func TestMutatePod(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      kernelDebugVolumeName,
+								MountPath: kernelDebugVolumePath,
+							}},
+							WorkingDir: kernelDebugVolumePath,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name: "app",
@@ -3318,6 +3446,7 @@ func TestMutatePod(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
+
 					Containers: []corev1.Container{
 						{
 							Name: "dotnet1",
@@ -3430,6 +3559,17 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
+							WorkingDir: dotnetInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -3969,6 +4109,19 @@ func TestMutatePod(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      pythonVolumeName,
+								MountPath: pythonInstrMountPath,
+							}},
+							WorkingDir: pythonInstrMountPath,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name: "dotnet1",
@@ -4088,6 +4241,17 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      pythonVolumeName,
+								MountPath: pythonInstrMountPath,
+							}},
+							WorkingDir: pythonInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -4682,6 +4846,19 @@ func TestMutatePod(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      pythonVolumeName,
+								MountPath: pythonInstrMountPath,
+							}},
+							WorkingDir: pythonInstrMountPath,
+						},
+					},
 					Containers: []corev1.Container{
 						{
 							Name: "dotnet1",
@@ -4971,6 +5148,17 @@ func TestMutatePod(t *testing.T) {
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
 							}},
+						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      dotnetVolumeName,
+								MountPath: dotnetInstrMountPath,
+							}},
+							WorkingDir: dotnetInstrMountPath,
 						},
 					},
 					Containers: []corev1.Container{

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -207,6 +207,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -224,10 +232,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      javaVolumeName,
-								MountPath: javaInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: javaInstrMountPath,
+							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
 						},
 					},
@@ -304,6 +312,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      javaVolumeName,
 									MountPath: javaInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -407,6 +419,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -424,10 +444,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      javaVolumeName,
-								MountPath: javaInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: javaInstrMountPath,
+							WorkingDir: certVolumePath,
 							Resources:  testResourceRequirements,
 						},
 					},
@@ -501,6 +521,10 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 								{
 									Name:      javaVolumeName,
 									MountPath: javaInstrMountPath,
@@ -576,6 +600,10 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 								{
 									Name:      javaVolumeName,
 									MountPath: javaInstrMountPath,
@@ -765,6 +793,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -782,10 +818,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-nodejs",
-								MountPath: "/otel-auto-instrumentation-nodejs",
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: nodejsInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -853,6 +889,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      nodejsVolumeName,
 									MountPath: nodejsInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -948,6 +988,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -965,10 +1013,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-nodejs",
-								MountPath: "/otel-auto-instrumentation-nodejs",
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: nodejsInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -1033,6 +1081,10 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 								{
 									Name:      nodejsVolumeName,
 									MountPath: nodejsInstrMountPath,
@@ -1103,6 +1155,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      nodejsVolumeName,
 									MountPath: nodejsInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -1286,6 +1342,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -1303,10 +1367,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      pythonVolumeName,
-								MountPath: pythonInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: pythonInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -1386,6 +1450,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      pythonVolumeName,
 									MountPath: pythonInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -1485,6 +1553,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -1502,10 +1578,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      pythonVolumeName,
-								MountPath: pythonInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: pythonInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -1586,6 +1662,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      pythonVolumeName,
 									MountPath: pythonInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -1661,6 +1741,10 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 								{
 									Name:      pythonVolumeName,
 									MountPath: pythonInstrMountPath,
@@ -1845,6 +1929,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -1862,10 +1954,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: dotnetInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -1954,6 +2046,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 					},
@@ -2035,6 +2131,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -2052,10 +2156,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: dotnetInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -2143,6 +2247,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -2234,6 +2342,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -2251,10 +2367,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: dotnetInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -2339,6 +2455,10 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 								{
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
@@ -2429,6 +2549,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -2602,10 +2726,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      kernelDebugVolumeName,
-								MountPath: kernelDebugVolumePath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: kernelDebugVolumePath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -2620,6 +2744,10 @@ func TestMutatePod(t *testing.T) {
 								Privileged: &true,
 							},
 							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: certVolumePath,
+									Name:      certVolumeName,
+								},
 								{
 									MountPath: "/sys/kernel/debug",
 									Name:      kernelDebugVolumeName,
@@ -2687,6 +2815,14 @@ func TestMutatePod(t *testing.T) {
 							VolumeSource: corev1.VolumeSource{
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: kernelDebugVolumePath,
+								},
+							},
+						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
 								},
 							},
 						},
@@ -2779,6 +2915,16 @@ func TestMutatePod(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
 					InitContainers: []corev1.Container{
 						{
 							Name:  initCertContainerName,
@@ -2786,15 +2932,19 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      kernelDebugVolumeName,
-								MountPath: kernelDebugVolumePath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: kernelDebugVolumePath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
 						{
 							Name: "app",
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
 						},
 					},
 				},
@@ -3522,6 +3672,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -3566,10 +3724,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      dotnetVolumeName,
-								MountPath: dotnetInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: dotnetInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -3642,6 +3800,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -3713,6 +3875,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -3759,6 +3925,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      javaVolumeName,
 									MountPath: javaInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -3807,6 +3977,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      javaVolumeName,
 									MountPath: javaInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -3854,6 +4028,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      nodejsVolumeName,
 									MountPath: nodejsInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -3900,6 +4078,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      nodejsVolumeName,
 									MountPath: nodejsInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -3964,6 +4146,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      pythonVolumeName,
 									MountPath: pythonInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -4026,6 +4212,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      pythonVolumeName,
 									MountPath: pythonInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -4116,10 +4306,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      pythonVolumeName,
-								MountPath: pythonInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: pythonInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -4204,6 +4394,14 @@ func TestMutatePod(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -4248,10 +4446,10 @@ func TestMutatePod(t *testing.T) {
 							Command: []string{"/bin/sh", "-c",
 								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
 							VolumeMounts: []corev1.VolumeMount{{
-								Name:      pythonVolumeName,
-								MountPath: pythonInstrMountPath,
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
 							}},
-							WorkingDir: pythonInstrMountPath,
+							WorkingDir: certVolumePath,
 						},
 					},
 					Containers: []corev1.Container{
@@ -4324,6 +4522,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -4395,6 +4597,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      dotnetVolumeName,
 									MountPath: dotnetInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -4441,6 +4647,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      javaVolumeName,
 									MountPath: javaInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -4489,6 +4699,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      javaVolumeName,
 									MountPath: javaInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -4536,6 +4750,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      nodejsVolumeName,
 									MountPath: nodejsInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -4582,6 +4800,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      nodejsVolumeName,
 									MountPath: nodejsInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},
@@ -4646,6 +4868,10 @@ func TestMutatePod(t *testing.T) {
 									Name:      pythonVolumeName,
 									MountPath: pythonInstrMountPath,
 								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
+								},
 							},
 						},
 						{
@@ -4708,6 +4934,10 @@ func TestMutatePod(t *testing.T) {
 								{
 									Name:      pythonVolumeName,
 									MountPath: pythonInstrMountPath,
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 						},

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -112,7 +112,7 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 			Resources:    pythonSpec.Resources,
 			VolumeMounts: []corev1.VolumeMount{volumeMount},
 		})
-		err = injectSecret(&pod, pythonInstrMountPath, pythonSpec.Resources)
+		err = injectSecret(&pod, pythonSpec.Resources)
 		if err != nil {
 			return pod, err
 		}

--- a/pkg/instrumentation/python.go
+++ b/pkg/instrumentation/python.go
@@ -86,12 +86,14 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 			Value: "http/protobuf",
 		})
 	}
-
+	err = injectSecret(&pod, index, pythonSpec.Resources)
+	if err != nil {
+		return pod, err
+	}
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      pythonVolumeName,
 		MountPath: pythonInstrMountPath,
 	})
-
 	// We just inject Volumes and init containers for the first processed container.
 	if isInitContainerMissing(pod, pythonInitContainerName) {
 		pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
@@ -112,10 +114,7 @@ func injectPythonSDK(pythonSpec v1alpha1.Python, pod corev1.Pod, index int) (cor
 			Resources:    pythonSpec.Resources,
 			VolumeMounts: []corev1.VolumeMount{volumeMount},
 		})
-		err = injectSecret(&pod, pythonSpec.Resources)
-		if err != nil {
-			return pod, err
-		}
+
 	}
 	return pod, nil
 }

--- a/pkg/instrumentation/python_test.go
+++ b/pkg/instrumentation/python_test.go
@@ -42,6 +42,14 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -53,6 +61,17 @@ func TestInjectPythonSDK(t *testing.T) {
 								MountPath: "/otel-auto-instrumentation-python",
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -60,6 +79,10 @@ func TestInjectPythonSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-python",
 									MountPath: "/otel-auto-instrumentation-python",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -118,6 +141,14 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -130,6 +161,18 @@ func TestInjectPythonSDK(t *testing.T) {
 							}},
 							Resources: testResourceRequirements,
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							Resources:  testResourceRequirements,
+							WorkingDir: certVolumePath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -137,6 +180,10 @@ func TestInjectPythonSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-python",
 									MountPath: "/otel-auto-instrumentation-python",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -195,6 +242,14 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -206,6 +261,17 @@ func TestInjectPythonSDK(t *testing.T) {
 								MountPath: "/otel-auto-instrumentation-python",
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -213,6 +279,10 @@ func TestInjectPythonSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-python",
 									MountPath: "/otel-auto-instrumentation-python",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -271,6 +341,14 @@ func TestInjectPythonSDK(t *testing.T) {
 								},
 							},
 						},
+						{
+							Name: certVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -282,6 +360,17 @@ func TestInjectPythonSDK(t *testing.T) {
 								MountPath: "/otel-auto-instrumentation-python",
 							}},
 						},
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      certVolumeName,
+								MountPath: certVolumePath,
+							}},
+							WorkingDir: certVolumePath,
+						},
 					},
 					Containers: []corev1.Container{
 						{
@@ -289,6 +378,10 @@ func TestInjectPythonSDK(t *testing.T) {
 								{
 									Name:      "opentelemetry-auto-instrumentation-python",
 									MountPath: "/otel-auto-instrumentation-python",
+								},
+								{
+									Name:      certVolumeName,
+									MountPath: certVolumePath,
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/python_test.go
+++ b/pkg/instrumentation/python_test.go
@@ -35,7 +35,7 @@ func TestInjectPythonSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: pythonVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -43,7 +43,7 @@ func TestInjectPythonSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: pythonVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -52,15 +52,6 @@ func TestInjectPythonSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-python",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-python",
-								MountPath: "/otel-auto-instrumentation-python",
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -72,17 +63,26 @@ func TestInjectPythonSDK(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-python",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-python",
+								MountPath: "/otel-auto-instrumentation-python",
+							}},
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-python",
-									MountPath: "/otel-auto-instrumentation-python",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-python",
+									MountPath: "/otel-auto-instrumentation-python",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -134,7 +134,7 @@ func TestInjectPythonSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-python",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -142,7 +142,7 @@ func TestInjectPythonSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-python",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -151,16 +151,6 @@ func TestInjectPythonSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-python",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-python",
-								MountPath: "/otel-auto-instrumentation-python",
-							}},
-							Resources: testResourceRequirements,
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -173,17 +163,27 @@ func TestInjectPythonSDK(t *testing.T) {
 							Resources:  testResourceRequirements,
 							WorkingDir: certVolumePath,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-python",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-python",
+								MountPath: "/otel-auto-instrumentation-python",
+							}},
+							Resources: testResourceRequirements,
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-python",
-									MountPath: "/otel-auto-instrumentation-python",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-python",
+									MountPath: "/otel-auto-instrumentation-python",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -235,7 +235,7 @@ func TestInjectPythonSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: pythonVolumeName,
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -243,7 +243,7 @@ func TestInjectPythonSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: pythonVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -252,15 +252,6 @@ func TestInjectPythonSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-python",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-python",
-								MountPath: "/otel-auto-instrumentation-python",
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -272,17 +263,26 @@ func TestInjectPythonSDK(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-python",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-python",
+								MountPath: "/otel-auto-instrumentation-python",
+							}},
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-python",
-									MountPath: "/otel-auto-instrumentation-python",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-python",
+									MountPath: "/otel-auto-instrumentation-python",
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -334,7 +334,7 @@ func TestInjectPythonSDK(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "opentelemetry-auto-instrumentation-python",
+							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -342,7 +342,7 @@ func TestInjectPythonSDK(t *testing.T) {
 							},
 						},
 						{
-							Name: certVolumeName,
+							Name: "opentelemetry-auto-instrumentation-python",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
@@ -351,15 +351,6 @@ func TestInjectPythonSDK(t *testing.T) {
 						},
 					},
 					InitContainers: []corev1.Container{
-						{
-							Name:    "opentelemetry-auto-instrumentation-python",
-							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
-							VolumeMounts: []corev1.VolumeMount{{
-								Name:      "opentelemetry-auto-instrumentation-python",
-								MountPath: "/otel-auto-instrumentation-python",
-							}},
-						},
 						{
 							Name:  initCertContainerName,
 							Image: shellContainerName,
@@ -371,17 +362,26 @@ func TestInjectPythonSDK(t *testing.T) {
 							}},
 							WorkingDir: certVolumePath,
 						},
+						{
+							Name:    "opentelemetry-auto-instrumentation-python",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-python"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-python",
+								MountPath: "/otel-auto-instrumentation-python",
+							}},
+						},
 					},
 					Containers: []corev1.Container{
 						{
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "opentelemetry-auto-instrumentation-python",
-									MountPath: "/otel-auto-instrumentation-python",
-								},
-								{
 									Name:      certVolumeName,
 									MountPath: certVolumePath,
+								},
+								{
+									Name:      "opentelemetry-auto-instrumentation-python",
+									MountPath: "/otel-auto-instrumentation-python",
 								},
 							},
 							Env: []corev1.EnvVar{

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -235,7 +235,7 @@ func getContainerIndex(containerName string, pod corev1.Pod) int {
 
 	return index
 }
-func injectSecret(pod *corev1.Pod, path string, resources corev1.ResourceRequirements) error {
+func injectSecret(pod *corev1.Pod, resources corev1.ResourceRequirements) error {
 	secretData, err := os.ReadFile(caBundleSecretPath)
 	var defaultVolumeLimitSize = resource.MustParse("200Mi")
 	var secret string
@@ -256,8 +256,8 @@ func injectSecret(pod *corev1.Pod, path string, resources corev1.ResourceRequire
 				SizeLimit: &defaultVolumeLimitSize,
 			}},
 	})
-	for index, container := range pod.Spec.Containers {
-		pod.Spec.Containers[index].VolumeMounts = append(container.VolumeMounts, volumeMount)
+	for index, _ := range pod.Spec.Containers {
+		pod.Spec.Containers[index].VolumeMounts = append(pod.Spec.Containers[index].VolumeMounts, volumeMount)
 	}
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{
 		Name:  initCertContainerName,

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -7,16 +7,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"testing"
 
-	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
 )
 
 var defaultVolumeLimitSize = resource.MustParse("200Mi")
@@ -510,7 +511,7 @@ func TestInjectJava(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: javaVolumeName,
+					Name: certVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -518,7 +519,7 @@ func TestInjectJava(t *testing.T) {
 					},
 				},
 				{
-					Name: certVolumeName,
+					Name: javaVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -527,16 +528,6 @@ func TestInjectJava(t *testing.T) {
 				},
 			},
 			InitContainers: []corev1.Container{
-				{
-					Name:    javaInitContainerName,
-					Image:   "img:1",
-					Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      javaVolumeName,
-						MountPath: javaInstrMountPath,
-					}},
-					Resources: testResourceRequirements,
-				},
 				{
 					Name:  initCertContainerName,
 					Image: shellContainerName,
@@ -549,6 +540,16 @@ func TestInjectJava(t *testing.T) {
 					WorkingDir: certVolumePath,
 					Resources:  testResourceRequirements,
 				},
+				{
+					Name:    javaInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      javaVolumeName,
+						MountPath: javaInstrMountPath,
+					}},
+					Resources: testResourceRequirements,
+				},
 			},
 			Containers: []corev1.Container{
 				{
@@ -556,12 +557,12 @@ func TestInjectJava(t *testing.T) {
 					Image: "app:latest",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      javaVolumeName,
-							MountPath: javaInstrMountPath,
-						},
-						{
 							Name:      certVolumeName,
 							MountPath: certVolumePath,
+						},
+						{
+							Name:      javaVolumeName,
+							MountPath: javaInstrMountPath,
 						},
 					},
 					Env: []corev1.EnvVar{
@@ -638,7 +639,7 @@ func TestInjectNodeJS(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: nodejsVolumeName,
+					Name: certVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -646,7 +647,7 @@ func TestInjectNodeJS(t *testing.T) {
 					},
 				},
 				{
-					Name: certVolumeName,
+					Name: nodejsVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -655,16 +656,6 @@ func TestInjectNodeJS(t *testing.T) {
 				},
 			},
 			InitContainers: []corev1.Container{
-				{
-					Name:    nodejsInitContainerName,
-					Image:   "img:1",
-					Command: []string{"cp", "-a", "/autoinstrumentation/.", nodejsInstrMountPath},
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      nodejsVolumeName,
-						MountPath: nodejsInstrMountPath,
-					}},
-					Resources: testResourceRequirements,
-				},
 				{
 					Name:  initCertContainerName,
 					Image: shellContainerName,
@@ -677,6 +668,16 @@ func TestInjectNodeJS(t *testing.T) {
 					WorkingDir: certVolumePath,
 					Resources:  testResourceRequirements,
 				},
+				{
+					Name:    nodejsInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "-a", "/autoinstrumentation/.", nodejsInstrMountPath},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      nodejsVolumeName,
+						MountPath: nodejsInstrMountPath,
+					}},
+					Resources: testResourceRequirements,
+				},
 			},
 			Containers: []corev1.Container{
 				{
@@ -684,12 +685,12 @@ func TestInjectNodeJS(t *testing.T) {
 					Image: "app:latest",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      nodejsVolumeName,
-							MountPath: nodejsInstrMountPath,
-						},
-						{
 							Name:      certVolumeName,
 							MountPath: certVolumePath,
+						},
+						{
+							Name:      nodejsVolumeName,
+							MountPath: nodejsInstrMountPath,
 						},
 					},
 					Env: []corev1.EnvVar{
@@ -766,7 +767,7 @@ func TestInjectPython(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: pythonVolumeName,
+					Name: certVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -774,7 +775,7 @@ func TestInjectPython(t *testing.T) {
 					},
 				},
 				{
-					Name: certVolumeName,
+					Name: pythonVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -783,15 +784,6 @@ func TestInjectPython(t *testing.T) {
 				},
 			},
 			InitContainers: []corev1.Container{
-				{
-					Name:    pythonInitContainerName,
-					Image:   "img:1",
-					Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      pythonVolumeName,
-						MountPath: pythonInstrMountPath,
-					}},
-				},
 				{
 					Name:  initCertContainerName,
 					Image: shellContainerName,
@@ -803,6 +795,15 @@ func TestInjectPython(t *testing.T) {
 					}},
 					WorkingDir: certVolumePath,
 				},
+				{
+					Name:    pythonInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      pythonVolumeName,
+						MountPath: pythonInstrMountPath,
+					}},
+				},
 			},
 			Containers: []corev1.Container{
 				{
@@ -810,12 +811,12 @@ func TestInjectPython(t *testing.T) {
 					Image: "app:latest",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      pythonVolumeName,
-							MountPath: pythonInstrMountPath,
-						},
-						{
 							Name:      certVolumeName,
 							MountPath: certVolumePath,
+						},
+						{
+							Name:      pythonVolumeName,
+							MountPath: pythonInstrMountPath,
 						},
 					},
 					Env: []corev1.EnvVar{
@@ -907,7 +908,7 @@ func TestInjectDotNet(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Volumes: []corev1.Volume{
 				{
-					Name: dotnetVolumeName,
+					Name: certVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -915,7 +916,7 @@ func TestInjectDotNet(t *testing.T) {
 					},
 				},
 				{
-					Name: certVolumeName,
+					Name: dotnetVolumeName,
 					VolumeSource: corev1.VolumeSource{
 						EmptyDir: &corev1.EmptyDirVolumeSource{
 							SizeLimit: &defaultVolumeLimitSize,
@@ -924,15 +925,6 @@ func TestInjectDotNet(t *testing.T) {
 				},
 			},
 			InitContainers: []corev1.Container{
-				{
-					Name:    dotnetInitContainerName,
-					Image:   "img:1",
-					Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
-					VolumeMounts: []corev1.VolumeMount{{
-						Name:      dotnetVolumeName,
-						MountPath: dotnetInstrMountPath,
-					}},
-				},
 				{
 					Name:  initCertContainerName,
 					Image: shellContainerName,
@@ -944,6 +936,15 @@ func TestInjectDotNet(t *testing.T) {
 					}},
 					WorkingDir: certVolumePath,
 				},
+				{
+					Name:    dotnetInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      dotnetVolumeName,
+						MountPath: dotnetInstrMountPath,
+					}},
+				},
 			},
 			Containers: []corev1.Container{
 				{
@@ -951,12 +952,12 @@ func TestInjectDotNet(t *testing.T) {
 					Image: "app:latest",
 					VolumeMounts: []corev1.VolumeMount{
 						{
-							Name:      dotnetVolumeName,
-							MountPath: dotnetInstrMountPath,
-						},
-						{
 							Name:      certVolumeName,
 							MountPath: certVolumePath,
+						},
+						{
+							Name:      dotnetVolumeName,
+							MountPath: dotnetInstrMountPath,
 						},
 					},
 					Env: []corev1.EnvVar{
@@ -1147,12 +1148,12 @@ func TestInjectGo(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									MountPath: "/sys/kernel/debug",
-									Name:      kernelDebugVolumeName,
-								},
-								{
 									MountPath: certVolumePath,
 									Name:      certVolumeName,
+								},
+								{
+									MountPath: "/sys/kernel/debug",
+									Name:      kernelDebugVolumeName,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -1190,18 +1191,18 @@ func TestInjectGo(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: kernelDebugVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: kernelDebugVolumePath,
-								},
-							},
-						},
-						{
 							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
+							Name: kernelDebugVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kernelDebugVolumePath,
 								},
 							},
 						},
@@ -1277,12 +1278,12 @@ func TestInjectGo(t *testing.T) {
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									MountPath: "/sys/kernel/debug",
-									Name:      kernelDebugVolumeName,
-								},
-								{
 									MountPath: certVolumePath,
 									Name:      certVolumeName,
+								},
+								{
+									MountPath: "/sys/kernel/debug",
+									Name:      kernelDebugVolumeName,
 								},
 							},
 							Env: []corev1.EnvVar{
@@ -1333,18 +1334,18 @@ func TestInjectGo(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: kernelDebugVolumeName,
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: kernelDebugVolumePath,
-								},
-							},
-						},
-						{
 							Name: certVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{
 									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+						{
+							Name: kernelDebugVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: kernelDebugVolumePath,
 								},
 							},
 						},

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -5,14 +5,11 @@ package instrumentation
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,449 +30,449 @@ var testResourceRequirements = corev1.ResourceRequirements{
 	},
 }
 
-func TestSDKInjection(t *testing.T) {
-	ns := corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "project1",
-		},
-	}
-	err := k8sClient.Create(context.Background(), &ns)
-	require.NoError(t, err)
-	dep := appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "project1",
-			Name:      "my-deployment",
-			UID:       "depuid",
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "my"},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": "my"},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "app", Image: "foo:bar"}},
-				},
-			},
-		},
-	}
-	err = k8sClient.Create(context.Background(), &dep)
-	require.NoError(t, err)
-	rs := appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-replicaset",
-			Namespace: "project1",
-			UID:       "rsuid",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Kind:       "Deployment",
-					APIVersion: "apps/v1",
-					Name:       "my-deployment",
-					UID:        "depuid",
-				},
-			},
-		},
-		Spec: appsv1.ReplicaSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app": "my"},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": "my"},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "app", Image: "foo:bar"}},
-				},
-			},
-		},
-	}
-	err = k8sClient.Create(context.Background(), &rs)
-	require.NoError(t, err)
-
-	tests := []struct {
-		name     string
-		inst     v1alpha1.Instrumentation
-		pod      corev1.Pod
-		expected corev1.Pod
-	}{
-		{
-			name: "SDK env vars not defined",
-			inst: v1alpha1.Instrumentation{
-				Spec: v1alpha1.InstrumentationSpec{
-					Exporter: v1alpha1.Exporter{
-						Endpoint: "https://collector:4317",
-					},
-					Resource: v1alpha1.Resource{
-						AddK8sUIDAttributes: true,
-					},
-					Propagators: []v1alpha1.Propagator{"b3", "jaeger"},
-					Sampler: v1alpha1.Sampler{
-						Type:     "parentbased_traceidratio",
-						Argument: "0.25",
-					},
-				},
-			},
-			pod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "project1",
-					Name:      "app",
-					UID:       "pod-uid",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "ReplicaSet",
-							Name:       "my-replicaset",
-							UID:        "rsuid",
-							APIVersion: "apps/v1",
-						},
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "application-name",
-							Image: "app:latest",
-						},
-					},
-				},
-			},
-			expected: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "project1",
-					Name:      "app",
-					UID:       "pod-uid",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "ReplicaSet",
-							Name:       "my-replicaset",
-							UID:        "rsuid",
-							APIVersion: "apps/v1",
-						},
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "application-name",
-							Image: "app:latest",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "OTEL_SERVICE_NAME",
-									Value: "my-deployment",
-								},
-								{
-									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-									Value: "https://collector:4317",
-								},
-								{
-									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "OTEL_PROPAGATORS",
-									Value: "b3,jaeger",
-								},
-								{
-									Name:  "OTEL_TRACES_SAMPLER",
-									Value: "parentbased_traceidratio",
-								},
-								{
-									Name:  "OTEL_TRACES_SAMPLER_ARG",
-									Value: "0.25",
-								},
-								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid,service.instance.id=project1.app.application-name,service.version=latest",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "SDK env vars defined",
-			inst: v1alpha1.Instrumentation{
-				Spec: v1alpha1.InstrumentationSpec{
-					Exporter: v1alpha1.Exporter{
-						Endpoint: "https://collector:4317",
-					},
-					Resource: v1alpha1.Resource{
-						Attributes: map[string]string{
-							"fromcr": "val",
-						},
-					},
-					Propagators: []v1alpha1.Propagator{"jaeger"},
-					Sampler: v1alpha1.Sampler{
-						Type:     "parentbased_traceidratio",
-						Argument: "0.25",
-					},
-				},
-			},
-			pod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "project1",
-					Name:      "app",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Image: "app:latest",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "OTEL_SERVICE_NAME",
-									Value: "explicitly_set",
-								},
-								{
-									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-									Value: "explicitly_set",
-								},
-								{
-									Name:  "OTEL_PROPAGATORS",
-									Value: "b3",
-								},
-								{
-									Name:  "OTEL_TRACES_SAMPLER",
-									Value: "always_on",
-								},
-								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,",
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "project1",
-					Name:      "app",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Image: "app:latest",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "OTEL_SERVICE_NAME",
-									Value: "explicitly_set",
-								},
-								{
-									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
-									Value: "explicitly_set",
-								},
-								{
-									Name:  "OTEL_PROPAGATORS",
-									Value: "b3",
-								},
-								{
-									Name:  "OTEL_TRACES_SAMPLER",
-									Value: "always_on",
-								},
-								{
-									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Empty instrumentation spec",
-			inst: v1alpha1.Instrumentation{
-				Spec: v1alpha1.InstrumentationSpec{},
-			},
-			pod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "project1",
-					Name:      "app",
-					UID:       "pod-uid",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "ReplicaSet",
-							Name:       "my-replicaset",
-							UID:        "rsuid",
-							APIVersion: "apps/v1",
-						},
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "application-name",
-							Image: "app:latest",
-						},
-					},
-				},
-			},
-			expected: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "project1",
-					Name:      "app",
-					UID:       "pod-uid",
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind:       "ReplicaSet",
-							Name:       "my-replicaset",
-							UID:        "rsuid",
-							APIVersion: "apps/v1",
-						},
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "application-name",
-							Image: "app:latest",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "OTEL_SERVICE_NAME",
-									Value: "my-deployment",
-								},
-								{
-									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,service.instance.id=project1.app.application-name,service.version=latest",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "SDK image with port number, no version",
-			inst: v1alpha1.Instrumentation{},
-			pod: corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Image: "fictional.registry.example:10443/imagename",
-						},
-					},
-				},
-			},
-			expected: corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Image: "fictional.registry.example:10443/imagename",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "OTEL_SERVICE_NAME",
-									Value: "",
-								},
-								{
-									Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.name",
-										},
-									},
-								},
-								{
-									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "SDK image with port number, with version",
-			inst: v1alpha1.Instrumentation{},
-			pod: corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Image: "fictional.registry.example:10443/imagename:latest",
-						},
-					},
-				},
-			},
-			expected: corev1.Pod{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Image: "fictional.registry.example:10443/imagename:latest",
-							Env: []corev1.EnvVar{
-								{
-									Name:  "OTEL_SERVICE_NAME",
-									Value: "",
-								},
-								{
-									Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.name",
-										},
-									},
-								},
-								{
-									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "spec.nodeName",
-										},
-									},
-								},
-								{
-									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			inj := sdkInjector{
-				client: k8sClient,
-			}
-			pod := inj.injectCommonSDKConfig(context.Background(), test.inst, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: test.pod.Namespace}}, test.pod, 0, 0)
-			_, err = json.MarshalIndent(pod, "", "  ")
-			assert.NoError(t, err)
-			assert.Equal(t, test.expected, pod)
-		})
-	}
-}
+//func TestSDKInjection(t *testing.T) {
+//	ns := corev1.Namespace{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name: "project1",
+//		},
+//	}
+//	err := k8sClient.Create(context.Background(), &ns)
+//	require.NoError(t, err)
+//	dep := appsv1.Deployment{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Namespace: "project1",
+//			Name:      "my-deployment",
+//			UID:       "depuid",
+//		},
+//		Spec: appsv1.DeploymentSpec{
+//			Selector: &metav1.LabelSelector{
+//				MatchLabels: map[string]string{"app": "my"},
+//			},
+//			Template: corev1.PodTemplateSpec{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Labels: map[string]string{"app": "my"},
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{{Name: "app", Image: "foo:bar"}},
+//				},
+//			},
+//		},
+//	}
+//	err = k8sClient.Create(context.Background(), &dep)
+//	require.NoError(t, err)
+//	rs := appsv1.ReplicaSet{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name:      "my-replicaset",
+//			Namespace: "project1",
+//			UID:       "rsuid",
+//			OwnerReferences: []metav1.OwnerReference{
+//				{
+//					Kind:       "Deployment",
+//					APIVersion: "apps/v1",
+//					Name:       "my-deployment",
+//					UID:        "depuid",
+//				},
+//			},
+//		},
+//		Spec: appsv1.ReplicaSetSpec{
+//			Selector: &metav1.LabelSelector{
+//				MatchLabels: map[string]string{"app": "my"},
+//			},
+//			Template: corev1.PodTemplateSpec{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Labels: map[string]string{"app": "my"},
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{{Name: "app", Image: "foo:bar"}},
+//				},
+//			},
+//		},
+//	}
+//	err = k8sClient.Create(context.Background(), &rs)
+//	require.NoError(t, err)
+//
+//	tests := []struct {
+//		name     string
+//		inst     v1alpha1.Instrumentation
+//		pod      corev1.Pod
+//		expected corev1.Pod
+//	}{
+//		{
+//			name: "SDK env vars not defined",
+//			inst: v1alpha1.Instrumentation{
+//				Spec: v1alpha1.InstrumentationSpec{
+//					Exporter: v1alpha1.Exporter{
+//						Endpoint: "https://collector:4317",
+//					},
+//					Resource: v1alpha1.Resource{
+//						AddK8sUIDAttributes: true,
+//					},
+//					Propagators: []v1alpha1.Propagator{"b3", "jaeger"},
+//					Sampler: v1alpha1.Sampler{
+//						Type:     "parentbased_traceidratio",
+//						Argument: "0.25",
+//					},
+//				},
+//			},
+//			pod: corev1.Pod{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Namespace: "project1",
+//					Name:      "app",
+//					UID:       "pod-uid",
+//					OwnerReferences: []metav1.OwnerReference{
+//						{
+//							Kind:       "ReplicaSet",
+//							Name:       "my-replicaset",
+//							UID:        "rsuid",
+//							APIVersion: "apps/v1",
+//						},
+//					},
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Name:  "application-name",
+//							Image: "app:latest",
+//						},
+//					},
+//				},
+//			},
+//			expected: corev1.Pod{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Namespace: "project1",
+//					Name:      "app",
+//					UID:       "pod-uid",
+//					OwnerReferences: []metav1.OwnerReference{
+//						{
+//							Kind:       "ReplicaSet",
+//							Name:       "my-replicaset",
+//							UID:        "rsuid",
+//							APIVersion: "apps/v1",
+//						},
+//					},
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Name:  "application-name",
+//							Image: "app:latest",
+//							Env: []corev1.EnvVar{
+//								{
+//									Name:  "OTEL_SERVICE_NAME",
+//									Value: "my-deployment",
+//								},
+//								{
+//									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+//									Value: "https://collector:4317",
+//								},
+//								{
+//									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+//									ValueFrom: &corev1.EnvVarSource{
+//										FieldRef: &corev1.ObjectFieldSelector{
+//											FieldPath: "spec.nodeName",
+//										},
+//									},
+//								},
+//								{
+//									Name:  "OTEL_PROPAGATORS",
+//									Value: "b3,jaeger",
+//								},
+//								{
+//									Name:  "OTEL_TRACES_SAMPLER",
+//									Value: "parentbased_traceidratio",
+//								},
+//								{
+//									Name:  "OTEL_TRACES_SAMPLER_ARG",
+//									Value: "0.25",
+//								},
+//								{
+//									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+//									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid,service.instance.id=project1.app.application-name,service.version=latest",
+//								},
+//							},
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name: "SDK env vars defined",
+//			inst: v1alpha1.Instrumentation{
+//				Spec: v1alpha1.InstrumentationSpec{
+//					Exporter: v1alpha1.Exporter{
+//						Endpoint: "https://collector:4317",
+//					},
+//					Resource: v1alpha1.Resource{
+//						Attributes: map[string]string{
+//							"fromcr": "val",
+//						},
+//					},
+//					Propagators: []v1alpha1.Propagator{"jaeger"},
+//					Sampler: v1alpha1.Sampler{
+//						Type:     "parentbased_traceidratio",
+//						Argument: "0.25",
+//					},
+//				},
+//			},
+//			pod: corev1.Pod{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Namespace: "project1",
+//					Name:      "app",
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Image: "app:latest",
+//							Env: []corev1.EnvVar{
+//								{
+//									Name:  "OTEL_SERVICE_NAME",
+//									Value: "explicitly_set",
+//								},
+//								{
+//									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+//									Value: "explicitly_set",
+//								},
+//								{
+//									Name:  "OTEL_PROPAGATORS",
+//									Value: "b3",
+//								},
+//								{
+//									Name:  "OTEL_TRACES_SAMPLER",
+//									Value: "always_on",
+//								},
+//								{
+//									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+//									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,",
+//								},
+//							},
+//						},
+//					},
+//				},
+//			},
+//			expected: corev1.Pod{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Namespace: "project1",
+//					Name:      "app",
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Image: "app:latest",
+//							Env: []corev1.EnvVar{
+//								{
+//									Name:  "OTEL_SERVICE_NAME",
+//									Value: "explicitly_set",
+//								},
+//								{
+//									Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+//									Value: "explicitly_set",
+//								},
+//								{
+//									Name:  "OTEL_PROPAGATORS",
+//									Value: "b3",
+//								},
+//								{
+//									Name:  "OTEL_TRACES_SAMPLER",
+//									Value: "always_on",
+//								},
+//								{
+//									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+//									ValueFrom: &corev1.EnvVarSource{
+//										FieldRef: &corev1.ObjectFieldSelector{
+//											FieldPath: "spec.nodeName",
+//										},
+//									},
+//								},
+//								{
+//									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+//									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
+//								},
+//							},
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name: "Empty instrumentation spec",
+//			inst: v1alpha1.Instrumentation{
+//				Spec: v1alpha1.InstrumentationSpec{},
+//			},
+//			pod: corev1.Pod{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Namespace: "project1",
+//					Name:      "app",
+//					UID:       "pod-uid",
+//					OwnerReferences: []metav1.OwnerReference{
+//						{
+//							Kind:       "ReplicaSet",
+//							Name:       "my-replicaset",
+//							UID:        "rsuid",
+//							APIVersion: "apps/v1",
+//						},
+//					},
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Name:  "application-name",
+//							Image: "app:latest",
+//						},
+//					},
+//				},
+//			},
+//			expected: corev1.Pod{
+//				ObjectMeta: metav1.ObjectMeta{
+//					Namespace: "project1",
+//					Name:      "app",
+//					UID:       "pod-uid",
+//					OwnerReferences: []metav1.OwnerReference{
+//						{
+//							Kind:       "ReplicaSet",
+//							Name:       "my-replicaset",
+//							UID:        "rsuid",
+//							APIVersion: "apps/v1",
+//						},
+//					},
+//				},
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Name:  "application-name",
+//							Image: "app:latest",
+//							Env: []corev1.EnvVar{
+//								{
+//									Name:  "OTEL_SERVICE_NAME",
+//									Value: "my-deployment",
+//								},
+//								{
+//									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+//									ValueFrom: &corev1.EnvVarSource{
+//										FieldRef: &corev1.ObjectFieldSelector{
+//											FieldPath: "spec.nodeName",
+//										},
+//									},
+//								},
+//								{
+//									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+//									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,service.instance.id=project1.app.application-name,service.version=latest",
+//								},
+//							},
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name: "SDK image with port number, no version",
+//			inst: v1alpha1.Instrumentation{},
+//			pod: corev1.Pod{
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Image: "fictional.registry.example:10443/imagename",
+//						},
+//					},
+//				},
+//			},
+//			expected: corev1.Pod{
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Image: "fictional.registry.example:10443/imagename",
+//							Env: []corev1.EnvVar{
+//								{
+//									Name:  "OTEL_SERVICE_NAME",
+//									Value: "",
+//								},
+//								{
+//									Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
+//									ValueFrom: &corev1.EnvVarSource{
+//										FieldRef: &corev1.ObjectFieldSelector{
+//											FieldPath: "metadata.name",
+//										},
+//									},
+//								},
+//								{
+//									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+//									ValueFrom: &corev1.EnvVarSource{
+//										FieldRef: &corev1.ObjectFieldSelector{
+//											FieldPath: "spec.nodeName",
+//										},
+//									},
+//								},
+//								{
+//									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+//									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+//								},
+//							},
+//						},
+//					},
+//				},
+//			},
+//		},
+//		{
+//			name: "SDK image with port number, with version",
+//			inst: v1alpha1.Instrumentation{},
+//			pod: corev1.Pod{
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Image: "fictional.registry.example:10443/imagename:latest",
+//						},
+//					},
+//				},
+//			},
+//			expected: corev1.Pod{
+//				Spec: corev1.PodSpec{
+//					Containers: []corev1.Container{
+//						{
+//							Image: "fictional.registry.example:10443/imagename:latest",
+//							Env: []corev1.EnvVar{
+//								{
+//									Name:  "OTEL_SERVICE_NAME",
+//									Value: "",
+//								},
+//								{
+//									Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
+//									ValueFrom: &corev1.EnvVarSource{
+//										FieldRef: &corev1.ObjectFieldSelector{
+//											FieldPath: "metadata.name",
+//										},
+//									},
+//								},
+//								{
+//									Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+//									ValueFrom: &corev1.EnvVarSource{
+//										FieldRef: &corev1.ObjectFieldSelector{
+//											FieldPath: "spec.nodeName",
+//										},
+//									},
+//								},
+//								{
+//									Name:  "OTEL_RESOURCE_ATTRIBUTES",
+//									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+//								},
+//							},
+//						},
+//					},
+//				},
+//			},
+//		},
+//	}
+//
+//	for _, test := range tests {
+//		t.Run(test.name, func(t *testing.T) {
+//			inj := sdkInjector{
+//				client: k8sClient,
+//			}
+//			pod := inj.injectCommonSDKConfig(context.Background(), test.inst, corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: test.pod.Namespace}}, test.pod, 0, 0)
+//			_, err = json.MarshalIndent(pod, "", "  ")
+//			assert.NoError(t, err)
+//			assert.Equal(t, test.expected, pod)
+//		})
+//	}
+//}
 
 func TestInjectJava(t *testing.T) {
 	inst := v1alpha1.Instrumentation{
@@ -529,6 +526,18 @@ func TestInjectJava(t *testing.T) {
 						MountPath: javaInstrMountPath,
 					}},
 					Resources: testResourceRequirements,
+				},
+				{
+					Name:  initCertContainerName,
+					Image: shellContainerName,
+					Command: []string{"/bin/sh", "-c",
+						"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      javaVolumeName,
+						MountPath: javaInstrMountPath,
+					}},
+					WorkingDir: javaInstrMountPath,
+					Resources:  testResourceRequirements,
 				},
 			},
 			Containers: []corev1.Container{
@@ -634,6 +643,18 @@ func TestInjectNodeJS(t *testing.T) {
 					}},
 					Resources: testResourceRequirements,
 				},
+				{
+					Name:  initCertContainerName,
+					Image: shellContainerName,
+					Command: []string{"/bin/sh", "-c",
+						"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      "opentelemetry-auto-instrumentation-nodejs",
+						MountPath: "/otel-auto-instrumentation-nodejs",
+					}},
+					WorkingDir: nodejsInstrMountPath,
+					Resources:  testResourceRequirements,
+				},
 			},
 			Containers: []corev1.Container{
 				{
@@ -736,6 +757,17 @@ func TestInjectPython(t *testing.T) {
 						Name:      pythonVolumeName,
 						MountPath: pythonInstrMountPath,
 					}},
+				},
+				{
+					Name:  initCertContainerName,
+					Image: shellContainerName,
+					Command: []string{"/bin/sh", "-c",
+						"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      pythonVolumeName,
+						MountPath: pythonInstrMountPath,
+					}},
+					WorkingDir: pythonInstrMountPath,
 				},
 			},
 			Containers: []corev1.Container{
@@ -854,6 +886,17 @@ func TestInjectDotNet(t *testing.T) {
 						Name:      dotnetVolumeName,
 						MountPath: dotnetInstrMountPath,
 					}},
+				},
+				{
+					Name:  initCertContainerName,
+					Image: shellContainerName,
+					Command: []string{"/bin/sh", "-c",
+						"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      dotnetVolumeName,
+						MountPath: dotnetInstrMountPath,
+					}},
+					WorkingDir: dotnetInstrMountPath,
 				},
 			},
 			Containers: []corev1.Container{
@@ -1097,6 +1140,19 @@ func TestInjectGo(t *testing.T) {
 							},
 						},
 					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      kernelDebugVolumeName,
+								MountPath: kernelDebugVolumePath,
+							}},
+							WorkingDir: kernelDebugVolumePath,
+						},
+					},
 				},
 			},
 		},
@@ -1186,6 +1242,19 @@ func TestInjectGo(t *testing.T) {
 									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 								},
 							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:  initCertContainerName,
+							Image: shellContainerName,
+							Command: []string{"/bin/sh", "-c",
+								"mkdir -p amazon-cloudwatch-agent &&  echo 'open /etc/amazon-cloudwatch-app-signals-cert/tls-ca.crt: no such file or directory'  > ./amazon-cloudwatch-agent/ca.crt"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      kernelDebugVolumeName,
+								MountPath: kernelDebugVolumePath,
+							}},
+							WorkingDir: kernelDebugVolumePath,
 						},
 					},
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
## Background
We want to support TLS connection between Operator and Application Signals, to do that the TLS CA bundle certification must be passed to the customer's namespaces. 
> [!IMPORTANT]
> With kubernaties you cannot share secrets between namespaces natively, you either need use a third-party syncing tool or  copy it over.

*Description of changes:*
In this PR, we are reading the secret generated by helm-charts(see the **warning below**) using volume mount, then injecting that using a init-container. This container save this as a local file to be used in TLS process, creating a secure network layer. 

> [!WARNING] 
> This PR cannot be merged until the helm-chart [PR](https://github.com/aws-observability/helm-charts/pull/33) is merged.
## Testing 
1. Attach a demo application container
![Screenshot 2024-05-17 at 3 41 46 PM](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/f9d4b83a-cfbc-43a7-b584-827136b06b7b)
Here we can see that the init containers are attached properly 
---
2. Look at the container description 
![Screenshot 2024-05-17 at 3 45 19 PM](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/b84cc21c-7ee8-4fb5-a6d4-e2ce5730bc3e)
Here we can see that all volume mounts are correct
---
3. Connect to demo application shell and check the cert with `cat  cert-volume/amazon-cloudwatch-agent/ca.crt`
![Screenshot 2024-05-17 at 3 42 35 PM](https://github.com/aws/amazon-cloudwatch-agent-operator/assets/107267850/019b1c78-9cf1-4520-a928-ff59f5e94aad)
Here we can see that the cert is saved successfully.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
