### PR TITLE
Add support for sending entity to Fluentbit via cloudwatch agent server

### DIFF
--- a/internal/manifests/collector/ports.go
+++ b/internal/manifests/collector/ports.go
@@ -22,23 +22,25 @@ import (
 )
 
 const (
-	StatsD            = "statsd"
-	CollectD          = "collectd"
-	XrayProxy         = "aws-proxy"
-	XrayTraces        = "aws-traces"
-	OtlpGrpc          = "otlp-grpc"
-	OtlpHttp          = "otlp-http"
-	AppSignalsGrpc    = "appsig-grpc"
-	AppSignalsHttp    = "appsig-http"
-	AppSignalsProxy   = "appsig-xray"
-	AppSignalsGrpcSA  = ":4315"
-	AppSignalsHttpSA  = ":4316"
-	AppSignalsProxySA = ":2000"
-	EMF               = "emf"
-	EMFTcp            = "emf-tcp"
-	EMFUdp            = "emf-udp"
-	CWA               = "cwa-"
-	JmxHttp           = "jmx-http"
+	StatsD             = "statsd"
+	CollectD           = "collectd"
+	XrayProxy          = "aws-proxy"
+	XrayTraces         = "aws-traces"
+	OtlpGrpc           = "otlp-grpc"
+	OtlpHttp           = "otlp-http"
+	AppSignalsGrpc     = "appsig-grpc"
+	AppSignalsHttp     = "appsig-http"
+	AppSignalsProxy    = "appsig-xray"
+	AppSignalsGrpcSA   = ":4315"
+	AppSignalsHttpSA   = ":4316"
+	AppSignalsProxySA  = ":2000"
+	AppSignalsServerSA = ":4311"
+	EMF                = "emf"
+	EMFTcp             = "emf-tcp"
+	EMFUdp             = "emf-udp"
+	CWA                = "cwa-"
+	JmxHttp            = "jmx-http"
+	Server             = "server"
 )
 
 var receiverDefaultPortsMap = map[string]int32{
@@ -286,14 +288,6 @@ func getTracesReceiversServicePorts(logger logr.Logger, config *adapters.CwaConf
 	return tracesPorts
 }
 
-func getAppSignalsServicePortsMap() map[int32][]corev1.ServicePort {
-	servicePortMap := make(map[int32][]corev1.ServicePort)
-	for k, v := range AppSignalsPortToServicePortMap {
-		servicePortMap[k] = v
-	}
-	return servicePortMap
-}
-
 func getApplicationSignalsReceiversServicePorts(logger logr.Logger, config *adapters.CwaConfig, servicePortsMap map[int32][]corev1.ServicePort) {
 	if !isAppSignalEnabled(config) {
 		return
@@ -302,6 +296,7 @@ func getApplicationSignalsReceiversServicePorts(logger logr.Logger, config *adap
 	getReceiverServicePort(logger, AppSignalsGrpcSA, AppSignalsGrpc, corev1.ProtocolTCP, servicePortsMap)
 	getReceiverServicePort(logger, AppSignalsHttpSA, AppSignalsHttp, corev1.ProtocolTCP, servicePortsMap)
 	getReceiverServicePort(logger, AppSignalsProxySA, AppSignalsProxy, corev1.ProtocolTCP, servicePortsMap)
+	getReceiverServicePort(logger, AppSignalsServerSA, Server, corev1.ProtocolTCP, servicePortsMap)
 }
 
 func portFromEndpoint(endpoint string) (int32, error) {

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -51,7 +51,10 @@ func TestDefaultCollectDGetContainerPorts(t *testing.T) {
 func TestApplicationSignals(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/application_signals.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[CWA+Server].ContainerPort)
+	assert.Equal(t, CWA+Server, containerPorts[CWA+Server].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[CWA+Server].Protocol)
 	assert.Equal(t, int32(4315), containerPorts[CWA+AppSignalsGrpc].ContainerPort)
 	assert.Equal(t, CWA+AppSignalsGrpc, containerPorts[CWA+AppSignalsGrpc].Name)
 	assert.Equal(t, int32(4316), containerPorts[CWA+AppSignalsHttp].ContainerPort)
@@ -152,6 +155,11 @@ func TestMultipleReceiversGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/multipleReceiversAgentConfig.json")
 	strings.Replace(cfg, "2900", "2000", 1)
 	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          CWA + Server,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4311),
+		},
 		{
 			Name:          CWA + AppSignalsGrpc,
 			Protocol:      corev1.ProtocolTCP,
@@ -310,7 +318,9 @@ func TestValidJSONAndValidOtelConfig(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/application_signals.json")
 	otelCfg := getStringFromFile("./test-resources/otelConfigs/otlpOtelConfig.yaml")
 	containerPorts := getContainerPorts(logger, cfg, otelCfg, []corev1.ServicePort{})
-	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, 5, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[CWA+Server].ContainerPort)
+	assert.Equal(t, CWA+Server, containerPorts[CWA+Server].Name)
 	assert.Equal(t, int32(4315), containerPorts[CWA+AppSignalsGrpc].ContainerPort)
 	assert.Equal(t, CWA+AppSignalsGrpc, containerPorts[CWA+AppSignalsGrpc].Name)
 	assert.Equal(t, int32(4316), containerPorts[CWA+AppSignalsHttp].ContainerPort)
@@ -325,7 +335,9 @@ func TestValidJSONAndInvalidOtelConfig(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/application_signals.json")
 	otelCfg := getStringFromFile("./test-resources/otelConfigs/invalidOtlpConfig.yaml")
 	containerPorts := getContainerPorts(logger, cfg, otelCfg, []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[CWA+Server].ContainerPort)
+	assert.Equal(t, CWA+Server, containerPorts[CWA+Server].Name)
 	assert.Equal(t, int32(4315), containerPorts[CWA+AppSignalsGrpc].ContainerPort)
 	assert.Equal(t, CWA+AppSignalsGrpc, containerPorts[CWA+AppSignalsGrpc].Name)
 	assert.Equal(t, int32(4316), containerPorts[CWA+AppSignalsHttp].ContainerPort)
@@ -338,7 +350,9 @@ func TestValidJSONAndConflictingOtelConfig(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/application_signals.json")
 	otelCfg := getStringFromFile("./test-resources/otelConfigs/conflictingPortOtlpConfig.yaml")
 	containerPorts := getContainerPorts(logger, cfg, otelCfg, []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[CWA+Server].ContainerPort)
+	assert.Equal(t, CWA+Server, containerPorts[CWA+Server].Name)
 	assert.Equal(t, int32(4315), containerPorts[CWA+AppSignalsGrpc].ContainerPort)
 	assert.Equal(t, CWA+AppSignalsGrpc, containerPorts[CWA+AppSignalsGrpc].Name)
 	assert.Equal(t, int32(4316), containerPorts[CWA+AppSignalsHttp].ContainerPort)
@@ -351,7 +365,9 @@ func TestValidJSONAndConflictingOtelConfigForXray(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/application_signals_with_traces.json")
 	otelCfg := getStringFromFile("./test-resources/otelConfigs/xrayOtelConfig.yaml")
 	containerPorts := getContainerPorts(logger, cfg, otelCfg, []corev1.ServicePort{})
-	assert.Equal(t, 6, len(containerPorts))
+	assert.Equal(t, 7, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[CWA+Server].ContainerPort)
+	assert.Equal(t, CWA+Server, containerPorts[CWA+Server].Name)
 	assert.Equal(t, int32(4315), containerPorts[CWA+AppSignalsGrpc].ContainerPort)
 	assert.Equal(t, CWA+AppSignalsGrpc, containerPorts[CWA+AppSignalsGrpc].Name)
 	assert.Equal(t, int32(4316), containerPorts[CWA+AppSignalsHttp].ContainerPort)

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -23,4 +23,9 @@ const (
 	EnvPodName  = "OTEL_RESOURCE_ATTRIBUTES_POD_NAME"
 	EnvPodUID   = "OTEL_RESOURCE_ATTRIBUTES_POD_UID"
 	EnvNodeName = "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME"
+
+	AWSEntityPrefix       = "com.amazonaws.cloudwatch.entity.internal."
+	ServiceNameSource     = AWSEntityPrefix + "service.name.source"
+	SourceInstrumentation = "Instrumentation"
+	SourceK8sWorkload     = "K8sWorkload"
 )

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -289,7 +289,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=javaagent,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=javaagent,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -477,7 +477,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -552,7 +552,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=javaagent-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -815,7 +815,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=nodejs,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=nodejs,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -987,7 +987,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1054,7 +1054,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=nodejs-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1326,7 +1326,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=python,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=python,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1514,7 +1514,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1593,7 +1593,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=python-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -1871,7 +1871,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=dotnet,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=dotnet,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -2050,7 +2050,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=dotnet-by-namespace-annotation,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=dotnet-by-namespace-annotation,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -2238,7 +2238,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app1,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app1,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -2325,7 +2325,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app2,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app2,k8s.namespace.name=dotnet-multiple-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -2565,7 +2565,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=go,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=go,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -2820,7 +2820,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.namespace.name=apache-httpd,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.namespace.name=apache-httpd,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -3061,7 +3061,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nginx,k8s.namespace.name=req-namespace,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd,service.instance.id=req-namespace.my-nginx-6c44bcbdd.nginx",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nginx,k8s.namespace.name=req-namespace,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd,service.instance.id=req-namespace.my-nginx-6c44bcbdd.nginx",
 								},
 							},
 						},
@@ -3498,7 +3498,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3569,7 +3569,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3616,7 +3616,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3663,7 +3663,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3710,7 +3710,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3757,7 +3757,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3820,7 +3820,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -3883,7 +3883,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4156,7 +4156,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4227,7 +4227,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4274,7 +4274,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4321,7 +4321,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=java2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4368,7 +4368,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4415,7 +4415,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=nodejs2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4478,7 +4478,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python1,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -4541,7 +4541,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=python2,k8s.namespace.name=multi-instrumentation-multi-containers-cn,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -5039,7 +5039,7 @@ func TestMutatePod(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-single-container-no-cont,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=dotnet1,k8s.namespace.name=multi-instrumentation-single-container-no-cont,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -160,7 +160,8 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 			index := getContainerIndex(container, pod)
 			// Apache agent is configured via config files rather than env vars.
 			// Therefore, service name, otlp endpoint and other attributes are passed to the agent injection method
-			pod = injectApacheHttpdagent(i.logger, otelinst.Spec.ApacheHttpd, pod, index, otelinst.Spec.Endpoint, i.createResourceMap(ctx, otelinst, ns, pod, index))
+			resMap, _ := i.createResourceMap(ctx, otelinst, ns, pod, index)
+			pod = injectApacheHttpdagent(i.logger, otelinst.Spec.ApacheHttpd, pod, index, otelinst.Spec.Endpoint, resMap)
 			pod = i.injectCommonEnvVar(otelinst, pod, index)
 			pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index, index)
 			pod = i.setInitContainerSecurityContext(pod, pod.Spec.Containers[index].SecurityContext, apacheAgentInitContainerName)
@@ -178,7 +179,8 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 			index := getContainerIndex(container, pod)
 			// Nginx agent is configured via config files rather than env vars.
 			// Therefore, service name, otlp endpoint and other attributes are passed to the agent injection method
-			pod = injectNginxSDK(i.logger, otelinst.Spec.Nginx, pod, index, otelinst.Spec.Endpoint, i.createResourceMap(ctx, otelinst, ns, pod, index))
+			resMap, _ := i.createResourceMap(ctx, otelinst, ns, pod, index)
+			pod = injectNginxSDK(i.logger, otelinst.Spec.Nginx, pod, index, otelinst.Spec.Endpoint, resMap)
 			pod = i.injectCommonEnvVar(otelinst, pod, index)
 			pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index, index)
 		}
@@ -243,13 +245,15 @@ func (i *sdkInjector) injectCommonEnvVar(otelinst v1alpha1.Instrumentation, pod 
 // and appIndex should represent the application being instrumented.
 func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alpha1.Instrumentation, ns corev1.Namespace, pod corev1.Pod, agentIndex int, appIndex int) corev1.Pod {
 	container := &pod.Spec.Containers[agentIndex]
-	resourceMap := i.createResourceMap(ctx, otelinst, ns, pod, appIndex)
+	resourceMap, existingRes := i.createResourceMap(ctx, otelinst, ns, pod, appIndex)
 	idx := getIndexOfEnv(container.Env, constants.EnvOTELServiceName)
+	serviceNameSource := constants.SourceInstrumentation
 	if idx == -1 {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name:  constants.EnvOTELServiceName,
 			Value: chooseServiceName(pod, resourceMap, appIndex),
 		})
+		serviceNameSource = constants.SourceK8sWorkload
 	}
 	if otelinst.Spec.Exporter.Endpoint != "" {
 		idx = getIndexOfEnv(container.Env, constants.EnvOTELExporterOTLPEndpoint)
@@ -262,7 +266,7 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 	}
 
 	// Some attributes might be empty, we should get them via k8s downward API
-	if resourceMap[string(semconv.K8SPodNameKey)] == "" {
+	if !existingRes[string(semconv.K8SPodNameKey)] && resourceMap[string(semconv.K8SPodNameKey)] == "" {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name: constants.EnvPodName,
 			ValueFrom: &corev1.EnvVarSource{
@@ -295,7 +299,7 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 		}
 	}
 
-	if resourceMap[string(semconv.K8SNodeNameKey)] == "" {
+	if !existingRes[string(semconv.K8SNodeNameKey)] && resourceMap[string(semconv.K8SNodeNameKey)] == "" {
 		container.Env = append(container.Env, corev1.EnvVar{
 			Name: constants.EnvNodeName,
 			ValueFrom: &corev1.EnvVarSource{
@@ -307,6 +311,10 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 		resourceMap[string(semconv.K8SNodeNameKey)] = fmt.Sprintf("$(%s)", constants.EnvNodeName)
 	}
 
+	if !existingRes[constants.ServiceNameSource] && resourceMap[constants.ServiceNameSource] == "" {
+		resourceMap[constants.ServiceNameSource] = serviceNameSource
+	}
+
 	idx = getIndexOfEnv(container.Env, constants.EnvOTELResourceAttrs)
 	resStr := resourceMapToStr(resourceMap)
 	if idx == -1 {
@@ -315,7 +323,7 @@ func (i *sdkInjector) injectCommonSDKConfig(ctx context.Context, otelinst v1alph
 			Value: resStr,
 		})
 	} else {
-		if !strings.HasSuffix(container.Env[idx].Value, ",") {
+		if !strings.HasSuffix(container.Env[idx].Value, ",") && resStr != "" {
 			resStr = "," + resStr
 		}
 		container.Env[idx].Value += resStr
@@ -364,16 +372,19 @@ func chooseServiceName(pod corev1.Pod, resources map[string]string, index int) s
 	if name := resources[string(semconv.K8SDeploymentNameKey)]; name != "" {
 		return name
 	}
+	if name := resources[string(semconv.K8SReplicaSetNameKey)]; name != "" {
+		return name
+	}
 	if name := resources[string(semconv.K8SStatefulSetNameKey)]; name != "" {
 		return name
 	}
 	if name := resources[string(semconv.K8SDaemonSetNameKey)]; name != "" {
 		return name
 	}
-	if name := resources[string(semconv.K8SJobNameKey)]; name != "" {
+	if name := resources[string(semconv.K8SCronJobNameKey)]; name != "" {
 		return name
 	}
-	if name := resources[string(semconv.K8SCronJobNameKey)]; name != "" {
+	if name := resources[string(semconv.K8SJobNameKey)]; name != "" {
 		return name
 	}
 	if name := resources[string(semconv.K8SPodNameKey)]; name != "" {
@@ -406,7 +417,7 @@ func createServiceInstanceId(namespaceName, podName, containerName string) strin
 
 // createResourceMap creates resource attribute map.
 // User defined attributes (in explicitly set env var) have higher precedence.
-func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.Instrumentation, ns corev1.Namespace, pod corev1.Pod, index int) map[string]string {
+func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.Instrumentation, ns corev1.Namespace, pod corev1.Pod, index int) (map[string]string, map[string]bool) {
 	// get existing resources env var and parse it into a map
 	existingRes := map[string]bool{}
 	existingResourceEnvIdx := getIndexOfEnv(pod.Spec.Containers[index].Env, constants.EnvOTELResourceAttrs)
@@ -442,7 +453,7 @@ func (i *sdkInjector) createResourceMap(ctx context.Context, otelinst v1alpha1.I
 			res[string(k)] = v
 		}
 	}
-	return res
+	return res, existingRes
 }
 
 func (i *sdkInjector) addParentResourceLabels(ctx context.Context, uid bool, ns corev1.Namespace, objectMeta metav1.ObjectMeta, resources map[attribute.Key]string) {

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -190,7 +191,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid,service.instance.id=project1.app.application-name,service.version=latest",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.deployment.uid=depuid,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,k8s.replicaset.uid=rsuid,service.instance.id=project1.app.application-name,service.version=latest",
 								},
 							},
 						},
@@ -288,7 +289,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
+									Value: "foo=bar,k8s.container.name=other,service.version=explicitly_set,com.amazonaws.cloudwatch.entity.internal.service.name.source=Instrumentation,fromcr=val,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app",
 								},
 							},
 						},
@@ -358,7 +359,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,service.instance.id=project1.app.application-name,service.version=latest",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=application-name,k8s.deployment.name=my-deployment,k8s.namespace.name=project1,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=app,k8s.pod.uid=pod-uid,k8s.replicaset.name=my-replicaset,service.instance.id=project1.app.application-name,service.version=latest",
 								},
 							},
 						},
@@ -406,7 +407,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -454,7 +455,7 @@ func TestSDKInjection(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 								},
 							},
 						},
@@ -572,7 +573,7 @@ func TestInjectJava(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -676,7 +677,7 @@ func TestInjectNodeJS(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -795,7 +796,164 @@ func TestInjectPython(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+						},
+					},
+				},
+			},
+		},
+	}, pod)
+}
+
+func TestInjectJavaAndPython(t *testing.T) {
+	instJava := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			Java: v1alpha1.Java{
+				Image:     "img:1",
+				Resources: testResourceRequirements,
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4317",
+			},
+		},
+	}
+	instPython := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			Python: v1alpha1.Python{
+				Image: "img:1",
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4318",
+			},
+		},
+	}
+
+	insts := languageInstrumentations{
+		Java:   instrumentationWithContainers{Instrumentation: &instJava, Containers: ""},
+		Python: instrumentationWithContainers{Instrumentation: &instPython, Containers: ""},
+	}
+	inj := sdkInjector{
+		logger: logr.Discard(),
+	}
+	pod := inj.inject(context.Background(), insts,
+		corev1.Namespace{},
+		corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app",
+						Image: "app:latest",
+					},
+				},
+			},
+		})
+	assert.Equal(t, corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: javaVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &defaultVolumeLimitSize,
+						},
+					},
+				},
+				{
+					Name: pythonVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &defaultVolumeLimitSize,
+						},
+					},
+				},
+			},
+			InitContainers: []corev1.Container{
+				{
+					Name:    javaInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      javaVolumeName,
+						MountPath: javaInstrMountPath,
+					}},
+					Resources: testResourceRequirements,
+				},
+				{
+					Name:    pythonInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      pythonVolumeName,
+						MountPath: pythonInstrMountPath,
+					}},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "app:latest",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      javaVolumeName,
+							MountPath: javaInstrMountPath,
+						},
+						{
+							Name:      pythonVolumeName,
+							MountPath: pythonInstrMountPath,
+						},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "JAVA_TOOL_OPTIONS",
+							Value: javaJVMArgument,
+						},
+						{
+							Name:  "OTEL_SERVICE_NAME",
+							Value: "app",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+							Value: "https://collector:4317",
+						},
+						{
+							Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
+						{
+							Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+						{
+							Name:  "PYTHONPATH",
+							Value: fmt.Sprintf("%s:%s", pythonPathPrefix, pythonPathSuffix),
+						},
+						{
+							Name:  "OTEL_TRACES_EXPORTER",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+							Value: "http/protobuf",
+						},
+						{
+							Name:  "OTEL_METRICS_EXPORTER",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+							Value: "http/protobuf",
+						},
+						{
+							Name:  "OTEL_RESOURCE_ATTRIBUTES",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -921,7 +1079,7 @@ func TestInjectDotNet(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
@@ -930,6 +1088,222 @@ func TestInjectDotNet(t *testing.T) {
 	}, pod)
 }
 
+func TestInjectJavaPythonAndDotNet(t *testing.T) {
+	instJava := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			Java: v1alpha1.Java{
+				Image:     "img:1",
+				Resources: testResourceRequirements,
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4317",
+			},
+		},
+	}
+	instPython := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			Python: v1alpha1.Python{
+				Image: "img:1",
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4318",
+			},
+		},
+	}
+
+	instDotNet := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			DotNet: v1alpha1.DotNet{
+				Image: "img:1",
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4318",
+			},
+		},
+	}
+	insts := languageInstrumentations{
+		Java:   instrumentationWithContainers{Instrumentation: &instJava, Containers: ""},
+		Python: instrumentationWithContainers{Instrumentation: &instPython, Containers: ""},
+		DotNet: instrumentationWithContainers{Instrumentation: &instDotNet, Containers: ""},
+	}
+	inj := sdkInjector{
+		logger: logr.Discard(),
+	}
+	pod := inj.inject(context.Background(), insts,
+		corev1.Namespace{},
+		corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "app",
+						Image: "app:latest",
+					},
+				},
+			},
+		})
+	assert.Equal(t, corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: javaVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &defaultVolumeLimitSize,
+						},
+					},
+				},
+				{
+					Name: pythonVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &defaultVolumeLimitSize,
+						},
+					},
+				},
+				{
+					Name: dotnetVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							SizeLimit: &defaultVolumeLimitSize,
+						},
+					},
+				},
+			},
+			InitContainers: []corev1.Container{
+				{
+					Name:    javaInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "/javaagent.jar", javaInstrMountPath + "/javaagent.jar"},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      javaVolumeName,
+						MountPath: javaInstrMountPath,
+					}},
+					Resources: testResourceRequirements,
+				},
+				{
+					Name:    pythonInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "-a", "/autoinstrumentation/.", pythonInstrMountPath},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      pythonVolumeName,
+						MountPath: pythonInstrMountPath,
+					}},
+				},
+				{
+					Name:    dotnetInitContainerName,
+					Image:   "img:1",
+					Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+					VolumeMounts: []corev1.VolumeMount{{
+						Name:      dotnetVolumeName,
+						MountPath: dotnetInstrMountPath,
+					}},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "app",
+					Image: "app:latest",
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      javaVolumeName,
+							MountPath: javaInstrMountPath,
+						},
+						{
+							Name:      pythonVolumeName,
+							MountPath: pythonInstrMountPath,
+						},
+						{
+							Name:      dotnetVolumeName,
+							MountPath: dotnetInstrMountPath,
+						},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "JAVA_TOOL_OPTIONS",
+							Value: javaJVMArgument,
+						},
+						{
+							Name:  "OTEL_SERVICE_NAME",
+							Value: "app",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+							Value: "https://collector:4317",
+						},
+						{
+							Name: "OTEL_RESOURCE_ATTRIBUTES_POD_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.name",
+								},
+							},
+						},
+						{
+							Name: "OTEL_RESOURCE_ATTRIBUTES_NODE_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+						{
+							Name:  "PYTHONPATH",
+							Value: fmt.Sprintf("%s:%s", pythonPathPrefix, pythonPathSuffix),
+						},
+						{
+							Name:  "OTEL_TRACES_EXPORTER",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL",
+							Value: "http/protobuf",
+						},
+						{
+							Name:  "OTEL_METRICS_EXPORTER",
+							Value: "otlp",
+						},
+						{
+							Name:  "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL",
+							Value: "http/protobuf",
+						},
+						{
+							Name:  envDotNetCoreClrEnableProfiling,
+							Value: dotNetCoreClrEnableProfilingEnabled,
+						},
+						{
+							Name:  envDotNetCoreClrProfiler,
+							Value: dotNetCoreClrProfilerID,
+						},
+						{
+							Name:  envDotNetCoreClrProfilerPath,
+							Value: dotNetCoreClrProfilerGlibcPath,
+						},
+						{
+							Name:  envDotNetStartupHook,
+							Value: dotNetStartupHookPath,
+						},
+						{
+							Name:  envDotNetAdditionalDeps,
+							Value: dotNetAdditionalDepsPath,
+						},
+						{
+							Name:  envDotNetOTelAutoHome,
+							Value: dotNetOTelAutoHomePath,
+						},
+						{
+							Name:  envDotNetSharedStore,
+							Value: dotNetSharedStorePath,
+						},
+						{
+							Name:  "OTEL_RESOURCE_ATTRIBUTES",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+						},
+					},
+				},
+			},
+		},
+	}, pod)
+}
 func TestInjectGo(t *testing.T) {
 	falsee := false
 	true := true
@@ -1082,7 +1456,7 @@ func TestInjectGo(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 								},
 							},
 						},
@@ -1183,7 +1557,7 @@ func TestInjectGo(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 								},
 							},
 						},
@@ -1350,7 +1724,7 @@ func TestInjectApacheHttpd(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)",
 								},
 							},
 						},
@@ -1513,7 +1887,7 @@ func TestInjectNginx(t *testing.T) {
 								},
 								{
 									Name:  "OTEL_RESOURCE_ATTRIBUTES",
-									Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd",
+									Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=my-nginx-6c44bcbdd",
 								},
 							},
 						},
@@ -1593,11 +1967,121 @@ func TestInjectSdkOnly(t *testing.T) {
 						},
 						{
 							Name:  "OTEL_RESOURCE_ATTRIBUTES",
-							Value: "k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
+							Value: "com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=app,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),service.version=latest",
 						},
 					},
 				},
 			},
 		},
 	}, pod)
+}
+
+func TestChooseServiceName(t *testing.T) {
+	tests := []struct {
+		name                string
+		resources           map[string]string
+		index               int
+		expectedServiceName string
+		labelValue          string
+		annotationValue     string
+	}{
+		{
+			name:                "first container",
+			resources:           map[string]string{},
+			index:               0,
+			expectedServiceName: "1st",
+		},
+		{
+			name:                "second container",
+			resources:           map[string]string{},
+			index:               1,
+			expectedServiceName: "2nd",
+		},
+		{
+			name: "from pod",
+			resources: map[string]string{
+				string(semconv.K8SPodNameKey): "my-pod",
+			},
+			index:               0,
+			expectedServiceName: "my-pod",
+		},
+		{
+			name: "from replicaset",
+			resources: map[string]string{
+				string(semconv.K8SReplicaSetNameKey): "my-rs",
+				string(semconv.K8SPodNameKey):        "my-rs-pod",
+			},
+			index:               0,
+			expectedServiceName: "my-rs",
+		},
+		{
+			name: "from deployment",
+			resources: map[string]string{
+				string(semconv.K8SDeploymentNameKey): "my-deploy",
+				string(semconv.K8SReplicaSetNameKey): "my-deploy-rs",
+				string(semconv.K8SPodNameKey):        "my-deploy-rs-pod",
+			},
+			index:               0,
+			expectedServiceName: "my-deploy",
+		},
+		{
+			name: "from cronjob",
+			resources: map[string]string{
+				string(semconv.K8SCronJobNameKey): "my-cronjob",
+				string(semconv.K8SJobNameKey):     "my-cronjob-job",
+				string(semconv.K8SPodNameKey):     "my-cronjob-job-pod",
+			},
+			index:               0,
+			expectedServiceName: "my-cronjob",
+		},
+		{
+			name: "from job",
+			resources: map[string]string{
+				string(semconv.K8SJobNameKey): "my-job",
+				string(semconv.K8SPodNameKey): "my-job-pod",
+			},
+			index:               0,
+			expectedServiceName: "my-job",
+		},
+		{
+			name: "from statefulset",
+			resources: map[string]string{
+				string(semconv.K8SStatefulSetNameKey): "my-statefulset",
+				string(semconv.K8SPodNameKey):         "my-statefulset-pod",
+			},
+			index:               0,
+			expectedServiceName: "my-statefulset",
+		},
+		{
+			name: "from daemonset",
+			resources: map[string]string{
+				string(semconv.K8SDaemonSetNameKey): "my-daemonset",
+				string(semconv.K8SPodNameKey):       "my-daemonset-pod",
+			},
+			index:               0,
+			expectedServiceName: "my-daemonset",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serviceName := chooseServiceName(corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/name": test.labelValue,
+					},
+					Annotations: map[string]string{
+						"resource.opentelemetry.io/service.name": test.annotationValue,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "1st"},
+						{Name: "2nd"},
+					},
+				},
+			}, test.resources, test.index)
+
+			assert.Equal(t, test.expectedServiceName, serviceName)
+		})
+	}
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Opens a port on cloudwatch agent pod if application signals is defined in the config on 4311. This port is used to talk to fluentbit to retrieve service name from an instrumented application
- Populates the Service name as Workload name if service.name attribute does not exist
- Add K8s ReplicaSet to be used as a workload name
- Populate ServiceNameSource with Instrumentation if the application is instrumented, or default to K8sWorkload


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
