### PR TITLE
Add status handlers for dcgm and neuron

### DIFF
--- a/controllers/dcgmexporter_controller.go
+++ b/controllers/dcgmexporter_controller.go
@@ -17,12 +17,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/dcgmexporter"
-
 	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests"
-	collectorStatus "github.com/aws/amazon-cloudwatch-agent-operator/internal/status/collector"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/dcgmexporter"
+	dcgmexporterStatus "github.com/aws/amazon-cloudwatch-agent-operator/internal/status/dcgmexporter"
 )
 
 // DcgmExporterReconciler reconciles a DcgmExporter object.
@@ -108,7 +107,7 @@ func (r *DcgmExporterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	err := reconcileDesiredObjects(ctx, r.Client, log, &params.DcgmExp, params.Scheme, desiredObjects...)
-	return collectorStatus.HandleReconcileStatus(ctx, log, params, err)
+	return dcgmexporterStatus.HandleReconcileStatus(ctx, log, params, err)
 }
 
 // BuildDcgmExporter returns the generation and collected errors of all manifests for a given instance.

--- a/controllers/neuronmonitor_controller.go
+++ b/controllers/neuronmonitor_controller.go
@@ -17,12 +17,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/neuronmonitor"
-
 	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests"
-	collectorStatus "github.com/aws/amazon-cloudwatch-agent-operator/internal/status/collector"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/neuronmonitor"
+	neuronmonitorStatus "github.com/aws/amazon-cloudwatch-agent-operator/internal/status/neuronmonitor"
 )
 
 // NeuronMonitorReconciler reconciles a NeuronMonitor object.
@@ -107,7 +106,7 @@ func (r *NeuronMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 	err := reconcileDesiredObjects(ctx, r.Client, log, &params.NeuronExp, params.Scheme, desiredObjects...)
-	return collectorStatus.HandleReconcileStatus(ctx, log, params, err)
+	return neuronmonitorStatus.HandleReconcileStatus(ctx, log, params, err)
 }
 
 // BuildNeuronMonitor returns the generation and collected errors of all manifests for a given instance.

--- a/internal/status/dcgmexporter/dcgmexporter.go
+++ b/internal/status/dcgmexporter/dcgmexporter.go
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dcgmexporter
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/version"
+)
+
+func UpdateDcgmExporterStatus(ctx context.Context, cli client.Client, changed *v1alpha1.DcgmExporter) error {
+	if changed.Status.Version == "" {
+		changed.Status.Version = version.DcgmExporter()
+	}
+
+	return nil
+}

--- a/internal/status/dcgmexporter/handle.go
+++ b/internal/status/dcgmexporter/handle.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dcgmexporter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests"
+)
+
+const (
+	eventTypeNormal  = "Normal"
+	eventTypeWarning = "Warning"
+
+	reasonError         = "Error"
+	reasonStatusFailure = "StatusFailure"
+	reasonInfo          = "Info"
+)
+
+func HandleReconcileStatus(ctx context.Context, log logr.Logger, params manifests.Params, err error) (ctrl.Result, error) {
+	log.V(2).Info("updating dcgmexporter status")
+	if err != nil {
+		params.Recorder.Event(&params.OtelCol, eventTypeWarning, reasonError, err.Error())
+		return ctrl.Result{}, err
+	}
+	changed := params.DcgmExp.DeepCopy()
+	statusErr := UpdateDcgmExporterStatus(ctx, params.Client, changed)
+	if statusErr != nil {
+		params.Recorder.Event(changed, eventTypeWarning, reasonStatusFailure, statusErr.Error())
+		return ctrl.Result{}, statusErr
+	}
+	statusPatch := client.MergeFrom(&params.DcgmExp)
+	if err := params.Client.Status().Patch(ctx, changed, statusPatch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to apply status changes to the DcgmExporter CR: %w", err)
+	}
+	params.Recorder.Event(changed, eventTypeNormal, reasonInfo, "applied status changes")
+	return ctrl.Result{}, nil
+}

--- a/internal/status/neuronmonitor/handle.go
+++ b/internal/status/neuronmonitor/handle.go
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package neuronmonitor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests"
+)
+
+const (
+	eventTypeNormal  = "Normal"
+	eventTypeWarning = "Warning"
+
+	reasonError         = "Error"
+	reasonStatusFailure = "StatusFailure"
+	reasonInfo          = "Info"
+)
+
+func HandleReconcileStatus(ctx context.Context, log logr.Logger, params manifests.Params, err error) (ctrl.Result, error) {
+	log.V(2).Info("updating neuronmonitor status")
+	if err != nil {
+		params.Recorder.Event(&params.NeuronExp, eventTypeWarning, reasonError, err.Error())
+		return ctrl.Result{}, err
+	}
+	changed := params.NeuronExp.DeepCopy()
+	statusErr := UpdateNeuronMonitorStatus(ctx, params.Client, changed)
+	if statusErr != nil {
+		params.Recorder.Event(changed, eventTypeWarning, reasonStatusFailure, statusErr.Error())
+		return ctrl.Result{}, statusErr
+	}
+	statusPatch := client.MergeFrom(&params.NeuronExp)
+	if err := params.Client.Status().Patch(ctx, changed, statusPatch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to apply status changes to the NeuronMonitor CR: %w", err)
+	}
+	params.Recorder.Event(changed, eventTypeNormal, reasonInfo, "applied status changes")
+	return ctrl.Result{}, nil
+}

--- a/internal/status/neuronmonitor/neuronmonitor.go
+++ b/internal/status/neuronmonitor/neuronmonitor.go
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package neuronmonitor
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/version"
+)
+
+func UpdateNeuronMonitorStatus(ctx context.Context, cli client.Client, changed *v1alpha1.NeuronMonitor) error {
+	if changed.Status.Version == "" {
+		changed.Status.Version = version.NeuronMonitor()
+	}
+	return nil
+}


### PR DESCRIPTION
*Description of changes:*
Using the same `collectorStatus` handler is causing excessive error logs due to missing resources at every reconcile loop. Following the [same pattern with the upstream](https://github.com/open-telemetry/opentelemetry-operator/tree/main/internal/status), this PR adds new status handlers for DCGM and Neuron then uses them in its corresponding controllers. There is not much logic in the status handler, but it can be extended as needed. 

Example error log when the same status handlers for all CRs:
```
{"level":"error","ts":"2024-05-07T16:30:04Z","msg":"Reconciler error","control │ler":"dcgmexporter","controllerGroup":"cloudwatch.aws.amazon.com","controllerKind":"DcgmExporter","DcgmExporter":{"name":"dcgm-exporter","namespace":"amazon-cloudwatch"},"namespace":"amazon-cloudwatch","name":"dcgm-exporter","reconcileID":"dda55a99-3e42-4070-9f21-ba48cf4d09b1","error":"failed to apply status changes to the AmazonCloudWatchAgent CR: resource name may not be empty","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227"}
```

Counting errors thrown at each reconcile loop before and after this change:
```
## BEFORE
kubectl logs amazon-cloudwatch-observability-controller-manager-5bb4f55zswj5 -n amazon-cloudwatch | grep -i "Reconciler error" | wc -l
     319

## AFTER
kubectl logs amazon-cloudwatch-observability-controller-manager-844757f6sbnz -n amazon-cloudwatch | grep -i "Reconciler error" | wc -l
       0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
