### PR TITLE
[TA] One service per Target Allocator 

### DIFF
--- a/internal/manifests/collector/config_replace.go
+++ b/internal/manifests/collector/config_replace.go
@@ -81,7 +81,7 @@ func ReplacePrometheusConfig(instance v1alpha1.AmazonCloudWatchAgent) (string, e
 	}
 
 	if featuregate.EnableTargetAllocatorRewrite.IsEnabled() {
-		updPromCfgMap, getCfgPromErr := ta.AddTAConfigToPromConfig(promCfgMap, naming.TAService())
+		updPromCfgMap, getCfgPromErr := ta.AddTAConfigToPromConfig(promCfgMap, naming.TAService(instance.Name))
 		if getCfgPromErr != nil {
 			return "", getCfgPromErr
 		}
@@ -94,7 +94,7 @@ func ReplacePrometheusConfig(instance v1alpha1.AmazonCloudWatchAgent) (string, e
 		return string(out), nil
 	}
 
-	updPromCfgMap, err := ta.AddHTTPSDConfigToPromConfig(promCfgMap, naming.TAService())
+	updPromCfgMap, err := ta.AddHTTPSDConfigToPromConfig(promCfgMap, naming.TAService(instance.Name))
 	if err != nil {
 		return "", err
 	}

--- a/internal/manifests/collector/config_replace_test.go
+++ b/internal/manifests/collector/config_replace_test.go
@@ -82,7 +82,7 @@ func TestPrometheusParser(t *testing.T) {
 		for _, scrapeConfig := range cfg.PromConfig.ScrapeConfigs {
 			assert.Len(t, scrapeConfig.ServiceDiscoveryConfigs, 1)
 			assert.Equal(t, scrapeConfig.ServiceDiscoveryConfigs[0].Name(), "http")
-			assert.Equal(t, scrapeConfig.ServiceDiscoveryConfigs[0].(*http.SDConfig).URL, "http://target-allocator-service:80/jobs/"+scrapeConfig.JobName+"/targets")
+			assert.Equal(t, scrapeConfig.ServiceDiscoveryConfigs[0].(*http.SDConfig).URL, fmt.Sprintf("https://%s-target-allocator-service:80/jobs/", param.OtelCol.Name)+scrapeConfig.JobName+"/targets")
 			expectedMap[scrapeConfig.JobName] = true
 		}
 		for k := range expectedMap {
@@ -106,7 +106,7 @@ func TestPrometheusParser(t *testing.T) {
 		assert.NotContains(t, prometheusConfig, "scrape_configs")
 
 		expectedTAConfig := map[interface{}]interface{}{
-			"endpoint": "http://target-allocator-service:80",
+			"endpoint": fmt.Sprintf("https://%s-target-allocator-service:80", param.OtelCol.Name),
 			"interval": "30s",
 		}
 		assert.Equal(t, expectedTAConfig, promCfgMap["target_allocator"])
@@ -160,7 +160,7 @@ func TestPrometheusParser(t *testing.T) {
 		assert.NotContains(t, prometheusConfig, "scrape_configs")
 
 		expectedTAConfig := map[interface{}]interface{}{
-			"endpoint": "http://target-allocator-service:80",
+			"endpoint": fmt.Sprintf("https://%s-target-allocator-service:80", param.OtelCol.Name),
 			"interval": "30s",
 		}
 		assert.Equal(t, expectedTAConfig, promCfgMap["target_allocator"])
@@ -305,7 +305,7 @@ func TestReplacePrometheusConfig(t *testing.T) {
   scrape_configs:
   - honor_labels: true
     http_sd_configs:
-    - url: http://target-allocator-service:80/jobs/service-x/targets
+    - url: https://test-target-allocator-service:80/jobs/service-x/targets
     job_name: service-x
     metric_relabel_configs:
     - action: keep
@@ -358,7 +358,7 @@ func TestReplacePrometheusConfig(t *testing.T) {
     scrape_interval: 1m
     scrape_timeout: 10s
 target_allocator:
-  endpoint: http://target-allocator-service:80
+  endpoint: https://test-target-allocator-service:80
   interval: 30s
 `
 

--- a/internal/manifests/collector/configmap_test.go
+++ b/internal/manifests/collector/configmap_test.go
@@ -139,7 +139,7 @@ func TestDesiredPrometheusConfigMap(t *testing.T) {
 			"prometheus.yaml": `config:
   scrape_configs:
   - http_sd_configs:
-    - url: http://target-allocator-service:80/jobs/cloudwatch-agent/targets
+    - url: https://test-target-allocator-service:80/jobs/cloudwatch-agent/targets
     job_name: cloudwatch-agent
     scrape_interval: 10s
 `,
@@ -188,10 +188,10 @@ func TestDesiredPrometheusConfigMap(t *testing.T) {
 			"prometheus.yaml": `config:
   scrape_configs:
   - http_sd_configs:
-    - url: http://target-allocator-service:80/jobs/serviceMonitor%2Ftest%2Ftest%2F0/targets
+    - url: https://test-target-allocator-service:80/jobs/serviceMonitor%2Ftest%2Ftest%2F0/targets
     job_name: serviceMonitor/test/test/0
 target_allocator:
-  endpoint: http://target-allocator-service:80
+  endpoint: https://test-target-allocator-service:80
   http_sd_config:
     refresh_interval: 60s
   interval: 30s
@@ -239,7 +239,7 @@ target_allocator:
 		expectedData := map[string]string{
 			"prometheus.yaml": `config: {}
 target_allocator:
-  endpoint: http://target-allocator-service:80
+  endpoint: https://test-target-allocator-service:80
   interval: 30s
 `,
 		}

--- a/internal/manifests/collector/testdata/config_expected_targetallocator.yaml
+++ b/internal/manifests/collector/testdata/config_expected_targetallocator.yaml
@@ -4,5 +4,5 @@ config:
     scrape_interval: 1m
     scrape_timeout: 10s
 target_allocator:
-  endpoint: http://target-allocator-service:80
+  endpoint: https://test-target-allocator-service:80
   interval: 30s

--- a/internal/manifests/collector/testdata/http_sd_config_servicemonitor_test_ta_set.yaml
+++ b/internal/manifests/collector/testdata/http_sd_config_servicemonitor_test_ta_set.yaml
@@ -11,7 +11,7 @@ config:
     - files:
       - file2.json
 target_allocator:
-  endpoint: http://target-allocator-service:80
+  endpoint: https://test-target-allocator-service:80
   interval: 30s
   http_sd_config:
     refresh_interval: 60s

--- a/internal/manifests/collector/testdata/http_sd_config_ta_test.yaml
+++ b/internal/manifests/collector/testdata/http_sd_config_ta_test.yaml
@@ -7,5 +7,5 @@ config:
       labels:
         my: label
 target_allocator:
-  endpoint: http://test-sd-target-allocator:80
+  endpoint: https://test-sd-target-allocator:80
   interval: 60s

--- a/internal/manifests/collector/testdata/relabel_config_expected_with_sd_config.yaml
+++ b/internal/manifests/collector/testdata/relabel_config_expected_with_sd_config.yaml
@@ -6,7 +6,7 @@ config:
   scrape_configs:
   - honor_labels: true
     http_sd_configs:
-    - url: http://target-allocator-service:80/jobs/service-x/targets
+    - url: https://test-target-allocator-service:80/jobs/service-x/targets
     job_name: service-x
     metric_relabel_configs:
     - action: keep

--- a/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
+++ b/internal/manifests/targetallocator/adapters/config_to_prom_config_test.go
@@ -181,6 +181,7 @@ func TestAddHTTPSDConfigToPromConfig(t *testing.T) {
 }
 
 func TestAddTAConfigToPromConfig(t *testing.T) {
+	collectorName := "test-collector"
 	t.Run("should return expected prom config map with TA config", func(t *testing.T) {
 		cfg := map[interface{}]interface{}{
 			"config": map[interface{}]interface{}{
@@ -202,12 +203,12 @@ func TestAddTAConfigToPromConfig(t *testing.T) {
 		expectedResult := map[interface{}]interface{}{
 			"config": map[interface{}]interface{}{},
 			"target_allocator": map[interface{}]interface{}{
-				"endpoint": "https://target-allocator-service:80",
+				"endpoint": fmt.Sprintf("https://%s-target-allocator-service:80", collectorName),
 				"interval": "30s",
 			},
 		}
 
-		result, err := ta.AddTAConfigToPromConfig(cfg, naming.TAService())
+		result, err := ta.AddTAConfigToPromConfig(cfg, naming.TAService(collectorName))
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedResult, result)
@@ -235,7 +236,7 @@ func TestAddTAConfigToPromConfig(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				_, err := ta.AddTAConfigToPromConfig(tc.cfg, naming.TAService())
+				_, err := ta.AddTAConfigToPromConfig(tc.cfg, naming.TAService(collectorName))
 
 				assert.Error(t, err)
 				assert.EqualError(t, err, tc.errText)

--- a/internal/manifests/targetallocator/container.go
+++ b/internal/manifests/targetallocator/container.go
@@ -11,8 +11,10 @@ import (
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/config"
 	"github.com/aws/amazon-cloudwatch-agent-operator/internal/naming"
 )
+
 // This has to be a constant so that TA container code can access it as well
 const TACertMountPath = "/etc/amazon-cloudwatch-target-allocator-cert"
+
 // Container builds a container for the given TargetAllocator.
 func Container(cfg config.Config, logger logr.Logger, otelcol v1alpha1.AmazonCloudWatchAgent) corev1.Container {
 	image := otelcol.Spec.TargetAllocator.Image

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -176,9 +176,9 @@ func TestContainerHasEnvVars(t *testing.T) {
 				SubPathExpr:      "",
 			},
 			{
-				Name:             "ta-secret",
-				ReadOnly:         true,
-				MountPath:        TACertMountPath,
+				Name:      "ta-secret",
+				ReadOnly:  true,
+				MountPath: TACertMountPath,
 			},
 		},
 		Ports: []corev1.ContainerPort{
@@ -233,9 +233,9 @@ func TestContainerDoesNotOverrideEnvVars(t *testing.T) {
 				SubPathExpr:      "",
 			},
 			{
-				Name:             "ta-secret",
-				ReadOnly:         true,
-				MountPath:        TACertMountPath,
+				Name:      "ta-secret",
+				ReadOnly:  true,
+				MountPath: TACertMountPath,
 			},
 		},
 		Ports: []corev1.ContainerPort{

--- a/internal/manifests/targetallocator/service.go
+++ b/internal/manifests/targetallocator/service.go
@@ -16,7 +16,7 @@ import (
 
 func Service(params manifests.Params) *corev1.Service {
 	version := strings.Split(params.OtelCol.Spec.TargetAllocator.Image, ":")
-	labels := Labels(params.OtelCol, naming.TAService())
+	labels := Labels(params.OtelCol, naming.TAService(params.OtelCol.Name))
 	if len(version) > 1 {
 		labels["app.kubernetes.io/version"] = version[len(version)-1]
 	} else {
@@ -27,7 +27,7 @@ func Service(params manifests.Params) *corev1.Service {
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      naming.TAService(),
+			Name:      naming.TAService(params.OtelCol.Name),
 			Namespace: params.OtelCol.Namespace,
 			Labels:    labels,
 		},

--- a/internal/naming/main.go
+++ b/internal/naming/main.go
@@ -37,8 +37,6 @@ func TASecretVolume() string {
 	return "ta-secret"
 }
 
-
-
 // PrometheusConfigMapVolume returns the name to use for the prometheus config map's volume in the pod.
 func PrometheusConfigMapVolume() string {
 	return "prometheus-config"
@@ -110,8 +108,9 @@ func Route(otelcol string, prefix string) string {
 }
 
 // TAService returns the name to use for the TargetAllocator service.
-func TAService() string {
-	return "target-allocator-service"
+func TAService(otelcol string) string {
+	return DNSName(Truncate("%s-target-allocator-service", 63, otelcol))
+
 }
 func TAPodDestination(otelcol string) string {
 	return DNSName(Truncate("%s-target-allocator", 63, otelcol))


### PR DESCRIPTION
## *Issue #, if available:*
Currently we same service for all Target Allocators which leads to issue when there is more than one, where one server will be ignored/never reached. So now we are creating one service per TA and update that endpoint on each collector configs.
## *Description of changes:*
* Changed service creation for TA 
* Changed naming.TAservice

## Testing
Tested with helm changes can see both services: 
### Pods
![Screenshot 2024-10-24 at 2 27 22 PM](https://github.com/user-attachments/assets/1abb3c38-f7a8-408b-8fc1-ce92e84f0a78)
### Services
![Screenshot 2024-10-24 at 2 27 38 PM](https://github.com/user-attachments/assets/86e63309-ed54-47a8-a367-f58d5a6b7ccc)


Also ran `make test`
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
