### PR TITLE
[Target Allocator] Enable Deployment and Daemonset modes for Agent

### DIFF
--- a/apis/v1alpha1/collector_webhook.go
+++ b/apis/v1alpha1/collector_webhook.go
@@ -171,7 +171,7 @@ func (c CollectorWebhook) validate(r *AmazonCloudWatchAgent) (admission.Warnings
 
 	// validate target allocation
 	if r.Spec.TargetAllocator.Enabled && r.Spec.Mode != ModeStatefulSet {
-		warnings = append(warnings, fmt.Sprintf("The OpenTelemetry Collector mode is set to %s, we do not recommend enabling Target Allocator when not running as a StatefulSet", r.Spec.Mode))
+		warnings = append(warnings, fmt.Sprintf("The Amazon CloudWatch Agent mode is set to %s, we do not recommend enabling Target Allocator when not running as a StatefulSet", r.Spec.Mode))
 	}
 
 	// validate Prometheus config for target allocation

--- a/apis/v1alpha1/collector_webhook.go
+++ b/apis/v1alpha1/collector_webhook.go
@@ -171,7 +171,7 @@ func (c CollectorWebhook) validate(r *AmazonCloudWatchAgent) (admission.Warnings
 
 	// validate target allocation
 	if r.Spec.TargetAllocator.Enabled && r.Spec.Mode != ModeStatefulSet {
-		return warnings, fmt.Errorf("the OpenTelemetry Collector mode is set to %s, which does not support the target allocation deployment", r.Spec.Mode)
+		warnings = append(warnings, fmt.Sprintf("The OpenTelemetry Collector mode is set to %s, we do not recommend enabling Target Allocator when not running as a StatefulSet", r.Spec.Mode))
 	}
 
 	// validate Prometheus config for target allocation


### PR DESCRIPTION
*Issue #, if available:*
We used to block Target Allocator usage with Agent whom have Deployment and Daemonset modes due to issues. However, After confirming that, Agent works with TA in these modes changing the error flag to just a warning, since it is no longer breaking. 

> [!WARNING] 
> Currently Target Allocator is NOT optimised for Daemonset and Deployment modes; thus, we have a warning recommending usage of Stateful Sets. It MUST be noted that this warning does not stop any helm upgrade or deployment, it merely recommends a optimised  solution. 

*Description of changes:*
*Change error text to warning when Agent is not in Stateful Set mode, and TA is enabled.
 
 *Testing* 
 1. I edited my helm chart to make agent a deployment and enabled TA 
 2.  I ran ` helm upgrade --install --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=us-west-2 `
 3. Got the following warning  
 ```
 W1017 15:05:39.137631   38124 warnings.go:70] The OpenTelemetry Collector mode is set to deployment, we do not recommend enabling Target Allocator when not running as a StatefulSet
Release "amazon-cloudwatch-operator" has been upgraded. Happy Helming!
NAME: amazon-cloudwatch-operator
LAST DEPLOYED: Thu Oct 17 15:05:33 2024
NAMESPACE: amazon-cloudwatch
STATUS: deployed
REVISION: 2
TEST SUITE: None
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
