### PR TITLE
Fix service name source being added multiple times for multiple injections

### DIFF
--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -236,7 +236,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=javaagent,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=javaagent,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -424,7 +424,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -499,7 +499,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -762,7 +762,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=nodejs,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=nodejs,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -934,7 +934,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1001,7 +1001,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1273,7 +1273,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=python,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=python,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1461,7 +1461,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1540,7 +1540,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1818,7 +1818,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=dotnet,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=dotnet,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1997,7 +1997,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=dotnet-by-namespace-annotation,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=dotnet-by-namespace-annotation,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -2185,7 +2185,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -2272,7 +2272,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -2512,7 +2512,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=go,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=go,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -2767,7 +2767,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=apache-httpd,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=apache-httpd,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -3008,7 +3008,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nginx,k8s.namespace.name=req-namespace,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd,service.instance.id=req-namespace.my-nginx-6c44bcbdd.nginx,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nginx,k8s.namespace.name=req-namespace,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd,service.instance.id=req-namespace.my-nginx-6c44bcbdd.nginx",
 								},
 							},
 						},
@@ -3445,7 +3445,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3516,7 +3516,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3563,7 +3563,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3610,7 +3610,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3657,7 +3657,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3704,7 +3704,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3767,7 +3767,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3830,7 +3830,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4103,7 +4103,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4174,7 +4174,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4221,7 +4221,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4268,7 +4268,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4315,7 +4315,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4362,7 +4362,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4425,7 +4425,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4488,7 +4488,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4986,7 +4986,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-single-container-no-cont,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-single-container-no-cont,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -160,7 +160,8 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 			index := getContainerIndex(container, pod)
 			// Apache agent is configured via config files rather than env vars.
 			// Therefore, service name, otlp endpoint and other attributes are passed to the agent injection method
-			pod = injectApacheHttpdagent(i.logger, otelinst.Spec.ApacheHttpd, pod, index, otelinst.Spec.Endpoint, i.createResourceMap(ctx, otelinst, ns, pod, index))
+			resMap, _ := i.createResourceMap(ctx, otelinst, ns, pod, index)
+			pod = injectApacheHttpdagent(i.logger, otelinst.Spec.ApacheHttpd, pod, index, otelinst.Spec.Endpoint, resMap)
 			pod = i.injectCommonEnvVar(otelinst, pod, index)
 			pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index, index)
 			pod = i.setInitContainerSecurityContext(pod, pod.Spec.Containers[index].SecurityContext, apacheAgentInitContainerName)
@@ -178,7 +179,8 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 			index := getContainerIndex(container, pod)
 			// Nginx agent is configured via config files rather than env vars.
 			// Therefore, service name, otlp endpoint and other attributes are passed to the agent injection method
-			pod = injectNginxSDK(i.logger, otelinst.Spec.Nginx, pod, index, otelinst.Spec.Endpoint, i.createResourceMap(ctx, otelinst, ns, pod, index))
+			resMap, _ := i.createResourceMap(ctx, otelinst, ns, pod, index)
+			pod = injectNginxSDK(i.logger, otelinst.Spec.Nginx, pod, index, otelinst.Spec.Endpoint, resMap)
 			pod = i.injectCommonEnvVar(otelinst, pod, index)
 			pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index, index)
 		}
@@ -243,7 +245,7 @@ func (i *sdkInjector) injectCommonEnvVar(otelinst v1alpha1.Instrumentation, pod 
 // and appIndex should represent the application being instrumented.
 func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alpha1.Instrumentation, ns corev1.Namespace, pod corev1.Pod, agentIndex int, appIndex int) corev1.Pod {
 	container := &pod.Spec.Containers[agentIndex]
-	resourceMap := i.createResourceMap(ctx, otelinst, ns, pod, appIndex)
+	resourceMap, existingRes := i.createResourceMap(ctx, otelinst, ns, pod, appIndex)
 	idx := getIndexOfEnv(container.Env, constants.EnvOTELServiceName)
 	serviceNameSource := constants.SourceInstrumentation
 	if idx == -1 {
@@ -263,22 +265,8 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 		}
 	}
 
-	// get existing resources env var and parse it into a map
-	existingRes := map[string]string{}
-	existingResourceEnvIdx := getIndexOfEnv(pod.Spec.Containers[appIndex].Env, constants.EnvOTELResourceAttrs)
-	if existingResourceEnvIdx > -1 {
-		existingResArr := strings.Split(pod.Spec.Containers[appIndex].Env[existingResourceEnvIdx].Value, ",")
-		for _, kv := range existingResArr {
-			keyValueArr := strings.Split(strings.TrimSpace(kv), "=")
-			if len(keyValueArr) != 2 {
-				continue
-			}
-			existingRes[keyValueArr[0]] = keyValueArr[1]
-		}
-	}
-
 	// Some attributes might be empty, we should get them via k8s downward API
-	if existingRes[string(semconv.K8SPodNameKey)] == "" && resourceMap[string(semconv.K8SPodNameKey)] == "" {
+	if !existingRes[string(semconv.K8SPodNameKey)] && resourceMap[string(semconv.K8SPodNameKey)] == "" {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name: constants.EnvPodName,
 			ValueFrom: &corev1.EnvVarSource{
@@ -311,7 +299,7 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 		}
 	}
 
-	if existingRes[string(semconv.K8SNodeNameKey)] == "" && resourceMap[string(semconv.K8SNodeNameKey)] == "" {
+	if !existingRes[string(semconv.K8SNodeNameKey)] && resourceMap[string(semconv.K8SNodeNameKey)] == "" {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name: constants.EnvNodeName,
 			ValueFrom: &corev1.EnvVarSource{
@@ -323,7 +311,7 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 		resourceMap[string(semconv.K8SNodeNameKey)] = fmt.Sprintf("$(%s)", constants.EnvNodeName)
 	}
 
-	if existingRes[constants.ServiceNameSource] == "" && resourceMap[constants.ServiceNameSource] == "" {
+	if !existingRes[constants.ServiceNameSource] && resourceMap[constants.ServiceNameSource] == "" {
 		resourceMap[constants.ServiceNameSource] = serviceNameSource
 	}
 
@@ -429,7 +417,7 @@ func createServiceInstanceId(namespaceName, podName, containerName string) strin
 
 // createResourceMap creates resource attribute map.
 // User defined attributes (in explicitly set env var) have higher precedence.
-func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.Instrumentation, ns corev1.Namespace, pod corev1.Pod, index int) map[string]string {
+func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.Instrumentation, ns corev1.Namespace, pod corev1.Pod, index int) (map[string]string, map[string]bool) {
 	// get existing resources env var and parse it into a map
 	existingRes := map[string]bool{}
 	existingResourceEnvIdx := getIndexOfEnv(pod.Spec.Containers[index].Env, constants.EnvOTELResourceAttrs)
@@ -465,7 +453,7 @@ func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.I
 			res[string(k)] = v
 		}
 	}
-	return res
+	return res, existingRes
 }
 
 func (i *sdkInjector) addParentResourceLabels(ctx context.Context, uid bool, ns corev1.Namespace, objectMeta metav1.ObjectMeta, resources map[attribute.Key]string) {

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -242,7 +242,6 @@ func (i *sdkInjector) injectCommonEnvVar(otelinst v1alpha1.Instrumentation, pod 
 // Go requires the agent to be a different container in the pod, so the agentIndex should represent this new sidecar
 // and appIndex should represent the application being instrumented.
 func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alpha1.Instrumentation, ns corev1.Namespace, pod corev1.Pod, agentIndex int, appIndex int) corev1.Pod {
-	i.logger.Info("injectCommonSDKConfig is called for pod", "pod.Name", pod.Name)
 	container := &pod.Spec.Containers[agentIndex]
 	resourceMap := i.createResourceMap(ctx, otelinst, ns, pod, appIndex)
 	idx := getIndexOfEnv(container.Env, constants.EnvOTELServiceName)
@@ -254,7 +253,6 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 		})
 		serviceNameSource = constants.SourceK8sWorkload
 	}
-	i.logger.Info("Setting the service name source", "serviceNameSource", serviceNameSource, "pod.Name", pod.Name)
 	if otelinst.Spec.Exporter.Endpoint != "" {
 		idx = getIndexOfEnv(container.Env, constants.EnvOTELExporterOTLPEndpoint)
 		if idx == -1 {
@@ -332,7 +330,6 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 	idx = getIndexOfEnv(container.Env, constants.EnvOTELResourceAttrs)
 	resStr := resourceMapToStr(resourceMap)
 	if idx == -1 {
-		i.logger.Info("Setting the OTEL resource attributes", "resourceMapString", resStr, "pod.name", pod.Name)
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  constants.EnvOTELResourceAttrs,
 			Value: resStr,
@@ -342,7 +339,6 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 			resStr = "," + resStr
 		}
 		container.Env[idx].Value += resStr
-		i.logger.Info("updating the OTEL resource attributes", "container index value", container.Env[idx].Value, "pod.name", pod.Name, "resourceMapString", resStr)
 	}
 
 	idx = getIndexOfEnv(container.Env, constants.EnvOTELPropagators)

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -191,7 +191,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid,service.instance.id=project1.app.application-name,service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid,service.instance.id=project1.app.application-name,service.version=latest",
 								},
 							},
 						},
@@ -289,7 +289,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,com.amazonaws.cloudwatch.entity.internal.service.name.source=Instrumentation",
+									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,com.amazonaws.cloudwatch.entity.internal.service.name.source=Instrumentation,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
 								},
 							},
 						},
@@ -359,7 +359,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,service.instance.id=project1.app.application-name,service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,service.instance.id=project1.app.application-name,service.version=latest",
 								},
 							},
 						},
@@ -407,7 +407,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -455,7 +455,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 								},
 							},
 						},
@@ -573,7 +573,7 @@ func TestInjectJava(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -677,7 +677,7 @@ func TestInjectNodeJS(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -796,7 +796,164 @@ func TestInjectPython(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+						},
+					},
+				},
+			},
+		},
+	}, pod)
+}
+
+func TestInjectJavaAndPython(t *testing.T) {
+	instJava := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			Java: v1alpha1.Java{
+				Image:     "img:1",
+				Resources: testResourceRequirements,
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4317",
+			},
+		},
+	}
+	instPython := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			Python: v1alpha1.Python{
+				Image: "img:1",
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4318",
+			},
+		},
+	}
+
+	insts := languageInstrumentations{
+		Java:   instrumentationWithContainers{Instrumentation: &instJava, Containers: ""},
+		Python: instrumentationWithContainers{Instrumentation: &instPython, Containers: ""},
+	}
+	inj := sdkInjector{
+		logger: logr.Discard(),
+	}
+	pod := inj.inject(context.Background(), insts,
+		corev1.Namespace{},
+		corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app",
+						Image: "app:latest",
+					},
+				},
+			},
+		})
+	assert.Equal(t, corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: javaVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &defaultVolumeLimitSize,
+						},
+					},
+				},
+				{
+					Name: pythonVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &defaultVolumeLimitSize,
+						},
+					},
+				},
+			},
+			InitContainers: []corev1.Container{
+				{
+					Name:    javaInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      javaVolumeName,
+						MountPath: javaInstrMountPath,
+					}},
+					Resources: testResourceRequirements,
+				},
+				{
+					Name:    pythonInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      pythonVolumeName,
+						MountPath: pythonInstrMountPath,
+					}},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "app:latest",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      javaVolumeName,
+							MountPath: javaInstrMountPath,
+						},
+						{
+							Name:      pythonVolumeName,
+							MountPath: pythonInstrMountPath,
+						},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "JAVA_TOOL_OPTIONS",
+							Value: javaJVMArgument,
+						},
+						{
+							Name:  "OTEL_SERVICE_NAME",
+							Value: "app",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+							Value: "https://collector:4317",
+						},
+						{
+							Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
+						{
+							Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+						{
+							Name:  "PYTHONPATH",
+							Value: fmt.Sprintf("%s:%s", pythonPathPrefix, pythonPathSuffix),
+						},
+						{
+							Name:  "OTEL_TRACES_EXPORTER",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+							Value: "http/protobuf",
+						},
+						{
+							Name:  "OTEL_METRICS_EXPORTER",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+							Value: "http/protobuf",
+						},
+						{
+							Name:  "OTEL_RESOURCE_ATTRIBUTES",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -922,7 +1079,7 @@ func TestInjectDotNet(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -1083,7 +1240,7 @@ func TestInjectGo(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 								},
 							},
 						},
@@ -1184,7 +1341,7 @@ func TestInjectGo(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 								},
 							},
 						},
@@ -1351,7 +1508,7 @@ func TestInjectApacheHttpd(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -1514,7 +1671,7 @@ func TestInjectNginx(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd",
 								},
 							},
 						},
@@ -1594,7 +1751,7 @@ func TestInjectSdkOnly(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},


### PR DESCRIPTION
*Issue #, if available:*
With the current code, if the customer pod has multiple injections , the service name source is being added multiple times and with invalid value from the second injection.
```
OTEL_RESOURCE_ATTRIBUTES: com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=petclinic,k8s.deployment.name=petclinic-1,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.replicaset.name=petclinic-1-6bb849b4d5,service.version=latest,**com.amazonaws.cloudwatch.entity.internal.service.name.source=Instrumentation,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)**
```

*Description of changes:*
added code to check the existing OTEL resource attributes and add the attribute only when the existing value is NULL

Tested using `Unit Tests`

Manual Testing on petclinic pod without custom service name

Before
```
OTEL_RESOURCE_ATTRIBUTES:   k8s.container.name=petclinic-container,k8s.daemonset.name=petclinic-pod,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.vers │
│ ion=latest,com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),com.amazonaws.cloudwatch.entity.internal.service.name.source=Instrumentation

```

After
```
OTEL_RESOURCE_ATTRIBUTES:                        com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=petclinic-container,k8s.daemonset.name=petclinic-pod,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_ │
│ NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest   
```

With Custom service name:

After
```
OTEL_RESOURCE_ATTRIBUTES:                        deployment.environment=compass-env,com.amazonaws.cloudwatch.entity.internal.service.name.source=Instrumentation,k8s.container.name=petclinic-container,k8s.daemonset.name=petclinic-pod,k8s.namespace.name=default,k8 │
│ s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest  
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
