### PR TITLE
Clean up  managed resources when disabled

### DIFF
--- a/controllers/amazoncloudwatchagent_controller.go
+++ b/controllers/amazoncloudwatchagent_controller.go
@@ -6,15 +6,14 @@ package controllers
 
 import (
 	"context"
-	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/manifestutils"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -22,6 +21,7 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests"
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/manifestutils"
 	collectorStatus "github.com/aws/amazon-cloudwatch-agent-operator/internal/status/collector"
 )
 

--- a/controllers/amazoncloudwatchagent_controller.go
+++ b/controllers/amazoncloudwatchagent_controller.go
@@ -46,8 +46,7 @@ type Params struct {
 func (r *AmazonCloudWatchAgentReconciler) findCloudWatchAgentOwnedObjects(ctx context.Context, owner v1alpha1.AmazonCloudWatchAgent) (map[types.UID]client.Object, error) {
 	// Define a map to store the owned objects
 	ownedObjects := make(map[types.UID]client.Object)
-	selector := manifestutils.SelectorLabels(owner.ObjectMeta, "*")
-	delete(selector, "app.kubernetes.io/component") //ignore components
+	selector := manifestutils.SelectorLabelsForAllOperatorManaged(owner.ObjectMeta)
 	listOps := &client.ListOptions{
 		Namespace:     owner.Namespace,
 		LabelSelector: labels.SelectorFromSet(selector),

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -107,7 +107,7 @@ func reconcileDesiredObjectUIDs(ctx context.Context, kubeClient client.Client, l
 		return nil, fmt.Errorf("failed to create objects for %s: %w", owner.GetName(), errors.Join(errs...))
 	}
 	for _, obj := range existingObjectList {
-		existingObjectMap[obj.GetUID()] = obj.DeepCopyObject().(client.Object)
+		existingObjectMap[obj.GetUID()] = obj
 	}
 	return existingObjectMap, nil
 }

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -57,19 +57,11 @@ func BuildCollector(params manifests.Params) ([]client.Object, error) {
 	}
 	return resources, nil
 }
-
-// @TODO: Later merge this in to reconcileDesiredObjects after implementing search functions for DCGM
-func reconcileDesiredObjectsWPrune(ctx context.Context, kubeClient client.Client, logger logr.Logger, owner v1alpha1.AmazonCloudWatchAgent, scheme *runtime.Scheme,
-	desiredObjects []client.Object,
-	searchOwnedObjectsFunc func(ctx context.Context, owner v1alpha1.AmazonCloudWatchAgent) (map[types.UID]client.Object, error),
-) error {
+func reconcileDesiredObjectUIDs(ctx context.Context, kubeClient client.Client, logger logr.Logger,
+	owner metav1.Object, scheme *runtime.Scheme, desiredObjects ...client.Object) (map[types.UID]client.Object, error) {
 	var errs []error
 	existingObjectMap := make(map[types.UID]client.Object)
-	existingObjectList := []client.Object{}
-	previouslyOwnedObjects, err := searchOwnedObjectsFunc(ctx, owner)
-	if err != nil {
-		return err
-	}
+	var existingObjectList []client.Object
 
 	for _, desired := range desiredObjects {
 		l := logger.WithValues(
@@ -77,7 +69,7 @@ func reconcileDesiredObjectsWPrune(ctx context.Context, kubeClient client.Client
 			"object_kind", desired.GetObjectKind(),
 		)
 		if isNamespaceScoped(desired) {
-			if setErr := ctrl.SetControllerReference(&owner, desired, scheme); setErr != nil {
+			if setErr := ctrl.SetControllerReference(owner, desired, scheme); setErr != nil {
 				l.Error(setErr, "failed to set controller owner reference to desired")
 				errs = append(errs, setErr)
 				continue
@@ -100,7 +92,7 @@ func reconcileDesiredObjectsWPrune(ctx context.Context, kubeClient client.Client
 			l.Error(crudErr, "detected immutable field change, trying to delete, new object will be created on next reconcile", "existing", existing.GetName())
 			delErr := kubeClient.Delete(ctx, existing)
 			if delErr != nil {
-				return delErr
+				return nil, delErr
 			}
 			continue
 		} else if crudErr != nil {
@@ -112,14 +104,27 @@ func reconcileDesiredObjectsWPrune(ctx context.Context, kubeClient client.Client
 		l.V(1).Info(fmt.Sprintf("desired has been %s", op))
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("failed to create objects for %s: %w", owner.GetName(), errors.Join(errs...))
+		return nil, fmt.Errorf("failed to create objects for %s: %w", owner.GetName(), errors.Join(errs...))
 	}
-
 	for _, obj := range existingObjectList {
 		existingObjectMap[obj.GetUID()] = obj.DeepCopyObject().(client.Object)
 	}
+	return existingObjectMap, nil
+}
+
+func reconcileDesiredObjectsWPrune(ctx context.Context, kubeClient client.Client, logger logr.Logger, owner v1alpha1.AmazonCloudWatchAgent, scheme *runtime.Scheme,
+	desiredObjects []client.Object,
+	searchOwnedObjectsFunc func(ctx context.Context, owner v1alpha1.AmazonCloudWatchAgent) (map[types.UID]client.Object, error),
+) error {
+	previouslyOwnedObjects, err := searchOwnedObjectsFunc(ctx, owner)
+	if err != nil {
+		return fmt.Errorf("failed to search owned objects: %w", err)
+	}
+
+	desiredObjectMap, err := reconcileDesiredObjectUIDs(ctx, kubeClient, logger, &owner, scheme, desiredObjects...)
+
 	// Pruning owned objects in the cluster which are not should not be present after the reconciliation.
-	err = pruneStaleObjects(ctx, kubeClient, logger, previouslyOwnedObjects, existingObjectMap)
+	err = pruneStaleObjects(ctx, kubeClient, logger, previouslyOwnedObjects, desiredObjectMap)
 	if err != nil {
 		return fmt.Errorf("failed to prune objects for %s: %w", owner.GetName(), err)
 	}
@@ -128,61 +133,19 @@ func reconcileDesiredObjectsWPrune(ctx context.Context, kubeClient client.Client
 
 // reconcileDesiredObjects runs the reconcile process using the mutateFn over the given list of objects.
 func reconcileDesiredObjects(ctx context.Context, kubeClient client.Client, logger logr.Logger, owner metav1.Object, scheme *runtime.Scheme, desiredObjects ...client.Object) error {
-	var errs []error
-	for _, desired := range desiredObjects {
-		l := logger.WithValues(
-			"object_name", desired.GetName(),
-			"object_kind", desired.GetObjectKind(),
-		)
-		if isNamespaceScoped(desired) {
-			if setErr := ctrl.SetControllerReference(owner, desired, scheme); setErr != nil {
-				l.Error(setErr, "failed to set controller owner reference to desired")
-				errs = append(errs, setErr)
-				continue
-			}
-		}
-
-		// existing is an object the controller runtime will hydrate for us
-		// we obtain the existing object by deep copying the desired object because it's the most convenient way
-		existing := desired.DeepCopyObject().(client.Object)
-		mutateFn := manifests.MutateFuncFor(existing, desired)
-		var op controllerutil.OperationResult
-		crudErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			result, createOrUpdateErr := ctrl.CreateOrUpdate(ctx, kubeClient, existing, mutateFn)
-			op = result
-			return createOrUpdateErr
-		})
-		if crudErr != nil && errors.Is(crudErr, manifests.ImmutableChangeErr) {
-			l.Error(crudErr, "detected immutable field change, trying to delete, new object will be created on next reconcile", "existing", existing.GetName())
-			delErr := kubeClient.Delete(ctx, existing)
-			if delErr != nil {
-				return delErr
-			}
-			continue
-		} else if crudErr != nil {
-			l.Error(crudErr, "failed to configure desired")
-			errs = append(errs, crudErr)
-			continue
-		}
-
-		l.V(1).Info(fmt.Sprintf("desired has been %s", op))
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to create objects for %s: %w", owner.GetName(), errors.Join(errs...))
-	}
-	return nil
+	_, err := reconcileDesiredObjectUIDs(ctx, kubeClient, logger, owner, scheme, desiredObjects...)
+	return err
 }
 
 func pruneStaleObjects(ctx context.Context, kubeClient client.Client, logger logr.Logger, previouslyOwnedMap, desiredMap map[types.UID]client.Object) error {
-	// Pruning owned objects in the cluster which are not should not be present after the reconciliation.
-	pruneErrs := []error{}
+	// Pruning owned objects in the cluster which should not be present after the reconciliation.
+	var pruneErrs []error
 	for uid, obj := range previouslyOwnedMap {
 		l := logger.WithValues(
 			"object_name", obj.GetName(),
 			"object_kind", obj.GetObjectKind().GroupVersionKind().Kind,
 		)
 		if _, found := desiredMap[uid]; found {
-			l.Info("uid found skipping")
 			continue
 		}
 

--- a/internal/manifests/manifestutils/labels.go
+++ b/internal/manifests/manifestutils/labels.go
@@ -72,3 +72,11 @@ func SelectorLabels(instance metav1.ObjectMeta, component string) map[string]str
 		"app.kubernetes.io/component":  component,
 	}
 }
+
+func SelectorLabelsForAllOperatorManaged(instance metav1.ObjectMeta) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/managed-by": "amazon-cloudwatch-agent-operator",
+		"app.kubernetes.io/instance":   naming.Truncate("%s.%s", 63, instance.Namespace, instance.Name),
+		"app.kubernetes.io/part-of":    "amazon-cloudwatch-agent",
+	}
+}


### PR DESCRIPTION
## *Issue #, if available:*
Currently when the collector changes modes or target allocator is toggled, the reconciler will create the new resource. However, reconciler will not remove previous resources.  This PR's goal is to let reconciler remove un-used managed resources. 
## *Description of changes:*
* Added a new reconcile function that will delete resources that are not built (required new function to not effect dcgm and other controllers)
* Added a managed resource finder that tracks: 
- ConfigMaps
- DaemonSets
- Deployments
- Services
- ServiceAccounts
- StatefulSets
## Testing 
I first deploy with TA enabled then disable it via helm charts.
### When target allocator is enabled: 
<details>
<summary>Pods</summary>

![Screenshot 2024-10-22 at 11 47 09 AM](https://github.com/user-attachments/assets/ed9454d9-3978-4e1e-8d3f-059427a99322)
</details>
<details>
<summary>Deployments</summary>

![Screenshot 2024-10-22 at 11 47 38 AM](https://github.com/user-attachments/assets/7f4be262-ba5d-4341-b34c-554dfa980498)

</details>
<details>
<summary>ConfigMaps</summary>

![Screenshot 2024-10-22 at 11 47 52 AM](https://github.com/user-attachments/assets/bf904903-3e88-4954-9fda-fac8ea3aee83)

</details>
<details>
<summary>Services</summary>

![Screenshot 2024-10-22 at 11 48 08 AM](https://github.com/user-attachments/assets/b7db6d5c-856e-4d3a-a3c6-653badebba03)

</details>
<details>
<summary>ServiceAccounts</summary>

![Screenshot 2024-10-22 at 11 48 21 AM](https://github.com/user-attachments/assets/ac7745a9-f0b1-4726-b55d-f13063faa7b7)

</details>

### When target allocator is disabled: 
<details>
<summary>Pods</summary>

![Screenshot 2024-10-22 at 11 49 51 AM](https://github.com/user-attachments/assets/bc404c39-00f7-479f-9dd9-dbe06daa765b)

</details>
<details>
<summary>Deployments</summary>

![Screenshot 2024-10-22 at 11 50 00 AM](https://github.com/user-attachments/assets/48a0ab45-75f0-427b-8aa8-9041f342bdd1)

</details>
<details>
<summary>ConfigMaps</summary>

![Screenshot 2024-10-22 at 11 50 09 AM](https://github.com/user-attachments/assets/e222ebd5-0ef9-419e-bf7b-6e7b3558df24)

</details>
<details>
<summary>Services</summary>

![Screenshot 2024-10-22 at 11 50 26 AM](https://github.com/user-attachments/assets/eb6b3180-2960-4cd5-98e4-8cf1e329c61f)

</details>
<details>
<summary>ServiceAccounts</summary>

![Screenshot 2024-10-22 at 11 50 39 AM](https://github.com/user-attachments/assets/3d5e3e4f-1b5c-43bd-bd61-2a3f11dfc3d5)

</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
