### PR TITLE
Update release testing v2

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -32,10 +32,10 @@ jobs:
       group: 'e2e-cw-agent-java-operator-test'
       cancel-in-progress: false
     secrets: inherit
-    uses: ./.github/workflows/appsignals-java-e2e-test.yml
+    uses: ./.github/workflows/application-signals-java-e2e-test.yml
     with:
       test-java-cluster-name: ${{ inputs.test-java-cluster-name }}
-      tag: 'staging'
+      tag: ${{ inputs.tag }}
 
   python-e2e-tests:
     # Two E2E tests should not run at the same time in the same EKS cluster
@@ -43,7 +43,7 @@ jobs:
       group: 'e2e-cw-agent-python-operator-test'
       cancel-in-progress: false
     secrets: inherit
-    uses: ./.github/workflows/appsignals-python-e2e-test.yml
+    uses: ./.github/workflows/application-signals-python-e2e-test.yml
     with:
       test-python-cluster-name: ${{ inputs.test-python-cluster-name }}
-      tag: 'staging'
+      tag: ${{ inputs.tag }}

--- a/.github/workflows/application-signals-java-e2e-test.yml
+++ b/.github/workflows/application-signals-java-e2e-test.yml
@@ -30,12 +30,14 @@ env:
   SAMPLE_APP_NAMESPACE: sample-app-namespace
   SAMPLE_APP_FRONTEND_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_SAMPLE_APP_FRONTEND_SVC_IMG }}
   SAMPLE_APP_REMOTE_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_SAMPLE_APP_REMOTE_SVC_IMG }}
-  METRIC_NAMESPACE: AppSignals
-  LOG_GROUP: /aws/appsignals/eks
+  METRIC_NAMESPACE: ApplicationSignals
+  LOG_GROUP: /aws/application-signals/data
   ECR_OPERATOR_STAGING_REPO: ${{ vars.ECR_OPERATOR_STAGING_REPO }}
+  APPLICATION_SIGNALS_ADOT_IMAGE: 611364707713.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-java-operator-staging:1.33.0-SNAPSHOT-91cbba8
+  APPLICATION_SIGNALS_CW_AGENT_IMAGE: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:00ef994d0feaa8ebe03da61cd9fcfcc1f20ca650
 
 jobs:
-  appsignals-e2e-test:
+  appsignals-java-e2e-test:
     runs-on: ubuntu-latest
     steps:
       # This step avoids code duplication for terraform templates and the validator
@@ -44,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aws-observability/aws-application-signals-test-framework
-          ref: main
+          ref: ga-release
 
       - name: Download enablement script
         uses: actions/checkout@v4
@@ -134,6 +136,22 @@ jobs:
         run: |
           kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}"}, {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Always"}]]'
           kubectl delete pods --all -n amazon-cloudwatch
+          sleep 10
+          kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+
+      - name: Patch the CloudWatch Agent image and restart CloudWatch pods
+        run: |
+          kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": "${{ env.APPLICATION_SIGNALS_CW_AGENT_IMAGE }}"}]'
+          kubectl delete pods --all -n amazon-cloudwatch
+          sleep 10
+          kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+
+      - name: Patch the ADOT image and restart CloudWatch pods
+        run: |
+          kubectl patch deploy -namazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+          -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/1", "value": "--auto-instrumentation-java-image=${{ env.APPLICATION_SIGNALS_ADOT_IMAGE }}"}]'
+          kubectl delete pods --all -n amazon-cloudwatch
+          sleep 10
           kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
 
       # Application pods need to be restarted for the
@@ -205,10 +223,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/outgoing-http-call/; echo
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/aws-sdk-call/; echo
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/; echo
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/client-call/; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"
 
       - name: Build Gradle
         run: ./gradlew
@@ -228,7 +246,7 @@ jobs:
           --platform-info ${{ inputs.test-java-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Call endpoints and validate generated metrics
@@ -246,7 +264,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Call endpoints and validate generated traces
@@ -263,7 +281,7 @@ jobs:
           --platform-info ${{ inputs.test-java-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       # Clean up Procedures

--- a/.github/workflows/application-signals-python-e2e-test.yml
+++ b/.github/workflows/application-signals-python-e2e-test.yml
@@ -29,13 +29,14 @@ env:
   SAMPLE_APP_NAMESPACE: python-sample-app-namespace
   APP_SIGNALS_PYTHON_E2E_FE_SA_IMG: appsignals-python-django-main-service
   APP_SIGNALS_PYTHON_E2E_RE_SA_IMG: appsignals-python-django-remote-service
-  METRIC_NAMESPACE: AppSignals
-  LOG_GROUP: /aws/appsignals/eks
+  METRIC_NAMESPACE: ApplicationSignals
+  LOG_GROUP: /aws/application-signals/data
   ECR_OPERATOR_STAGING_REPO: ${{ vars.ECR_OPERATOR_STAGING_REPO }}
-
+  APPLICATION_SIGNALS_ADOT_IMAGE: 637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-python-staging:0.2.0-408d938
+  APPLICATION_SIGNALS_CW_AGENT_IMAGE: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:00ef994d0feaa8ebe03da61cd9fcfcc1f20ca650
 
 jobs:
-  appsignals-e2e-test:
+  appsignals-python-e2e-test:
     runs-on: ubuntu-latest
     steps:
       - name: Download enablement script
@@ -99,7 +100,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: aws-observability/aws-application-signals-test-framework
-          ref: main
+          ref: ga-python
           path: aws-application-signals-test-framework
 
       - name: Set up terraform
@@ -141,6 +142,22 @@ jobs:
         run: |
           kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}"}, {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Always"}]]'
           kubectl delete pods --all -n amazon-cloudwatch
+          sleep 10
+          kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+
+      - name: Patch the CloudWatch Agent image and restart CloudWatch pods
+        run: |
+          kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": "${{ env.APPLICATION_SIGNALS_CW_AGENT_IMAGE }}"}]'
+          kubectl delete pods --all -n amazon-cloudwatch
+          sleep 10
+          kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+
+      - name: Patch the ADOT image and restart CloudWatch pods
+        run: |
+          kubectl patch deploy -namazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+          -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/2", "value": "--auto-instrumentation-python-image=${{ env.APPLICATION_SIGNALS_ADOT_IMAGE }}"}]'
+          kubectl delete pods --all -n amazon-cloudwatch
+          sleep 10
           kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
 
       # Application pods need to be restarted for the
@@ -211,10 +228,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/outgoing-http-call
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/aws-sdk-call
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/client-call
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"; echo
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/client-call"; echo
 
       # Validation for app signals telemetry data
       - name: Call endpoint and validate generated EMF logs
@@ -232,7 +249,7 @@ jobs:
           --platform-info ${{ inputs.test-python-cluster-name }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Call endpoints and validate generated metrics
@@ -249,9 +266,9 @@ jobs:
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --platform-info ${{ inputs.test-python-cluster-name }}
           --service-name python-application-${{ env.TESTING_ID }}
-          --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
+          --remote-service-name python-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Call endpoints and validate generated traces
@@ -263,13 +280,12 @@ jobs:
           --endpoint http://${{ env.APP_ENDPOINT }}
           --region ${{ env.AWS_DEFAULT_REGION }}
           --account-id ${{ env.TEST_ACCOUNT }}
-          --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --platform-info ${{ inputs.test-python-cluster-name }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       # Clean up Procedures

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -83,7 +83,7 @@ jobs:
 
   e2e-test:
     needs: MakeBinary
-    uses: ./.github/workflows/appsignals-e2e-test.yml
+    uses: ./.github/workflows/application-signals-e2e-test.yml
     secrets: inherit
     with:
       test-java-cluster-name: 'e2e-cw-agent-operator-test'


### PR DESCRIPTION
*Issue #, if available:*
We need to update the release testing to point to branches containing the latest validator changes (ga-release, ga-python)

*Description of changes*
- Pointed E2E testing to retrieve validator from respective branch (`ga-release` and `ga-python`)
- Made necessary update on workflow based on this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/68/files):

Adot Artifacts Used:
- Python EKS: [637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-python-staging:0.2.0-408d938](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/9120281390/job/25108995904)
- Java EKS: [611364707713.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-java-operator-staging:1.33.0-SNAPSHOT-91cbba8](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/9119002183/job/25074698471)

CW Agent Used: 
- [ACCOUNTID.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:00ef994d0feaa8ebe03da61cd9fcfcc1f20ca650](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/9132484921)

Test run: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/9133882145

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
