### PR TITLE
Fix command for java auto instrumentation on windows nodes

### DIFF
--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -10,16 +10,17 @@ import (
 )
 
 const (
-	envJavaToolsOptions   = "JAVA_TOOL_OPTIONS"
-	javaJVMArgument       = " -javaagent:/otel-auto-instrumentation-java/javaagent.jar"
-	javaInitContainerName = initContainerName + "-java"
-	javaVolumeName        = volumeName + "-java"
-	javaInstrMountPath    = "/otel-auto-instrumentation-java"
+	envJavaToolsOptions       = "JAVA_TOOL_OPTIONS"
+	javaJVMArgument           = " -javaagent:/otel-auto-instrumentation-java/javaagent.jar"
+	javaInitContainerName     = initContainerName + "-java"
+	javaVolumeName            = volumeName + "-java"
+	javaInstrMountPath        = "/otel-auto-instrumentation-java"
+	javaInstrMountPathWindows = "\\otel-auto-instrumentation-java"
 )
 
 var (
 	commandLinux   = []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"}
-	commandWindows = []string{"CMD", "/c", "copy", "javaagent.jar", javaInstrMountPath}
+	commandWindows = []string{"CMD", "/c", "copy", "javaagent.jar", javaInstrMountPathWindows}
 )
 
 func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.Pod, error) {

--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	commandLinux   = []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"}
-	commandWindows = []string{"copy", "javaagent.jar", javaInstrMountPath}
+	commandWindows = []string{"CMD", "/c", "copy", "javaagent.jar", javaInstrMountPath}
 )
 
 func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.Pod, error) {

--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	commandLinux   = []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"}
-	commandWindows = []string{"copy", "javaagent.jar", "otel-auto-instrumentation-java"}
+	commandWindows = []string{"CMD", "/c", "copy", "javaagent.jar", javaInstrMountPath}
 )
 
 func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.Pod, error) {

--- a/pkg/instrumentation/javaagent.go
+++ b/pkg/instrumentation/javaagent.go
@@ -19,7 +19,7 @@ const (
 
 var (
 	commandLinux   = []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"}
-	commandWindows = []string{"CMD", "/c", "copy", "javaagent.jar", javaInstrMountPath}
+	commandWindows = []string{"copy", "javaagent.jar", "otel-auto-instrumentation-java"}
 )
 
 func injectJavaagent(javaSpec v1alpha1.Java, pod corev1.Pod, index int) (corev1.Pod, error) {

--- a/pkg/instrumentation/javaagent_test.go
+++ b/pkg/instrumentation/javaagent_test.go
@@ -178,3 +178,175 @@ func TestInjectJavaagent(t *testing.T) {
 		})
 	}
 }
+
+func TestInjectJavaagentWindows(t *testing.T) {
+	tests := []struct {
+		name string
+		v1alpha1.Java
+		pod      corev1.Pod
+		expected corev1.Pod
+		err      error
+	}{
+		{
+			name: "JAVA_TOOL_OPTIONS not defined",
+			Java: v1alpha1.Java{Image: "foo/bar:1"},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/os": "windows",
+					},
+					Containers: []corev1.Container{
+						{},
+					},
+				},
+			},
+			expected: corev1.Pod{
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/os": "windows",
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "opentelemetry-auto-instrumentation-java",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:    "opentelemetry-auto-instrumentation-java",
+							Image:   "foo/bar:1",
+							Command: []string{"CMD", "/c", "copy", "javaagent.jar", "\\otel-auto-instrumentation-java"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "opentelemetry-auto-instrumentation-java",
+									MountPath: "/otel-auto-instrumentation-java",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "JAVA_TOOL_OPTIONS",
+									Value: javaJVMArgument,
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "JAVA_TOOL_OPTIONS defined",
+			Java: v1alpha1.Java{Image: "foo/bar:1", Resources: testResourceRequirements},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Env: []corev1.EnvVar{
+								{
+									Name:  "JAVA_TOOL_OPTIONS",
+									Value: "-Dbaz=bar",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{
+						{
+							Name: "opentelemetry-auto-instrumentation-java",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: &defaultVolumeLimitSize,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:    "opentelemetry-auto-instrumentation-java",
+							Image:   "foo/bar:1",
+							Command: []string{"cp", "/javaagent.jar", "/otel-auto-instrumentation-java/javaagent.jar"},
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "opentelemetry-auto-instrumentation-java",
+								MountPath: "/otel-auto-instrumentation-java",
+							}},
+							Resources: testResourceRequirements,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "opentelemetry-auto-instrumentation-java",
+									MountPath: "/otel-auto-instrumentation-java",
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "JAVA_TOOL_OPTIONS",
+									Value: "-Dbaz=bar" + javaJVMArgument,
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "JAVA_TOOL_OPTIONS defined as ValueFrom",
+			Java: v1alpha1.Java{Image: "foo/bar:1"},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Env: []corev1.EnvVar{
+								{
+									Name:      "JAVA_TOOL_OPTIONS",
+									ValueFrom: &corev1.EnvVarSource{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Env: []corev1.EnvVar{
+								{
+									Name:      "JAVA_TOOL_OPTIONS",
+									ValueFrom: &corev1.EnvVarSource{},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: fmt.Errorf("the container defines env var value via ValueFrom, envVar: %s", envJavaToolsOptions),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod, err := injectJavaagent(test.Java, test.pod, 0)
+			assert.Equal(t, test.expected, pod)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Fix command for java auto instrumentation on windows to use cmd.exe
- Modifies the injection logic to use the following command to copy the instrumentation jar:
```
Command:
      CMD
      /c
      copy
      javaagent.jar
      \otel-auto-instrumentation-java
```

The above will be injected for pods with the `kubernetes.io/os: windows` node selector. The EKS [documentation](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html) requires this selector be added to pods.

---
**This will not enable support for windows. The operator still needs a windows build of the auto instrumentation image.**

Tested using a dev build on a windows node and saw java app running:
```
Defaulted container "sample-app" out of: sample-app, opentelemetry-auto-instrumentation-java (init)
Picked up JAVA_TOOL_OPTIONS:  -javaagent:/otel-auto-instrumentation-java/javaagent.jar
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
[otel.javaagent 2024-06-18 15:01:56:503 +0000] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 1.33.0-aws-SNAPSHOT
[otel.javaagent 2024-06-18 15:01:58:070 +0000] [main] INFO software.amazon.opentelemetry.javaagent.providers.AwsApplicationSignalsCustomizerProvider - AWS Application Signals enabled
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
