### PR TITLE
Use replicaset name as part of service name fallback

### DIFF
--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -367,6 +367,9 @@ func chooseServiceName(pod corev1.Pod, resources map[string]string, index int) s
 	if name := resources[string(semconv.K8SDeploymentNameKey)]; name != "" {
 		return name
 	}
+	if name := resources[string(semconv.K8SReplicaSetNameKey)]; name != "" {
+		return name
+	}
 	if name := resources[string(semconv.K8SStatefulSetNameKey)]; name != "" {
 		return name
 	}


### PR DESCRIPTION
*Description of changes:*
Upstream otel-collector uses replicaset name as service name as part of the service name fallback strategy. Our operator does not do that yet. https://github.com/open-telemetry/opentelemetry-operator/blob/main/pkg/instrumentation/sdk.go#L420

In this PR, we add change to parse replicaset name as service name when available.

### Test
```
Environment:                                                                                                                                                                                                                                                                                                                   │
│       OTEL_AWS_APP_SIGNALS_ENABLED:                    true                                                                                                                                                                                                                                                                        │
│       OTEL_AWS_APPLICATION_SIGNALS_ENABLED:            true                                                                                                                                                                                                                                                                        │
│       OTEL_TRACES_SAMPLER_ARG:                         endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000                                                                                                                                                                                                                     │
│       OTEL_TRACES_SAMPLER:                             xray                                                                                                                                                                                                                                                                        │
│       OTEL_EXPORTER_OTLP_PROTOCOL:                     http/protobuf                                                                                                                                                                                                                                                               │
│       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:              http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces                                                                                                                                                                                                                    │
│       OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT:          http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics                                                                                                                                                                                                                   │
│       OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT:  http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics                                                                                                                                                                                                                   │
│       OTEL_METRICS_EXPORTER:                           none                                                                                                                                                                                                                                                                        │
│       OTEL_LOGS_EXPORTER:                              none                                                                                                                                                                                                                                                                        │
│       JAVA_TOOL_OPTIONS:                                -javaagent:/otel-auto-instrumentation-java/javaagent.jar                                                                                                                                                                                                                   │
│       OTEL_SERVICE_NAME:                               busybox-log-generator                                                                                                                                                                                                                                                       │
│       OTEL_RESOURCE_ATTRIBUTES_POD_NAME:               busybox-log-generator-lshz5 (v1:metadata.name)                                                                                                                                                                                                                              │
│       OTEL_PROPAGATORS:                                tracecontext,baggage,b3,xray                                                                                                                                                                                                                                                │
│       OTEL_RESOURCE_ATTRIBUTES:                        k8s.container.name=busybox,k8s.namespace.name=default,k8s.node.name=ip-192-168-63-18.ec2.internal,k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.replicaset.name=busybox-log-generator,service.version=busybox,com.amazonaws.cloudwatch.entity.internal.service.name │
│ .source=K8sWorkload
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
