### PR TITLE
Setup cert-watcher for TA server cert

### DIFF
--- a/cmd/amazon-cloudwatch-agent-target-allocator/main.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	httpOptions := []server.Option{}
-	tlsConfig, confErr := cfg.HTTPS.NewTLSConfig()
+	tlsConfig, confErr := cfg.HTTPS.NewTLSConfig(ctx)
 	if confErr != nil {
 		setupLog.Error(confErr, "Unable to initialize TLS configuration", "Config", cfg.HTTPS)
 		os.Exit(1)

--- a/internal/manifests/targetallocator/container_test.go
+++ b/internal/manifests/targetallocator/container_test.go
@@ -176,9 +176,9 @@ func TestContainerHasEnvVars(t *testing.T) {
 				SubPathExpr:      "",
 			},
 			{
-				Name:             "ta-secret",
-				ReadOnly:         true,
-				MountPath:        TACertMountPath,
+				Name:      "ta-secret",
+				ReadOnly:  true,
+				MountPath: TACertMountPath,
 			},
 		},
 		Ports: []corev1.ContainerPort{
@@ -233,9 +233,9 @@ func TestContainerDoesNotOverrideEnvVars(t *testing.T) {
 				SubPathExpr:      "",
 			},
 			{
-				Name:             "ta-secret",
-				ReadOnly:         true,
-				MountPath:        TACertMountPath,
+				Name:      "ta-secret",
+				ReadOnly:  true,
+				MountPath: TACertMountPath,
 			},
 		},
 		Ports: []corev1.ContainerPort{

--- a/internal/naming/main.go
+++ b/internal/naming/main.go
@@ -37,8 +37,6 @@ func TASecretVolume() string {
 	return "ta-secret"
 }
 
-
-
 // PrometheusConfigMapVolume returns the name to use for the prometheus config map's volume in the pod.
 func PrometheusConfigMapVolume() string {
 	return "prometheus-config"


### PR DESCRIPTION
*Description of changes:* With the current setup, when the TA server certs are rotated, the TA pod is required to be restarted for it to pick up the updated certs - thus requiring explicit intervention.
With this change, we introduce a cert watcher that runs a background watch on the cert files and refreshes anytime a change is detected, thus still preserving connectivity without having to restart the TA pod.

*Testing*:
* Deployed the updated TA image to a dev cluster and executed the following sequence of events:
1. Helm install
2. Confirm collector is able to talk to TA
3. Helm upgrade with no change to simulate a rotation of certs
4. Restart collector pod to pick up new CA bundle on client i.e. collector (but not restart TA intentionally)
5. Confirm collector is still able to talk to TA
* The sequence above would fail prior to this change and passes with the change. Additionally, we see the following log line printed in TA pod logs:
```
{"level":"info","ts":"2024-10-28T23:26:44Z","logger":"controller-runtime.certwatcher","msg":"Updated current TLS certificate"}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
