### PR TITLE
[CI/CD] Add Target Allocator(TA) Build to Build and Upload Workflow

### DIFF
--- a/.github/workflows/build-and-upload-integration.yml
+++ b/.github/workflows/build-and-upload-integration.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - target-allocator
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -7,7 +7,8 @@ env:
   AWS_ASSUME_ROLE: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
   ECR_OPERATOR_STAGING_REPO: ${{ vars.ECR_OPERATOR_STAGING_REPO }}
   ECR_TARGET_ALLOCATOR_STAGING_REPO: ${{ vars.ECR_TARGET_ALLOCATOR_STAGING_REPO}}
-  ECR_OPERATOR_RELEASE_IMAGE: ${{ secrets.ECR_OPERATOR_RELEASE_IMAGE }}
+  ECR_OPERATOR_RELEASE_IMAGE: ${{ vars.ECR_TARGET_ALLOCATOR_TEST_OPERATOR_REPO}}
+  ECR_TARGET_ALLOCATOR_RELEASE_REPO: ${{ vars.ECR_TARGET_ALLOCATOR_RELEASE_REPO}}
 
 on:
   workflow_dispatch:
@@ -172,3 +173,9 @@ jobs:
           docker buildx imagetools create \
           -t ${{ env.ECR_OPERATOR_RELEASE_IMAGE }} \
           ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
+
+      - name: Push image to TA release ECR
+        run: |
+          docker buildx imagetools create \
+          -t ${{ env.ECR_TARGET_ALLOCATOR_RELEASE_REPO}} \
+          ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -86,7 +86,7 @@ jobs:
         if: steps.cached_binaries.outputs.cache-hit == false
         with:
           file: ./Dockerfile
-          context: ./amazon-cloudwatch-agent-target-allocator
+          context: ./cmd/amazon-cloudwatch-agent-target-allocator
           push: true
           tags: ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
           platforms: linux/amd64, linux/arm64

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -71,6 +71,15 @@ jobs:
       - name: Set up QEMU
         if: steps.cached_binaries.outputs.cache-hit == false
         uses: docker/setup-qemu-action@v1
+      - name: Build Cloudwatch Agent Target Allocator Image and push to ECR
+        uses: docker/build-push-action@v4
+        if: steps.cached_binaries.outputs.cache-hit == false
+        with:
+          file: ./cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+          context: ./cmd/amazon-cloudwatch-agent-target-allocator
+          push: true
+          tags: ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
+          platforms: linux/amd64, linux/arm64
 
       - name: Build Cloudwatch Agent Operator Image and push to ECR
         uses: docker/build-push-action@v4
@@ -81,15 +90,7 @@ jobs:
           push: true
           tags: ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
           platforms: linux/amd64, linux/arm64
-      - name: Build Cloudwatch Agent Target Allocator Image and push to ECR
-        uses: docker/build-push-action@v4
-        if: steps.cached_binaries.outputs.cache-hit == false
-        with:
-          file: ./Dockerfile
-          context: ./cmd/amazon-cloudwatch-agent-target-allocator
-          push: true
-          tags: ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
-          platforms: linux/amd64, linux/arm64
+
 
   e2e-test:
     name: "Application Signals E2E Test"

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -39,6 +39,7 @@ jobs:
   MakeBinary:
     name: 'MakeContainerImage'
     runs-on: ubuntu-latest
+    needs: MakeTABinary
     permissions:
       id-token: write
       contents: read
@@ -71,6 +72,47 @@ jobs:
       - name: Set up QEMU
         if: steps.cached_binaries.outputs.cache-hit == false
         uses: docker/setup-qemu-action@v1
+  MakeTABinary:
+    name: 'MakeTargetAllocatorImage'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: ~1.20
+          cache: false
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
+          aws-region: us-west-2
+
+      - name: Login to ECR
+        if: steps.cached_binaries.outputs.cache-hit == false
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set up Docker Buildx
+        if: steps.cached_binaries.outputs.cache-hit == false
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set up QEMU
+        if: steps.cached_binaries.outputs.cache-hit == false
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build Binaries
+        run: |
+          go mod download
+          export GOARCH=arm64 && make targetallocator 
+          export GOARCH=amd64 && make targetallocator 
       - name: Build Cloudwatch Agent Target Allocator Image and push to ECR
         uses: docker/build-push-action@v4
         if: steps.cached_binaries.outputs.cache-hit == false
@@ -80,17 +122,6 @@ jobs:
           push: true
           tags: ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
           platforms: linux/amd64, linux/arm64
-
-      - name: Build Cloudwatch Agent Operator Image and push to ECR
-        uses: docker/build-push-action@v4
-        if: steps.cached_binaries.outputs.cache-hit == false
-        with:
-          file: ./Dockerfile
-          context: .
-          push: true
-          tags: ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
-          platforms: linux/amd64, linux/arm64
-
 
   e2e-test:
     name: "Application Signals E2E Test"

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -72,6 +72,17 @@ jobs:
       - name: Set up QEMU
         if: steps.cached_binaries.outputs.cache-hit == false
         uses: docker/setup-qemu-action@v1
+
+      - name: Build Cloudwatch Agent Operator Image and push to ECR
+        uses: docker/build-push-action@v4
+        if: steps.cached_binaries.outputs.cache-hit == false
+        with:
+          file: ./Dockerfile
+          context: .
+          push: true
+          tags: ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
+          platforms: linux/amd64, linux/arm64
+
   MakeTABinary:
     name: 'MakeTargetAllocatorImage'
     runs-on: ubuntu-latest
@@ -86,8 +97,8 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.20
-          cache: false
+          go-version: '>1.22'
+          cache: true
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -6,6 +6,7 @@ env:
   # Use terraform assume role for uploading to ecr
   AWS_ASSUME_ROLE: ${{ secrets.TERRAFORM_AWS_ASSUME_ROLE }}
   ECR_OPERATOR_STAGING_REPO: ${{ vars.ECR_OPERATOR_STAGING_REPO }}
+  ECR_TARGET_ALLOCATOR_STAGING_REPO: ${{ vars.ECR_TARGET_ALLOCATOR_STAGING_REPO}}
   ECR_OPERATOR_RELEASE_IMAGE: ${{ secrets.ECR_OPERATOR_RELEASE_IMAGE }}
 
 on:
@@ -79,6 +80,15 @@ jobs:
           context: .
           push: true
           tags: ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
+          platforms: linux/amd64, linux/arm64
+      - name: Build Cloudwatch Agent Target Allocator Image and push to ECR
+        uses: docker/build-push-action@v4
+        if: steps.cached_binaries.outputs.cache-hit == false
+        with:
+          file: ./Dockerfile
+          context: ./amazon-cloudwatch-agent-target-allocator
+          push: true
+          tags: ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
           platforms: linux/amd64, linux/arm64
 
   e2e-test:

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -39,7 +39,6 @@ jobs:
   MakeBinary:
     name: 'MakeContainerImage'
     runs-on: ubuntu-latest
-    needs: MakeTABinary
     permissions:
       id-token: write
       contents: read
@@ -136,7 +135,7 @@ jobs:
 
   e2e-test:
     name: "Application Signals E2E Test"
-    needs: MakeBinary
+    needs: [MakeBinary,MakeTABinary]
     uses: ./.github/workflows/application-signals-e2e-test.yml
     secrets: inherit
     permissions:

--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 cloudwatch-agent=1.300045.0b810
 
 # Represents the current release of the CloudWatch Agent Operator.
-operator=1.7.0
+operator=pentest
 
 # Represents the current release of ADOT language instrumentation.
 aws-otel-java-instrumentation=v1.32.2
@@ -12,4 +12,4 @@ aws-otel-nodejs-instrumentation=0.52.1
 
 dcgm-exporter=3.3.7-3.5.0-ubuntu22.04
 neuron-monitor=1.0.1
-target-allocator=0.90.0
+target-allocator=pentest

--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 cloudwatch-agent=1.300045.0b810
 
 # Represents the current release of the CloudWatch Agent Operator.
-operator=pentest
+operator=1.7.0
 
 # Represents the current release of ADOT language instrumentation.
 aws-otel-java-instrumentation=v1.32.2
@@ -12,4 +12,4 @@ aws-otel-nodejs-instrumentation=0.52.1
 
 dcgm-exporter=3.3.7-3.5.0-ubuntu22.04
 neuron-monitor=1.0.1
-target-allocator=pentest
+target-allocator=0.90.0


### PR DESCRIPTION
Issue #, if available:
Currently we are not building TA container when we build the operator image. We want to do this to accommodate for release and testing.
Description of changes:
Added target allocator docker build to Build-and-upload-release workflow.
Testing:
Here is a demo run where it is able to create he images:
https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/11297993137
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.