### PR TITLE
Adding target-allocator pod label to service selectors

### DIFF
--- a/internal/manifests/targetallocator/service.go
+++ b/internal/manifests/targetallocator/service.go
@@ -23,7 +23,7 @@ func Service(params manifests.Params) *corev1.Service {
 		labels["app.kubernetes.io/version"] = "latest"
 	}
 
-	selector := Labels(params.OtelCol, naming.TAService())
+	selector := Labels(params.OtelCol, naming.TargetAllocator(params.OtelCol.Name))
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manifests/targetallocator/service_test.go
+++ b/internal/manifests/targetallocator/service_test.go
@@ -26,9 +26,18 @@ func TestServicePorts(t *testing.T) {
 
 	ports := []v1.ServicePort{{Name: "targetallocation", Port: 80, TargetPort: intstr.FromInt32(8080)}}
 
+	expectedLabels := map[string]string{
+		"app.kubernetes.io/managed-by": "amazon-cloudwatch-agent-operator",
+		"app.kubernetes.io/instance":   "default.my-instance",
+		"app.kubernetes.io/part-of":    "amazon-cloudwatch-agent",
+		"app.kubernetes.io/component":  "amazon-cloudwatch-agent-target-allocator",
+		"app.kubernetes.io/name":       "my-instance-target-allocator",
+	}
+
 	s := Service(params)
 
 	assert.Equal(t, ports[0].Name, s.Spec.Ports[0].Name)
 	assert.Equal(t, ports[0].Port, s.Spec.Ports[0].Port)
 	assert.Equal(t, ports[0].TargetPort, s.Spec.Ports[0].TargetPort)
+	assert.Equal(t, expectedLabels, s.Spec.Selector)
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Target Allocator deployment pods are attached the following label  ```app.kubernetes.io/instance=amazon-cloudwatch.prometheus-cloudwatch-agent```, To map these pods with the target allocator service, the selector should be set to the same key-value pair
2. See for reference -  https://github.com/aws/amazon-cloudwatch-agent-operator/blob/target-allocator/internal/manifests/targetallocator/deployment.go#L21

*Testing*:
After deploying changes on cluster, verified the service selector and endpoint
```
dev-dsk-mitsalvi-2b-dd18fa62 % kubectl describe svc target-allocator-service -n amazon-cloudwatch
Name:              target-allocator-service
Namespace:         amazon-cloudwatch
Labels:            app.kubernetes.io/component=amazon-cloudwatch-agent-target-allocator
                   app.kubernetes.io/instance=amazon-cloudwatch.prometheus-cloudwatch-agent
                   app.kubernetes.io/managed-by=amazon-cloudwatch-agent-operator
                   app.kubernetes.io/name=target-allocator-service
                   app.kubernetes.io/part-of=amazon-cloudwatch-agent
                   app.kubernetes.io/version=ta4
Annotations:       <none>
Selector:          app.kubernetes.io/component=amazon-cloudwatch-agent-target-allocator,app.kubernetes.io/instance=amazon-cloudwatch.prometheus-cloudwatch-agent,app.kubernetes.io/managed-by=amazon-cloudwatch-agent-operator,app.kubernetes.io/name=prometheus-cloudwatch-agent-target-allocator,app.kubernetes.io/part-of=amazon-cloudwatch-agent
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                10.100.17.68
IPs:               10.100.17.68
Port:              targetallocation  80/TCP
TargetPort:        8080/TCP
Endpoints:         192.168.80.202:8080
Session Affinity:  None
Events:            <none>
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
