### PR TITLE
Use kubernetes version 1.30 for integration tests

### DIFF
--- a/integration-tests/terraform/eks/variables.tf
+++ b/integration-tests/terraform/eks/variables.tf
@@ -8,7 +8,7 @@ variable "region" {
 
 variable "k8s_version" {
   type    = string
-  default = "1.24"
+  default = "1.30"
 }
 
 variable "test_dir" {


### PR DESCRIPTION
*Issue #, if available:*
Will help resolve https://github.com/aws/containers-roadmap/issues/2359

*Description of changes:*
Add 1.30 as default version in the integration tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
