### PR TITLE
Use kubectl wait to make the integration test more reliable

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -57,8 +57,9 @@ jobs:
       - name: Test case for AmazonCloudWatchAgent pod creation
         run: |
           kubectl apply -f integration-tests/manifests/cloudwatch-agent-daemonset.yaml -n amazon-cloudwatch
-          sleep 60
-          kubectl describe pods -n amazon-cloudwatch
+          sleep 5
+          kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+          
           pod_name="$(kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/component=amazon-cloudwatch-agent,app.kubernetes.io/instance=amazon-cloudwatch.cloudwatch-agent -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
           if [ -z "$pod_name" ]; then
             echo "Pod $pod_name is not created. Exiting with ERROR."
@@ -72,18 +73,17 @@ jobs:
         run: |
           kubectl apply -f integration-tests/java/sample-deployment-java.yaml
           sleep 5 
-          kubectl get pods -A 
-          kubectl describe pods -n default
+          kubectl wait --for=condition=Ready pod --all -n default
+          
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/java/default_instrumentation_java_env_variables.json
 
       - name: Test for defined instrumentation resources for Java
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
-          sleep 5
           kubectl rollout restart deployment nginx
           sleep 5
-          kubectl get pods -A
-          kubectl describe pods -n default
+          kubectl wait --for=condition=Ready pod --all -n default
+          
           cd integration-tests/manifests/cmd
           go run validate_instrumentation_vars.go default ns_instrumentation_env_variables.json     
           kubectl delete instrumentation sample-instrumentation
@@ -91,20 +91,19 @@ jobs:
       - name: Test for default instrumentation resources for python
         run: |
           kubectl apply -f integration-tests/python/sample-deployment-python.yaml
-          sleep 5
           kubectl rollout restart deployment nginx
           sleep 5
-          kubectl get pods -A 
-          kubectl describe pods -n default
+          kubectl wait --for=condition=Ready pod --all -n default
+          
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/python/default_instrumentation_python_env_variables.json
 
       - name: Test for defined instrumentation resources for python
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
-          sleep 5
           kubectl rollout restart deployment nginx
           sleep 5
-          kubectl describe pods -n default
+          kubectl wait --for=condition=Ready pod --all -n default
+          
           cd integration-tests/manifests/cmd
           go run validate_instrumentation_vars.go default ns_instrumentation_env_variables.json
           kubectl delete instrumentation sample-instrumentation
@@ -112,22 +111,19 @@ jobs:
       - name: Test for default instrumentation resources for python and java
         run: |
           kubectl apply -f integration-tests/python-java/sample-deployment-python-java.yaml
-          sleep 5
           kubectl rollout restart deployment nginx
           sleep 5
-          kubectl get pods -A 
-          kubectl describe pods -n default
-          kubectl describe pods -n amazon-cloudwatch
+          kubectl wait --for=condition=Ready pod --all -n default
+          
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/python-java/default_instrumentation_python-java_env_variables.json
 
       - name: Test for defined instrumentation resources for python and java
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
-          sleep 5
           kubectl rollout restart deployment nginx
           sleep 5
-          kubectl get pods -A
-          kubectl describe pods -n default
+          kubectl wait --for=condition=Ready pod --all -n default
+          
           cd integration-tests/manifests/cmd
           go run validate_instrumentation_vars.go default ns_instrumentation_env_variables.json
           kubectl delete instrumentation sample-instrumentation
@@ -327,5 +323,3 @@ jobs:
           go test -v -run TestPythonOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
           go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 30m
-
-


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Instead of using sleep, we should use `kubectl wait` for resources to be available before continuing with the test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
