### PR TITLE
Support configurable resources for NodeJS.

### DIFF
--- a/integration-tests/manifests/annotations/validate_annotations_deployment_test.go
+++ b/integration-tests/manifests/annotations/validate_annotations_deployment_test.go
@@ -95,7 +95,7 @@ func TestJavaOnlyDeployment(t *testing.T) {
 	updateTheOperator(t, clientSet, string(jsonStr))
 
 	if err := checkResourceAnnotations(t, clientSet, "deployment", uniqueNamespace, deploymentName, sampleDeploymentYamlNameRelPath, startTime, []string{injectJavaAnnotation, autoAnnotateJavaAnnotation}, false); err != nil {
-		t.Fatalf("Failed annotation check:  %s", err.Error())
+		t.Fatalf("Failed annotation check: %s", err.Error())
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func main() {
 	pflag.Parse()
 
 	// set instrumentation cpu and memory limits in environment variables to be used for default instrumentation; default values received from https://github.com/open-telemetry/opentelemetry-operator/blob/main/apis/v1alpha1/instrumentation_webhook.go
-	autoInstrumentationConfig := map[string]map[string]map[string]string{"java": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}}, "python": {"limits": {"cpu": "500m", "memory": "32Mi"}, "requests": {"cpu": "50m", "memory": "32Mi"}}, "dotnet": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}}}
+	autoInstrumentationConfig := map[string]map[string]map[string]string{"java": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}}, "python": {"limits": {"cpu": "500m", "memory": "32Mi"}, "requests": {"cpu": "50m", "memory": "32Mi"}}, "dotnet": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}}, "nodejs": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}}}
 	err := json.Unmarshal([]byte(autoInstrumentationConfigStr), &autoInstrumentationConfig)
 	if err != nil {
 		setupLog.Info(fmt.Sprintf("Using default values: %v", autoInstrumentationConfig))
@@ -157,8 +157,8 @@ func main() {
 	if dotNetVar, ok := autoInstrumentationConfig["dotnet"]; ok {
 		setLangEnvVars("DOTNET", dotNetVar)
 	}
-	if dotNetVar, ok := autoInstrumentationConfig["nodejs"]; ok {
-		setLangEnvVars("NODEJS", dotNetVar)
+	if nodeJSVar, ok := autoInstrumentationConfig["nodejs"]; ok {
+		setLangEnvVars("NODEJS", nodeJSVar)
 	}
 
 	// set supported language instrumentation images in environment variable to be used for default instrumentation

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -29,7 +29,7 @@ const (
 	java    = "JAVA"
 	python  = "PYTHON"
 	dotNet  = "DOTNET"
-	nodejs  = "NODEJS"
+	nodeJS  = "NODEJS"
 	limit   = "LIMIT"
 	request = "REQUEST"
 )
@@ -175,8 +175,8 @@ func getDefaultInstrumentation(agentConfig *adapters.CwaConfig, isWindowsPod boo
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 				},
 				Resources: corev1.ResourceRequirements{
-					Limits:   getInstrumentationConfigForResource(nodejs, limit),
-					Requests: getInstrumentationConfigForResource(nodejs, request),
+					Limits:   getInstrumentationConfigForResource(nodeJS, limit),
+					Requests: getInstrumentationConfigForResource(nodeJS, request),
 				},
 			},
 		},

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -29,6 +29,7 @@ const (
 	java    = "JAVA"
 	python  = "PYTHON"
 	dotNet  = "DOTNET"
+	nodejs  = "NODEJS"
 	limit   = "LIMIT"
 	request = "REQUEST"
 )
@@ -172,6 +173,10 @@ func getDefaultInstrumentation(agentConfig *adapters.CwaConfig, isWindowsPod boo
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: fmt.Sprintf("%s://%s:4316/v1/metrics", exporterPrefix, cloudwatchAgentServiceEndpoint)},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits:   getInstrumentationConfigForResource(nodejs, limit),
+					Requests: getInstrumentationConfigForResource(nodejs, request),
 				},
 			},
 		},

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -34,6 +34,10 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_MEM_LIMIT", "128Mi")
 	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_CPU_REQUEST", "50m")
 	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_MEM_REQUEST", "128Mi")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_CPU_LIMIT", "500m")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_MEM_LIMIT", "128Mi")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_CPU_REQUEST", "50m")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_MEM_REQUEST", "128Mi")
 
 	httpInst := &v1alpha1.Instrumentation{
 		Status: v1alpha1.InstrumentationStatus{},
@@ -142,6 +146,16 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
 				},
 			},
 		},
@@ -254,6 +268,16 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
 			},
 		},
 	}
@@ -333,6 +357,10 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_MEM_LIMIT", "128Mi")
 	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_CPU_REQUEST", "50m")
 	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_MEM_REQUEST", "128Mi")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_CPU_LIMIT", "500m")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_MEM_LIMIT", "128Mi")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_CPU_REQUEST", "50m")
+	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_MEM_REQUEST", "128Mi")
 
 	httpInst := &v1alpha1.Instrumentation{
 		Status: v1alpha1.InstrumentationStatus{},
@@ -441,6 +469,16 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
 				},
 			},
 		},
@@ -552,6 +590,16 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+				},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("500m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("50m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
 				},
 			},
 		},


### PR DESCRIPTION
### Description of changes
NodeJS support was recently implemented: https://github.com/aws/amazon-cloudwatch-agent-operator/pull/220 & https://github.com/aws-observability/helm-charts/pull/91. This change allows support for configurable resources for NodeJS init containers likewise to the https://github.com/aws/amazon-cloudwatch-agent-operator/pull/196 changes. 

### Testing
Ran `make test` and all unit tests were passing.

### Manual testing
1. `helm upgrade --install amazon-cloudwatch-observability helm-charts/charts/amazon-cloudwatch-observability --values helm-charts/charts/amazon-cloudwatch-observability/values.yaml --set clusterName=<cluster-name> --set region=<region> --set manager.autoInstrumentationResources.nodejs.limits.cpu=200m --set manager.autoInstrumentationResources.nodejs.limits.memory=512Mi --set manager.autoInstrumentationResources.nodejs.requests.cpu=200m --set manager.autoInstrumentationResources.nodejs.requests.memory=51Mi`
2. `kubectl edit deployment amazon-cloudwatch-observability-controller-manager`

<img width="1133" alt="Screenshot 2024-09-08 at 12 18 21 PM" src="https://github.com/user-attachments/assets/b0ebd60a-fcf5-4b84-8f7d-989e9bb78f9d">

3. `kubectl apply -f amazon-cloudwatch-agent-operator/integration-tests/nodejs/sample-deployment-nodejs.yaml`
4. `kubectl get pods`
5. `kubectl describe pod nginx-XXXXXXXXXX-XXXXX`

<img width="195" alt="Screenshot 2024-09-08 at 12 21 51 PM" src="https://github.com/user-attachments/assets/294eac47-2226-40f7-8689-7f96f425029a">

#### Test case
`helm upgrade --install amazon-cloudwatch-observability helm-charts/charts/amazon-cloudwatch-observability --values helm-charts/charts/amazon-cloudwatch-observability/values.yaml --set clusterName=<cluster-name> --set region=<region> --set manager.autoInstrumentationResources.nodejs.limits.cpu=200m --set manager.autoInstrumentationResources.nodejs.limits.memory="" --set manager.autoInstrumentationResources.nodejs.requests.cpu=200m --set manager.autoInstrumentationResources.nodejs.requests.memory=51Mi`
<img width="1127" alt="Screenshot 2024-09-08 at 12 24 05 PM" src="https://github.com/user-attachments/assets/92e474d2-c5ec-4d0e-9848-096edfd2da9a">
<img width="188" alt="Screenshot 2024-09-08 at 12 26 14 PM" src="https://github.com/user-attachments/assets/fc106342-baa4-472e-bed4-00a0dd8bcdd4">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
