### PR TITLE
Update CW Agent image to use updated version

### DIFF
--- a/.github/workflows/application-signals-java-e2e-test.yml
+++ b/.github/workflows/application-signals-java-e2e-test.yml
@@ -34,7 +34,7 @@ env:
   LOG_GROUP: /aws/application-signals/data
   ECR_OPERATOR_STAGING_REPO: ${{ vars.ECR_OPERATOR_STAGING_REPO }}
   APPLICATION_SIGNALS_ADOT_IMAGE: 611364707713.dkr.ecr.us-west-2.amazonaws.com/adot-autoinstrumentation-java-operator-staging:1.33.0-SNAPSHOT-91cbba8
-  APPLICATION_SIGNALS_CW_AGENT_IMAGE: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:00ef994d0feaa8ebe03da61cd9fcfcc1f20ca650
+  APPLICATION_SIGNALS_CW_AGENT_IMAGE: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:eca8174758d95308006632ec4d5533d765db9ca8
 
 jobs:
   appsignals-java-e2e-test:

--- a/.github/workflows/application-signals-python-e2e-test.yml
+++ b/.github/workflows/application-signals-python-e2e-test.yml
@@ -33,7 +33,7 @@ env:
   LOG_GROUP: /aws/application-signals/data
   ECR_OPERATOR_STAGING_REPO: ${{ vars.ECR_OPERATOR_STAGING_REPO }}
   APPLICATION_SIGNALS_ADOT_IMAGE: 637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-python-staging:0.2.0-408d938
-  APPLICATION_SIGNALS_CW_AGENT_IMAGE: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:00ef994d0feaa8ebe03da61cd9fcfcc1f20ca650
+  APPLICATION_SIGNALS_CW_AGENT_IMAGE: 506463145083.dkr.ecr.us-west-2.amazonaws.com/cwagent-integration-test:eca8174758d95308006632ec4d5533d765db9ca8
 
 jobs:
   appsignals-python-e2e-test:


### PR DESCRIPTION
*Issue #, if available:*
The validation template for E2E release testing was updated few days to account for new changes in the cw-agent image. 
The operator release testing is currently using an outdated version which doesn't match the validation template. We need to update it to use the latest one

*Description of changes:*
Updated cw-agent image version to the one created by the latest integration test ([Link](https://github.com/aws/amazon-cloudwatch-agent/actions/runs/9180421980/job/25285871577)). 

Test run: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/9199165314/job/25303406781


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
