### PR TITLE
Added tolerations support for dcgmexporter and neuronmonitor.

### DIFF
--- a/apis/v1alpha1/dcgmexpoter_types.go
+++ b/apis/v1alpha1/dcgmexpoter_types.go
@@ -43,7 +43,7 @@ type DcgmExporterSpec struct {
 	// consumed in the config file for the Collector.
 	// +optional
 	Env []v1.EnvVar `json:"env,omitempty"`
-	// Toleration to schedule OpenTelemetry Collector pods.
+	// Toleration to schedule DCGM Exporter pods.
 	// This is only relevant to daemonset, statefulset, and deployment mode
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`

--- a/apis/v1alpha1/dcgmexpoter_types.go
+++ b/apis/v1alpha1/dcgmexpoter_types.go
@@ -43,6 +43,10 @@ type DcgmExporterSpec struct {
 	// consumed in the config file for the Collector.
 	// +optional
 	Env []v1.EnvVar `json:"env,omitempty"`
+	// Toleration to schedule OpenTelemetry Collector pods.
+	// This is only relevant to daemonset, statefulset, and deployment mode
+	// +optional
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Volumes represents which volumes to use in the underlying collector deployment(s).
 	// +optional
 	// +listType=atomic

--- a/apis/v1alpha1/neuronmonitor_types.go
+++ b/apis/v1alpha1/neuronmonitor_types.go
@@ -62,7 +62,7 @@ type NeuronMonitorSpec struct {
 	// consumed in the config file for the Collector.
 	// +optional
 	Env []v1.EnvVar `json:"env,omitempty"`
-	// Toleration to schedule OpenTelemetry Collector pods.
+	// Toleration to schedule Neuron Monitor Exporter pods.
 	// This is only relevant to daemonset, statefulset, and deployment mode
 	// +optional
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`

--- a/apis/v1alpha1/neuronmonitor_types.go
+++ b/apis/v1alpha1/neuronmonitor_types.go
@@ -62,6 +62,10 @@ type NeuronMonitorSpec struct {
 	// consumed in the config file for the Collector.
 	// +optional
 	Env []v1.EnvVar `json:"env,omitempty"`
+	// Toleration to schedule OpenTelemetry Collector pods.
+	// This is only relevant to daemonset, statefulset, and deployment mode
+	// +optional
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 	// Volumes represents which volumes to use in the underlying collector deployment(s).
 	// +optional
 	// +listType=atomic

--- a/internal/manifests/dcgmexporter/daemonset.go
+++ b/internal/manifests/dcgmexporter/daemonset.go
@@ -40,6 +40,7 @@ func DaemonSet(params manifests.Params) *appsv1.DaemonSet {
 					ServiceAccountName: ServiceAccountName(params.DcgmExp),
 					Containers:         []corev1.Container{Container(params.Config, params.Log, params.DcgmExp)},
 					Volumes:            Volumes(params.DcgmExp),
+					Tolerations:        params.DcgmExp.Spec.Tolerations,
 					NodeSelector:       params.DcgmExp.Spec.NodeSelector,
 					Affinity:           params.DcgmExp.Spec.Affinity,
 				},

--- a/internal/manifests/neuronmonitor/daemonset.go
+++ b/internal/manifests/neuronmonitor/daemonset.go
@@ -40,6 +40,7 @@ func DaemonSet(params manifests.Params) *appsv1.DaemonSet {
 					ServiceAccountName: ServiceAccountName(params.NeuronExp),
 					Containers:         []corev1.Container{Container(params.Config, params.Log, params.NeuronExp)},
 					Volumes:            Volumes(params.NeuronExp),
+					Tolerations:        params.NeuronExp.Spec.Tolerations,
 					NodeSelector:       params.NeuronExp.Spec.NodeSelector,
 					Affinity:           params.NeuronExp.Spec.Affinity,
 				},


### PR DESCRIPTION
*Description of changes:*
In order to support tolerations for https://github.com/aws-observability/helm-charts/pull/41, we need to update these files in the operator to add tolerations for dcgmexporter and neuronmonitor.

*How I tested:*
1. I placed these operator changes onto its own ECR repo.
- I already tested both the new ECR repo operator and helm chart changes for the above pull request.
- For this, I tested the both the (1) old CRDs + ECR repo operator changes and (2) new CRDs + old operator.

I observed that for (1), tainted nodes never ran any services as expected, but there were no errors. Before setting up (2), I ran into the following error:
```
W0521 01:12:26.400410    1435 warnings.go:70] unknown field "spec.tolerations"
W0521 01:12:26.444189    1435 warnings.go:70] unknown field "spec.tolerations"
```

However, it was resolved after updating CRDs with `kubectl apply -f helm-charts/charts/amazon-cloudwatch-observability/crds` in the updated `helm-charts` branch, which means there are no issues for both (1) and (2). Also, (2) didn't run changes for the `dcgmexporter`, which was expected since the change this PR intends to make isn't being applied:
```
NAME                                                              READY   STATUS    RESTARTS   AGE   IP               NODE                             NOMINATED NODE   READINESS GATES
amazon-cloudwatch-observability-controller-manager-677b54bszxsf   1/1     Running   0          57s   192.168.53.113   ip-192-168-33-152.ec2.internal   <none>           <none>
cloudwatch-agent-g7h96                                            1/1     Running   0          56s   192.168.54.143   ip-192-168-33-152.ec2.internal   <none>           <none>
fluent-bit-g4znc                                                  1/1     Running   0          57s   192.168.33.152   ip-192-168-33-152.ec2.internal   <none>           <none>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
