### PR TITLE
Changed naming for OTLP container ports from agent JSON

### DIFF
--- a/internal/manifests/collector/ports.go
+++ b/internal/manifests/collector/ports.go
@@ -5,6 +5,7 @@ package collector
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -187,8 +188,12 @@ func getReceiverServicePort(logger logr.Logger, serviceAddress string, receiverN
 			if _, ok := servicePortsMap[port]; ok {
 				logger.Info("Duplicate port has been configured in Agent Config for port", zap.Int32("port", port))
 			} else {
+				name := CWA + receiverName
+				if receiverName == OtlpGrpc || receiverName == OtlpHttp {
+					name = fmt.Sprintf("%s-%d", receiverName, port)
+				}
 				sp := corev1.ServicePort{
-					Name:     CWA + receiverName,
+					Name:     name,
 					Port:     port,
 					Protocol: protocol,
 				}

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -73,16 +73,25 @@ func TestEMFGetContainerPorts(t *testing.T) {
 
 func TestXrayAndOTLPGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAndOTLPAgentConfig.json")
+	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          CWA + XrayTraces,
+			Protocol:      corev1.ProtocolUDP,
+			ContainerPort: int32(2000),
+		},
+		{
+			Name:          OtlpGrpc + "-4327",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4327),
+		},
+		{
+			Name:          OtlpHttp + "-4328",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4328),
+		},
+	}
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
-	assert.Equal(t, int32(2000), containerPorts[CWA+XrayTraces].ContainerPort)
-	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
-	assert.Equal(t, int32(4327), containerPorts[CWA+OtlpGrpc].ContainerPort)
-	assert.Equal(t, CWA+OtlpGrpc, containerPorts[CWA+OtlpGrpc].Name)
-	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+OtlpGrpc].Protocol)
-	assert.Equal(t, int32(4328), containerPorts[CWA+OtlpHttp].ContainerPort)
-	assert.Equal(t, CWA+OtlpHttp, containerPorts[CWA+OtlpHttp].Name)
-	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+OtlpHttp].Protocol)
+	checkPorts(t, wantPorts, containerPorts)
 }
 
 func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
@@ -142,35 +151,65 @@ func TestNilMetricsGetContainerPorts(t *testing.T) {
 func TestMultipleReceiversGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/multipleReceiversAgentConfig.json")
 	strings.Replace(cfg, "2900", "2000", 1)
+	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          CWA + AppSignalsGrpc,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4315),
+		},
+		{
+			Name:          CWA + AppSignalsHttp,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4316),
+		},
+		{
+			Name:          CWA + AppSignalsProxy,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(2000),
+		},
+		{
+			Name:          CWA + StatsD,
+			Protocol:      corev1.ProtocolUDP,
+			ContainerPort: int32(8135),
+		},
+		{
+			Name:          CWA + CollectD,
+			Protocol:      corev1.ProtocolUDP,
+			ContainerPort: int32(25936),
+		},
+		{
+			Name:          EMFTcp,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(25888),
+		},
+		{
+			Name:          EMFUdp,
+			Protocol:      corev1.ProtocolUDP,
+			ContainerPort: int32(25888),
+		},
+		{
+			Name:          CWA + XrayTraces,
+			Protocol:      corev1.ProtocolUDP,
+			ContainerPort: int32(2800),
+		},
+		{
+			Name:          CWA + XrayProxy,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(2900),
+		},
+		{
+			Name:          OtlpGrpc + "-4327",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4327),
+		},
+		{
+			Name:          OtlpHttp + "-4328",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4328),
+		},
+	}
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 11, len(containerPorts))
-	assert.Equal(t, int32(4315), containerPorts[CWA+AppSignalsGrpc].ContainerPort)
-	assert.Equal(t, CWA+AppSignalsGrpc, containerPorts[CWA+AppSignalsGrpc].Name)
-	assert.Equal(t, int32(4316), containerPorts[CWA+AppSignalsHttp].ContainerPort)
-	assert.Equal(t, CWA+AppSignalsHttp, containerPorts[CWA+AppSignalsHttp].Name)
-	assert.Equal(t, int32(2000), containerPorts[CWA+AppSignalsProxy].ContainerPort)
-	assert.Equal(t, CWA+AppSignalsProxy, containerPorts[CWA+AppSignalsProxy].Name)
-	assert.Equal(t, int32(8135), containerPorts[CWA+StatsD].ContainerPort)
-	assert.Equal(t, CWA+StatsD, containerPorts[CWA+StatsD].Name)
-	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+StatsD].Protocol)
-	assert.Equal(t, int32(25936), containerPorts[CWA+CollectD].ContainerPort)
-	assert.Equal(t, CWA+CollectD, containerPorts[CWA+CollectD].Name)
-	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+CollectD].Protocol)
-	assert.Equal(t, int32(25888), containerPorts[EMFTcp].ContainerPort)
-	assert.Equal(t, EMFTcp, containerPorts[EMFTcp].Name)
-	assert.Equal(t, int32(25888), containerPorts[EMFUdp].ContainerPort)
-	assert.Equal(t, EMFUdp, containerPorts[EMFUdp].Name)
-	assert.Equal(t, corev1.ProtocolUDP, containerPorts[EMFUdp].Protocol)
-	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
-	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
-	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
-	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
-	assert.Equal(t, CWA+XrayProxy, containerPorts[CWA+XrayProxy].Name)
-	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+XrayProxy].Protocol)
-	assert.Equal(t, int32(4327), containerPorts[CWA+OtlpGrpc].ContainerPort)
-	assert.Equal(t, CWA+OtlpGrpc, containerPorts[CWA+OtlpGrpc].Name)
-	assert.Equal(t, int32(4328), containerPorts[CWA+OtlpHttp].ContainerPort)
-	assert.Equal(t, CWA+OtlpHttp, containerPorts[CWA+OtlpHttp].Name)
+	checkPorts(t, wantPorts, containerPorts)
 }
 
 func TestSpecPortsOverrideGetContainerPorts(t *testing.T) {
@@ -201,38 +240,70 @@ func TestInvalidConfigGetContainerPorts(t *testing.T) {
 	cfg = cfg + ","
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
 	assert.Equal(t, 0, len(containerPorts))
-
 }
 
 func TestValidOTLPMetricsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpMetricsAgentConfig.json")
+	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          OtlpGrpc + "-1234",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(1234),
+		},
+		{
+			Name:          OtlpHttp + "-2345",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(2345),
+		},
+	}
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(1234), containerPorts["cwa-otlp-grpc"].ContainerPort)
-	assert.Equal(t, "cwa-otlp-grpc", containerPorts["cwa-otlp-grpc"].Name)
-	assert.Equal(t, int32(2345), containerPorts["cwa-otlp-http"].ContainerPort)
-	assert.Equal(t, "cwa-otlp-http", containerPorts["cwa-otlp-http"].Name)
-
+	checkPorts(t, wantPorts, containerPorts)
 }
 
 func TestValidOTLPLogsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpLogsAgentConfig.json")
+	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          OtlpGrpc + "-1234",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(1234),
+		},
+		{
+			Name:          OtlpHttp + "-2345",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(2345),
+		},
+	}
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(1234), containerPorts["cwa-otlp-grpc"].ContainerPort)
-	assert.Equal(t, "cwa-otlp-grpc", containerPorts["cwa-otlp-grpc"].Name)
-	assert.Equal(t, int32(2345), containerPorts["cwa-otlp-http"].ContainerPort)
-	assert.Equal(t, "cwa-otlp-http", containerPorts["cwa-otlp-http"].Name)
+	checkPorts(t, wantPorts, containerPorts)
 }
 
 func TestValidOTLPLogsAndMetricsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpMetricsLogsAgentConfig.json")
+	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          OtlpGrpc + "-1234",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(1234),
+		},
+		{
+			Name:          OtlpHttp + "-2345",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(2345),
+		},
+		{
+			Name:          OtlpGrpc + "-4317",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4317),
+		},
+		{
+			Name:          OtlpHttp + "-4318",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4318),
+		},
+	}
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(1234), containerPorts["cwa-otlp-grpc"].ContainerPort)
-	assert.Equal(t, "cwa-otlp-grpc", containerPorts["cwa-otlp-grpc"].Name)
-	assert.Equal(t, int32(2345), containerPorts["cwa-otlp-http"].ContainerPort)
-	assert.Equal(t, "cwa-otlp-http", containerPorts["cwa-otlp-http"].Name)
+	checkPorts(t, wantPorts, containerPorts)
 }
 
 func TestValidJSONAndValidOtelConfig(t *testing.T) {
@@ -323,6 +394,18 @@ func TestJMXContainerInsightsGetContainerPorts(t *testing.T) {
 	assert.Equal(t, int32(4314), containerPorts[JmxHttp].ContainerPort)
 	assert.Equal(t, JmxHttp, containerPorts[JmxHttp].Name)
 	assert.Equal(t, corev1.ProtocolTCP, containerPorts[JmxHttp].Protocol)
+}
+
+func checkPorts(t *testing.T, want []corev1.ContainerPort, got map[string]corev1.ContainerPort) {
+	t.Helper()
+
+	assert.Equal(t, len(want), len(got))
+	for _, wantPort := range want {
+		gotPort := got[wantPort.Name]
+		assert.Equal(t, wantPort.Name, gotPort.Name)
+		assert.Equal(t, wantPort.Protocol, gotPort.Protocol)
+		assert.Equal(t, wantPort.ContainerPort, gotPort.ContainerPort)
+	}
 }
 
 func getStringFromFile(path string) string {


### PR DESCRIPTION
*Description of changes:*
The agent JSON can have an OTLP configuration in the `metrics/metrics_collected`, `logs/metrics_collected`, and `traces/traces_collected` sections. The port discovery function didn't take into account multiple and would drop one as a duplicate. Updated the function to name these ports `otlp-<protocol>-<port>` (e.g. otlp-http-4317) to prevent naming collisions and ensure that the ports are available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
