### PR TITLE
[TA] Target Allocator TLS Unit-tests

### DIFF
--- a/cmd/amazon-cloudwatch-agent-target-allocator/config/config.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/config/config.go
@@ -11,8 +11,9 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 
 	"github.com/go-logr/logr"
 	"github.com/prometheus/common/model"

--- a/cmd/amazon-cloudwatch-agent-target-allocator/server/server.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/server/server.go
@@ -73,6 +73,8 @@ func WithTLSConfig(tlsConfig *tls.Config, httpsListenAddr string) Option {
 		s.setRouter(httpsRouter)
 
 		s.httpsServer = &http.Server{Addr: httpsListenAddr, Handler: httpsRouter, ReadHeaderTimeout: 90 * time.Second, TLSConfig: tlsConfig}
+		s.server.Shutdown(context.Background())
+		s.server = s.httpsServer
 	}
 }
 

--- a/cmd/amazon-cloudwatch-agent-target-allocator/server/server_test.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/server/server_test.go
@@ -614,6 +614,7 @@ func TestServer_JobHandler(t *testing.T) {
 		})
 	}
 }
+
 func TestServer_Readiness(t *testing.T) {
 	tests := []struct {
 		description   string
@@ -677,6 +678,7 @@ func TestServer_Readiness(t *testing.T) {
 		})
 	}
 }
+
 func TestServer_ValidCAonTLS(t *testing.T) {
 	listenAddr := ":8443"
 	s, tlsConfig, err := createTestTLSServer(listenAddr)
@@ -725,10 +727,13 @@ func TestServer_ValidCAonTLS(t *testing.T) {
 			// Only check the status code if there was no error
 			if err == nil {
 				assert.Equal(t, tc.expectedCode, request.StatusCode)
+			} else {
+				t.Log(err)
 			}
 		})
 	}
 }
+
 func TestServer_MissingCAonTLS(t *testing.T) {
 	listenAddr := ":8443"
 	s, _, err := createTestTLSServer(listenAddr)
@@ -773,6 +778,7 @@ func TestServer_MissingCAonTLS(t *testing.T) {
 		})
 	}
 }
+
 func TestServer_HTTPOnTLS(t *testing.T) {
 	listenAddr := ":8443"
 	s, _, err := createTestTLSServer(listenAddr)
@@ -818,6 +824,7 @@ func TestServer_HTTPOnTLS(t *testing.T) {
 		})
 	}
 }
+
 func createTestTLSServer(listenAddr string) (*Server, *tls.Config, error) {
 	//testing using this function replicates customer environment
 	svrConfig := allocatorconfig.HTTPSServerConfig{}
@@ -839,8 +846,13 @@ func createTestTLSServer(listenAddr string) (*Server, *tls.Config, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	return NewServer(logger, nil, listenAddr, httpOptions...), bundle, nil
+	allocator := &mockAllocator{targetItems: map[string]*target.Item{
+		"a": target.NewItem("job1", "", model.LabelSet{}, ""),
+	}}
+
+	return NewServer(logger, allocator, listenAddr, httpOptions...), bundle, nil
 }
+
 func newLink(jobName string) target.LinkJSON {
 	return target.LinkJSON{Link: fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(jobName))}
 }
@@ -864,6 +876,7 @@ func readCABundle(caBundlePath string) (*tls.Config, error) {
 	}
 	return tlsConfig, nil
 }
+
 func generateTestingCerts() (caBundlePath, caCertPath, caKeyPath string, err error) {
 	// Generate private key
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/cmd/amazon-cloudwatch-agent-target-allocator/server/server_test.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/server/server_test.go
@@ -4,13 +4,22 @@
 package server
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 	"time"
 
@@ -185,7 +194,7 @@ func TestServer_TargetsHandler(t *testing.T) {
 
 func TestServer_ScrapeConfigsHandler(t *testing.T) {
 	svrConfig := allocatorconfig.HTTPSServerConfig{}
-	tlsConfig, _ := svrConfig.NewTLSConfig()
+	tlsConfig, _ := svrConfig.NewTLSConfig(context.TODO())
 	tests := []struct {
 		description   string
 		scrapeConfigs map[string]*promconfig.ScrapeConfig
@@ -668,7 +677,261 @@ func TestServer_Readiness(t *testing.T) {
 		})
 	}
 }
+func TestServer_ValidCAonTLS(t *testing.T) {
+	listenAddr := ":8443"
+	s, tlsConfig, err := createTestTLSServer(listenAddr)
+	assert.NoError(t, err)
+	go func() {
+		assert.ErrorIs(t, s.StartHTTPS(), http.ErrServerClosed)
+	}()
+	time.Sleep(100 * time.Millisecond) // wait for server to launch
+	defer func() {
+		err := s.ShutdownHTTPS(context.Background())
+		if err != nil {
+			assert.NoError(t, err)
+		}
+	}()
+	tests := []struct {
+		description  string
+		endpoint     string
+		expectedCode int
+	}{
+		{
+			description:  "with tls test for scrape config",
+			endpoint:     "scrape_configs",
+			expectedCode: http.StatusOK,
+		},
+		{
+			description:  "with tls test for jobs",
+			endpoint:     "jobs",
+			expectedCode: http.StatusOK,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			// Create a custom HTTP client with TLS transport
+			client := &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: tlsConfig,
+				},
+			}
 
+			// Make the GET request
+			request, err := client.Get(fmt.Sprintf("https://localhost%s/%s", listenAddr, tc.endpoint))
+
+			// Verify if a certificate verification error occurred
+			require.NoError(t, err)
+
+			// Only check the status code if there was no error
+			if err == nil {
+				assert.Equal(t, tc.expectedCode, request.StatusCode)
+			}
+		})
+	}
+}
+func TestServer_MissingCAonTLS(t *testing.T) {
+	listenAddr := ":8443"
+	s, _, err := createTestTLSServer(listenAddr)
+	assert.NoError(t, err)
+	go func() {
+		assert.ErrorIs(t, s.StartHTTPS(), http.ErrServerClosed)
+	}()
+	time.Sleep(100 * time.Millisecond) // wait for server to launch
+	defer func() {
+		err := s.ShutdownHTTPS(context.Background())
+		if err != nil {
+			assert.NoError(t, err)
+		}
+	}()
+	tests := []struct {
+		description  string
+		endpoint     string
+		expectedCode int
+	}{
+		{
+			description:  "no tls test for scrape config",
+			endpoint:     "scrape_configs",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			description:  "no tls test for jobs",
+			endpoint:     "jobs",
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			request, err := http.Get(fmt.Sprintf("https://localhost%s/%s", listenAddr, tc.endpoint))
+
+			// Verify if a certificate verification error occurred
+			require.Error(t, err)
+
+			// Only check the status code if there was no error
+			if err == nil {
+				assert.Equal(t, tc.expectedCode, request.StatusCode)
+			}
+		})
+	}
+}
+func TestServer_HTTPOnTLS(t *testing.T) {
+	listenAddr := ":8443"
+	s, _, err := createTestTLSServer(listenAddr)
+	assert.NoError(t, err)
+	go func() {
+		assert.NoError(t, s.StartHTTPS())
+	}()
+	time.Sleep(100 * time.Millisecond) // wait for server to launch
+
+	defer func(s *Server, ctx context.Context) {
+		err := s.Shutdown(ctx)
+		if err != nil {
+			assert.NoError(t, err)
+		}
+	}(s, context.Background())
+	tests := []struct {
+		description  string
+		endpoint     string
+		expectedCode int
+	}{
+		{
+			description:  "no tls test for scrape config",
+			endpoint:     "scrape_configs",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			description:  "no tls test for jobs",
+			endpoint:     "jobs",
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			request, err := http.Get(fmt.Sprintf("http://localhost%s/%s", listenAddr, tc.endpoint))
+
+			// Verify if a certificate verification error occurred
+			//require.Error(t, err)
+
+			// Only check the status code if there was no error
+			if err == nil {
+				assert.Equal(t, tc.expectedCode, request.StatusCode)
+			}
+		})
+	}
+}
+func createTestTLSServer(listenAddr string) (*Server, *tls.Config, error) {
+	//testing using this function replicates customer environment
+	svrConfig := allocatorconfig.HTTPSServerConfig{}
+	caBundle, caCert, caKey, err := generateTestingCerts()
+	if err != nil {
+		return nil, nil, err
+	}
+	svrConfig.TLSKeyFilePath = caKey
+	svrConfig.TLSCertFilePath = caCert
+	tlsConfig, err := svrConfig.NewTLSConfig(context.TODO())
+	if err != nil {
+		return nil, nil, err
+	}
+	httpOptions := []Option{}
+	httpOptions = append(httpOptions, WithTLSConfig(tlsConfig, listenAddr))
+
+	//generate ca bundle
+	bundle, err := readCABundle(caBundle)
+	if err != nil {
+		return nil, nil, err
+	}
+	return NewServer(logger, nil, listenAddr, httpOptions...), bundle, nil
+}
 func newLink(jobName string) target.LinkJSON {
 	return target.LinkJSON{Link: fmt.Sprintf("/jobs/%s/targets", url.QueryEscape(jobName))}
+}
+
+func readCABundle(caBundlePath string) (*tls.Config, error) {
+	// Load the CA bundle
+	caCert, err := os.ReadFile(caBundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA bundle: %w", err)
+	}
+
+	// Create a CA pool and add the CA certificate(s)
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to add CA certificates to pool")
+	}
+
+	// Set up TLS configuration with the CA pool
+	tlsConfig := &tls.Config{
+		RootCAs: caCertPool,
+	}
+	return tlsConfig, nil
+}
+func generateTestingCerts() (caBundlePath, caCertPath, caKeyPath string, err error) {
+	// Generate private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error generating private key: %w", err)
+	}
+
+	// Set up certificate template
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "localhost",
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(365 * 24 * time.Hour), // 1 year validity
+		KeyUsage:  x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+		},
+		DNSNames: []string{"localhost"},
+	}
+
+	// Self-sign the certificate
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error creating certificate: %w", err)
+	}
+
+	// Create temporary files
+	tempDir := os.TempDir()
+
+	caCertFile, err := os.CreateTemp(tempDir, "ca-cert-*.crt")
+	if err != nil {
+		return "", "", "", fmt.Errorf("error creating temp CA cert file: %w", err)
+	}
+	defer caCertFile.Close()
+
+	caKeyFile, err := os.CreateTemp(tempDir, "ca-key-*.key")
+	if err != nil {
+		return "", "", "", fmt.Errorf("error creating temp CA key file: %w", err)
+	}
+	defer caKeyFile.Close()
+
+	caBundleFile, err := os.CreateTemp(tempDir, "ca-bundle-*.crt")
+	if err != nil {
+		return "", "", "", fmt.Errorf("error creating temp CA bundle file: %w", err)
+	}
+	defer caBundleFile.Close()
+
+	// Write the private key to the key file
+	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return "", "", "", fmt.Errorf("error writing private key: %w", err)
+	}
+	err = pem.Encode(caKeyFile, &pem.Block{Type: "EC PRIVATE KEY", Bytes: privateKeyBytes})
+	if err != nil {
+		return "", "", "", fmt.Errorf("error writing private key: %w", err)
+	}
+
+	// Write the certificate to the certificate and bundle files
+	certPEM := &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}
+	if err = pem.Encode(caCertFile, certPEM); err != nil {
+		return "", "", "", fmt.Errorf("error writing certificate: %w", err)
+	}
+	if err = pem.Encode(caBundleFile, certPEM); err != nil {
+		return "", "", "", fmt.Errorf("error writing bundle certificate: %w", err)
+	}
+
+	// Return the file paths
+	return caBundleFile.Name(), caCertFile.Name(), caKeyFile.Name(), nil
 }


### PR DESCRIPTION
## *Issue #, if available:*
Adding new unittest for TLS functionality of scrape server.
## *Description of changes:*
* Added Missing Credential Test, where we ping the server without a Certificate 
* Added HTTP request on the HTTPS server Test 
* Added Valid Credential Test, where we ping the server with a valid Certificate.
* Patched the server so that when https server is created http server is terminated
## *Testing*
Ran make test on `cmd` folder of operator repo: 
![Screenshot 2024-10-31 at 11 52 38 AM](https://github.com/user-attachments/assets/871736fd-f875-48f6-aa31-a6f0af6ffbb1)
```
?       github.com/aws/amazon-cloudwatch-agent-operator [no test files]
?       github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha2   [no test files]
?       github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator    [no test files]
ok      github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1   0.446s
?       github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests      [no test files]
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/allocation 1.160s
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/collector  1.701s
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/config     3.069s
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/diff       2.306s
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/prehook    2.337s
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/server     4.298s
?       github.com/aws/amazon-cloudwatch-agent-operator/internal/status/collector       [no test files]
?       github.com/aws/amazon-cloudwatch-agent-operator/internal/status/dcgmexporter    [no test files]
?       github.com/aws/amazon-cloudwatch-agent-operator/internal/status/neuronmonitor   [no test files]
?       github.com/aws/amazon-cloudwatch-agent-operator/pkg/constants   [no test files]
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/target     14.620s
ok      github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/watcher    5.666s
ok      github.com/aws/amazon-cloudwatch-agent-operator/controllers     6.053s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/config 3.057s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/collector    6.416s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/collector/adapters   6.418s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/dcgmexporter 5.516s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/manifestutils        5.221s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/neuronmonitor        4.908s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/targetallocator      4.814s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/targetallocator/adapters     4.787s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/naming 3.877s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/version        4.251s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/namespacemutation      3.008s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/podmutation    7.915s
ok      github.com/aws/amazon-cloudwatch-agent-operator/internal/webhook/workloadmutation       1.797s
ok      github.com/aws/amazon-cloudwatch-agent-operator/pkg/featuregate 2.595s
ok      github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation     8.952s
ok      github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/auto        2.485s
ok      github.com/aws/amazon-cloudwatch-agent-operator/pkg/instrumentation/upgrade     9.643s
ok      github.com/aws/amazon-cloudwatch-agent-operator/pkg/sidecar     2.325s

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
