### PR TITLE
Fixing integration tests for EKS add-on with the change to separate Container Insights and AppSignals resources in Windows

### DIFF
--- a/integration-tests/eks/resourceCount_linuxonly_test.go
+++ b/integration-tests/eks/resourceCount_linuxonly_test.go
@@ -9,11 +9,11 @@ package eks_addon
 const (
 	// Services count for CW agent on Linux and Windows
 	serviceCountLinux   = 6
-	serviceCountWindows = 3
+	serviceCountWindows = 6
 
 	// DaemonSet count for CW agent on Linux and Windows
 	daemonsetCountLinux   = 4
-	daemonsetCountWindows = 2
+	daemonsetCountWindows = 3
 
 	// Pods count for CW agent on Linux and Windows
 	podCountLinux   = 3

--- a/integration-tests/eks/resourceCount_windowslinux_test.go
+++ b/integration-tests/eks/resourceCount_windowslinux_test.go
@@ -9,11 +9,11 @@ package eks_addon
 const (
 	// Services count for CW agent on Linux and Windows
 	serviceCountLinux   = 6
-	serviceCountWindows = 3
+	serviceCountWindows = 6
 
 	// DaemonSet count for CW agent on Linux and Windows
 	daemonsetCountLinux   = 4
-	daemonsetCountWindows = 2
+	daemonsetCountWindows = 3
 
 	// Pods count for CW agent on Linux and Windows
 	podCountLinux   = 3

--- a/integration-tests/eks/validateResources_test.go
+++ b/integration-tests/eks/validateResources_test.go
@@ -26,17 +26,18 @@ import (
 )
 
 const (
-	nameSpace            = "amazon-cloudwatch"
-	addOnName            = "amazon-cloudwatch-observability"
-	agentName            = "cloudwatch-agent"
-	agentNameWindows     = "cloudwatch-agent-windows"
-	operatorName         = addOnName + "-controller-manager"
-	fluentBitName        = "fluent-bit"
-	fluentBitNameWindows = "fluent-bit-windows"
-	dcgmExporterName     = "dcgm-exporter"
-	neuronMonitor        = "neuron-monitor"
-	podNameRegex         = "(" + agentName + "|" + agentNameWindows + "|" + operatorName + "|" + fluentBitName + "|" + fluentBitNameWindows + ")-*"
-	serviceNameRegex     = agentName + "(-headless|-monitoring)?|" + agentNameWindows + "(-headless|-monitoring)?|" + addOnName + "-webhook-service|" + dcgmExporterName + "-service|" + neuronMonitor + "-service"
+	nameSpace                         = "amazon-cloudwatch"
+	addOnName                         = "amazon-cloudwatch-observability"
+	agentName                         = "cloudwatch-agent"
+	agentNameWindows                  = "cloudwatch-agent-windows"
+	agentNameWindowsContainerInsights = "cloudwatch-agent-windows-container-insights"
+	operatorName                      = addOnName + "-controller-manager"
+	fluentBitName                     = "fluent-bit"
+	fluentBitNameWindows              = "fluent-bit-windows"
+	dcgmExporterName                  = "dcgm-exporter"
+	neuronMonitor                     = "neuron-monitor"
+	podNameRegex                      = "(" + agentName + "|" + agentNameWindows + "|" + agentNameWindowsContainerInsights + "|" + operatorName + "|" + fluentBitName + "|" + fluentBitNameWindows + ")-*"
+	serviceNameRegex                  = agentName + "(-headless|-monitoring)?|" + agentNameWindows + "(-headless|-monitoring)?|" + agentNameWindowsContainerInsights + "(-headless|-monitoring)?|" + addOnName + "-webhook-service|" + dcgmExporterName + "-service|" + neuronMonitor + "-service"
 )
 
 const (
@@ -102,6 +103,9 @@ func TestOperatorOnEKs(t *testing.T) {
 		// - cloudwatch-agent-windows
 		// - cloudwatch-agent-windows-headless
 		// - cloudwatch-agent-windows-monitoring
+		// - cloudwatch-agent-windows-container-insights
+		// - cloudwatch-agent-windows-container-insights-headless
+		// - cloudwatch-agent-windows-container-insights-monitoring
 		// - dcgm-exporter-service
 		// - neuron-monitor-service
 		if match, _ := regexp.MatchString(serviceNameRegex, service.Name); !match {
@@ -133,6 +137,7 @@ func TestOperatorOnEKs(t *testing.T) {
 		// matches
 		// - cloudwatch-agent
 		// - cloudwatch-agent-windows
+		// - cloudwatch-agent-windows-container-insights
 		// - fluent-bit
 		// - fluent-bit-windows
 		// - dcgm-exporter (this can be removed in the future)


### PR DESCRIPTION

*Description of changes:*
As part of this change - https://github.com/aws-observability/helm-charts/pull/90 separate K8s resources are being created with HostNetwork=true for Container insights and the non hostNetwork being used for other functionalities.

This PR updates the integration tests count post making this change

Run - https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/10775786465

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
