### PR TITLE
Adding support for otlp receivers in agent JSON and set xray receiver to UDP

### DIFF
--- a/internal/manifests/collector/adapters/config_from.go
+++ b/internal/manifests/collector/adapters/config_from.go
@@ -58,6 +58,7 @@ type Traces struct {
 type MetricsCollected struct {
 	StatsD   *statsD   `json:"statsd,omitempty"`
 	CollectD *collectD `json:"collectd,omitempty"`
+	OTLP     *otlp     `json:"otlp,omitempty"`
 }
 
 type LogMetricsCollected struct {
@@ -65,6 +66,7 @@ type LogMetricsCollected struct {
 	ApplicationSignals *AppSignals `json:"application_signals,omitempty"`
 	AppSignals         *AppSignals `json:"app_signals,omitempty"`
 	Kubernetes         *kubernetes `json:"kubernetes,omitempty"`
+	OTLP               *otlp       `json:"otlp,omitempty"`
 }
 
 type TracesCollected struct {

--- a/internal/manifests/collector/parser/receiver/receiver_aws-xray.go
+++ b/internal/manifests/collector/parser/receiver/receiver_aws-xray.go
@@ -5,6 +5,7 @@ package receiver
 
 import (
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/collector/parser"
 )
@@ -14,11 +15,12 @@ const parserNameAWSXRAY = "__awsxray"
 // NewAWSXrayReceiverParser builds a new parser for AWS xray receivers, from the contrib repository.
 func NewAWSXrayReceiverParser(logger logr.Logger, name string, config map[interface{}]interface{}) parser.ComponentPortParser {
 	return &GenericReceiver{
-		logger:      logger,
-		name:        name,
-		config:      config,
-		defaultPort: 2000,
-		parserName:  parserNameAWSXRAY,
+		logger:          logger,
+		name:            name,
+		config:          config,
+		defaultPort:     2000,
+		parserName:      parserNameAWSXRAY,
+		defaultProtocol: corev1.ProtocolUDP,
 	}
 }
 

--- a/internal/manifests/collector/ports.go
+++ b/internal/manifests/collector/ports.go
@@ -162,6 +162,14 @@ func getMetricsReceiversServicePorts(logger logr.Logger, config *adapters.CwaCon
 	if config.Metrics.MetricsCollected.CollectD != nil {
 		getReceiverServicePort(logger, config.Metrics.MetricsCollected.CollectD.ServiceAddress, CollectD, corev1.ProtocolUDP, servicePortsMap)
 	}
+
+	//OTLP
+	if config.Metrics.MetricsCollected.OTLP != nil {
+		//GRPC
+		getReceiverServicePort(logger, config.Metrics.MetricsCollected.OTLP.GRPCEndpoint, OtlpGrpc, corev1.ProtocolTCP, servicePortsMap)
+		//HTTP
+		getReceiverServicePort(logger, config.Metrics.MetricsCollected.OTLP.HTTPEndpoint, OtlpHttp, corev1.ProtocolTCP, servicePortsMap)
+	}
 }
 
 func getReceiverServicePort(logger logr.Logger, serviceAddress string, receiverName string, protocol corev1.Protocol, servicePortsMap map[int32][]corev1.ServicePort) {
@@ -196,8 +204,12 @@ func getReceiverServicePort(logger logr.Logger, serviceAddress string, receiverN
 }
 
 func getLogsReceiversServicePorts(logger logr.Logger, config *adapters.CwaConfig, servicePortsMap map[int32][]corev1.ServicePort) {
+	if config.Logs == nil || config.Logs.LogMetricsCollected == nil {
+		return
+	}
+
 	//EMF - https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_CloudWatch_Agent.html
-	if config.Logs != nil && config.Logs.LogMetricsCollected != nil && config.Logs.LogMetricsCollected.EMF != nil {
+	if config.Logs.LogMetricsCollected.EMF != nil {
 		if _, ok := servicePortsMap[receiverDefaultPortsMap[EMF]]; ok {
 			logger.Info("Duplicate port has been configured in Agent Config for port", zap.Int32("port", receiverDefaultPortsMap[EMF]))
 		} else {
@@ -213,6 +225,14 @@ func getLogsReceiversServicePorts(logger logr.Logger, config *adapters.CwaConfig
 			}
 			servicePortsMap[receiverDefaultPortsMap[EMF]] = []corev1.ServicePort{tcp, udp}
 		}
+	}
+
+	//OTLP
+	if config.Logs.LogMetricsCollected.OTLP != nil {
+		//GRPC
+		getReceiverServicePort(logger, config.Logs.LogMetricsCollected.OTLP.GRPCEndpoint, OtlpGrpc, corev1.ProtocolTCP, servicePortsMap)
+		//HTTP
+		getReceiverServicePort(logger, config.Logs.LogMetricsCollected.OTLP.HTTPEndpoint, OtlpHttp, corev1.ProtocolTCP, servicePortsMap)
 	}
 }
 

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -204,6 +204,37 @@ func TestInvalidConfigGetContainerPorts(t *testing.T) {
 
 }
 
+func TestValidOTLPMetricsPort(t *testing.T) {
+	cfg := getStringFromFile("./test-resources/otlpMetricsAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(1234), containerPorts["cwa-otlp-grpc"].ContainerPort)
+	assert.Equal(t, "cwa-otlp-grpc", containerPorts["cwa-otlp-grpc"].Name)
+	assert.Equal(t, int32(2345), containerPorts["cwa-otlp-http"].ContainerPort)
+	assert.Equal(t, "cwa-otlp-http", containerPorts["cwa-otlp-http"].Name)
+
+}
+
+func TestValidOTLPLogsPort(t *testing.T) {
+	cfg := getStringFromFile("./test-resources/otlpLogsAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(1234), containerPorts["cwa-otlp-grpc"].ContainerPort)
+	assert.Equal(t, "cwa-otlp-grpc", containerPorts["cwa-otlp-grpc"].Name)
+	assert.Equal(t, int32(2345), containerPorts["cwa-otlp-http"].ContainerPort)
+	assert.Equal(t, "cwa-otlp-http", containerPorts["cwa-otlp-http"].Name)
+}
+
+func TestValidOTLPLogsAndMetricsPort(t *testing.T) {
+	cfg := getStringFromFile("./test-resources/otlpMetricsLogsAgentConfig.json")
+	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(1234), containerPorts["cwa-otlp-grpc"].ContainerPort)
+	assert.Equal(t, "cwa-otlp-grpc", containerPorts["cwa-otlp-grpc"].Name)
+	assert.Equal(t, int32(2345), containerPorts["cwa-otlp-http"].ContainerPort)
+	assert.Equal(t, "cwa-otlp-http", containerPorts["cwa-otlp-http"].Name)
+}
+
 func TestValidJSONAndValidOtelConfig(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/application_signals.json")
 	otelCfg := getStringFromFile("./test-resources/otelConfigs/otlpOtelConfig.yaml")
@@ -243,6 +274,25 @@ func TestValidJSONAndConflictingOtelConfig(t *testing.T) {
 	assert.Equal(t, CWA+AppSignalsHttp, containerPorts[CWA+AppSignalsHttp].Name)
 	assert.Equal(t, int32(2000), containerPorts[CWA+AppSignalsProxy].ContainerPort)
 	assert.Equal(t, CWA+AppSignalsProxy, containerPorts[CWA+AppSignalsProxy].Name)
+}
+
+func TestValidJSONAndConflictingOtelConfigForXray(t *testing.T) {
+	cfg := getStringFromFile("./test-resources/application_signals_with_traces.json")
+	otelCfg := getStringFromFile("./test-resources/otelConfigs/xrayOtelConfig.yaml")
+	containerPorts := getContainerPorts(logger, cfg, otelCfg, []corev1.ServicePort{})
+	assert.Equal(t, 6, len(containerPorts))
+	assert.Equal(t, int32(4315), containerPorts[CWA+AppSignalsGrpc].ContainerPort)
+	assert.Equal(t, CWA+AppSignalsGrpc, containerPorts[CWA+AppSignalsGrpc].Name)
+	assert.Equal(t, int32(4316), containerPorts[CWA+AppSignalsHttp].ContainerPort)
+	assert.Equal(t, CWA+AppSignalsHttp, containerPorts[CWA+AppSignalsHttp].Name)
+	assert.Equal(t, int32(2000), containerPorts[CWA+AppSignalsProxy].ContainerPort)
+	assert.Equal(t, CWA+AppSignalsProxy, containerPorts[CWA+AppSignalsProxy].Name)
+	assert.Equal(t, int32(2000), containerPorts["awsxray"].ContainerPort)
+	assert.Equal(t, "awsxray", containerPorts["awsxray"].Name)
+	assert.Equal(t, int32(4317), containerPorts["otlp-grpc"].ContainerPort)
+	assert.Equal(t, "otlp-grpc", containerPorts["otlp-grpc"].Name)
+	assert.Equal(t, int32(4318), containerPorts["otlp-http"].ContainerPort)
+	assert.Equal(t, "otlp-http", containerPorts["otlp-http"].Name)
 }
 
 func TestIsDuplicatePort(t *testing.T) {

--- a/internal/manifests/collector/test-resources/application_signals_with_traces.json
+++ b/internal/manifests/collector/test-resources/application_signals_with_traces.json
@@ -1,0 +1,12 @@
+{
+  "logs": {
+    "metrics_collected": {
+      "application_signals": { }
+    }
+  },
+  "traces": {
+    "traces_collected": {
+      "application_signals": { }
+    }
+  }
+}

--- a/internal/manifests/collector/test-resources/otelConfigs/xrayOtelConfig.yaml
+++ b/internal/manifests/collector/test-resources/otelConfigs/xrayOtelConfig.yaml
@@ -1,0 +1,37 @@
+  extensions:
+    health_check: {}
+
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+    awsxray:
+      endpoint: 0.0.0.0:2000
+      transport: udp
+
+  processors:
+    batch/traces:
+      timeout: 1s
+      send_batch_size: 50
+    batch/metrics:
+      timeout: 60s
+
+  exporters:
+    awsxray: {}
+    awsemf: {}
+
+  service:
+    pipelines:
+      traces:
+        receivers: [ otlp,awsxray ]
+        processors: [ batch/traces ]
+        exporters: [ awsxray ]
+      metrics:
+        receivers: [ otlp ]
+        processors: [ batch/metrics ]
+        exporters: [ awsemf ]
+
+    extensions: [ health_check ]

--- a/internal/manifests/collector/test-resources/otlpLogsAgentConfig.json
+++ b/internal/manifests/collector/test-resources/otlpLogsAgentConfig.json
@@ -1,0 +1,10 @@
+{
+  "logs":{
+    "metrics_collected":{
+      "otlp":{
+        "grpc_endpoint":"0.0.0.0:1234",
+        "http_endpoint":"0.0.0.0:2345"
+      }
+    }
+  }
+}

--- a/internal/manifests/collector/test-resources/otlpMetricsAgentConfig.json
+++ b/internal/manifests/collector/test-resources/otlpMetricsAgentConfig.json
@@ -1,0 +1,10 @@
+{
+  "metrics":{
+    "metrics_collected":{
+      "otlp":{
+        "grpc_endpoint":"0.0.0.0:1234",
+        "http_endpoint":"0.0.0.0:2345"
+      }
+    }
+  }
+}

--- a/internal/manifests/collector/test-resources/otlpMetricsLogsAgentConfig.json
+++ b/internal/manifests/collector/test-resources/otlpMetricsLogsAgentConfig.json
@@ -1,0 +1,18 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "otlp": {
+        "grpc_endpoint": "0.0.0.0:4317",
+        "http_endpoint": "0.0.0.0:4318"
+      }
+    }
+  },
+    "logs": {
+      "metrics_collected": {
+        "otlp": {
+          "grpc_endpoint": "0.0.0.0:1234",
+          "http_endpoint": "0.0.0.0:2345"
+        }
+      }
+    }
+  }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add support for opening up OTLP ports on the agent container and service when the OTLP receivers are enabled as part of the metrics or logs section
2. Set the protocol of the x-ray receiver to UDP according to "Adding support for otlp receivers in agent JSON and set xray receiver to UDP to as to not conflict with the Application Signals traces port


*Testing*
Deploying the following YAML config with the default Application Signals JSON enabled --
```
    receivers:
      otlp:
        protocols:
          grpc:
            endpoint: 0.0.0.0:4317
          http:
            endpoint: 0.0.0.0:4318
      awsxray:
        endpoint: 0.0.0.0:2000
        transport: udp
    processors:
      batch/traces:
        timeout: 1s
        send_batch_size: 50
      batch/metrics:
        timeout: 60s
    exporters:
      awsxray: { }
      awsemf: { }
    service:
      pipelines:
        traces:
          receivers: [ otlp,awsxray ]
          processors: [ batch/traces ]
          exporters: [ awsxray ]
        metrics:
          receivers: [ otlp ]
          processors: [ batch/metrics ]
          exporters: [ awsemf ]
```

```
Port:              cwa-appsig-grpc  4315/TCP
TargetPort:        4315/TCP
Endpoints:         192.168.4.7:4315,192.168.75.27:4315
Port:              cwa-appsig-http  4316/TCP
TargetPort:        4316/TCP
Endpoints:         192.168.4.7:4316,192.168.75.27:4316
Port:              cwa-appsig-xray  2000/TCP
TargetPort:        2000/TCP
Endpoints:         192.168.4.7:2000,192.168.75.27:2000
Port:              awsxray  2000/UDP
TargetPort:        2000/UDP
Endpoints:         192.168.4.7:2000,192.168.75.27:2000
Port:              otlp-grpc  4317/TCP
TargetPort:        4317/TCP
Endpoints:         192.168.4.7:4317,192.168.75.27:4317
Port:              otlp-http  4318/TCP
TargetPort:        4318/TCP
Endpoints:         192.168.4.7:4318,192.168.75.27:4318
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
