### PR TITLE
Implement Bypass Test Mechanism for Emergent Release

### DIFF
--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -159,7 +159,7 @@ jobs:
         run: |
           echo "**E2E test bypass requested**" >> $GITHUB_STEP_SUMMARY
           echo "**Failing Test**: ${{ inputs.e2e-test-bypass-link }}" >> $GITHUB_STEP_SUMMARY
-          echo "**2PR: ${{ inputs.e2e-test-bypass-approver }}" >> $GITHUB_STEP_SUMMARY
+          echo "**2PR**: ${{ inputs.e2e-test-bypass-approver }}" >> $GITHUB_STEP_SUMMARY
 
   e2e-test:
     if: ${{ inputs.e2e-test-bypass-link == '' && inputs.e2e-test-bypass-approver == '' }}

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
       e2e-test-bypass-approver:
-        description: '2PR GitHub Username (for bypass)'
+        description: 'Approver GitHub Username (for bypass)'
         required: false
         type: string
       tag:
@@ -43,7 +43,7 @@ on:
         required: false
         type: string
       e2e-test-bypass-approver:
-        description: '2PR GitHub Username (for bypass)'
+        description: 'Approver GitHub Username (for bypass)'
         required: false
         type: string
       tag:
@@ -159,7 +159,7 @@ jobs:
         run: |
           echo "**E2E test bypass requested**" >> $GITHUB_STEP_SUMMARY
           echo "**Failing Test**: ${{ inputs.e2e-test-bypass-link }}" >> $GITHUB_STEP_SUMMARY
-          echo "**2PR**: ${{ inputs.e2e-test-bypass-approver }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Approver**: ${{ inputs.e2e-test-bypass-approver }}" >> $GITHUB_STEP_SUMMARY
 
   e2e-test:
     if: ${{ inputs.e2e-test-bypass-link == '' && inputs.e2e-test-bypass-approver == '' }}

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -19,11 +19,11 @@ on:
         default: false
         type: boolean
       e2e-test-bypass-link:
-        description: 'Link to failed E2E test run (for bypass)'
+        description: 'Failed E2E Test Run Link (for bypass)'
         required: false
         type: string
       e2e-test-bypass-approver:
-        description: 'GitHub username of person who can 2PR bypass for the E2E test run'
+        description: '2PR GitHub Username (for bypass)'
         required: false
         type: string
       tag:
@@ -39,11 +39,11 @@ on:
         default: false
         type: boolean
       e2e-test-bypass-link:
-        description: 'Link to failed E2E test run (for bypass)'
+        description: 'Failed E2E Test Run Link (for bypass)'
         required: false
         type: string
       e2e-test-bypass-approver:
-        description: 'GitHub username of person who can 2PR bypass for the E2E test run'
+        description: '2PR GitHub Username (for bypass)'
         required: false
         type: string
       tag:
@@ -157,9 +157,9 @@ jobs:
     steps:
       - name: Echo bypass information
         run: |
-          echo "E2E test bypass requested" >> $GITHUB_STEP_SUMMARY
-          echo "Link: ${{ inputs.e2e-test-bypass-link }}" >> $GITHUB_STEP_SUMMARY
-          echo "Approver: ${{ inputs.e2e-test-bypass-approver }}" >> $GITHUB_STEP_SUMMARY
+          echo "**E2E test bypass requested**" >> $GITHUB_STEP_SUMMARY
+          echo "**Failing Test**: ${{ inputs.e2e-test-bypass-link }}" >> $GITHUB_STEP_SUMMARY
+          echo "**2PR: ${{ inputs.e2e-test-bypass-approver }}" >> $GITHUB_STEP_SUMMARY
 
   e2e-test:
     if: ${{ inputs.e2e-test-bypass-link == '' && inputs.e2e-test-bypass-approver == '' }}

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -134,6 +134,7 @@ jobs:
           go mod download
           export GOARCH=arm64 && make targetallocator 
           export GOARCH=amd64 && make targetallocator 
+
       - name: Build Cloudwatch Agent Target Allocator Image and push to ECR
         uses: docker/build-push-action@v4
         if: steps.cached_binaries.outputs.cache-hit == false

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -163,13 +163,6 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
 
-  test-production-env:
-    runs-on: ubuntu-latest
-    environment: 'production'
-    steps:
-      - name: Test Production Environment
-        run: echo "Successfully accessed production environment."
-
   push-release-ecr:
     if: ${{ inputs.release }}
     needs: [MakeTABinary, e2e-test]

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -173,6 +173,13 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
 
+  test-production-env:
+    runs-on: ubuntu-latest
+    environment: 'production'
+    steps:
+      - name: Test Production Environment
+        run: echo "Successfully accessed production environment."
+
   push-release-ecr:
     if: ${{ inputs.release }}
     needs: [MakeTABinary, e2e-test]

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -163,6 +163,13 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
 
+  test-production-env:
+    runs-on: ubuntu-latest
+    environment: 'production'
+    steps:
+      - name: Test Production Environment
+        run: echo "Successfully accessed production environment."
+
   push-release-ecr:
     if: ${{ inputs.release }}
     needs: [MakeTABinary, e2e-test]

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -18,11 +18,14 @@ on:
         required: false
         default: false
         type: boolean
-      bypass-e2e-test:
-        description: "Bypass E2E Test"
+      e2e-test-bypass-link:
+        description: 'Link to failed E2E test run (for bypass)'
         required: false
-        default: false
-        type: boolean
+        type: string
+      e2e-test-bypass-approver:
+        description: 'GitHub username of person who can 2PR bypassing the E2E test run'
+        required: false
+        type: string
       tag:
         description: 'Staging Artifact Tag'
         required: false
@@ -35,11 +38,14 @@ on:
         required: false
         default: false
         type: boolean
-      bypass-e2e-test:
-        description: "Bypass E2E Test"
+      e2e-test-bypass-link:
+        description: 'Link to failed E2E test run (for bypass)'
         required: false
-        default: false
-        type: boolean
+        type: string
+      e2e-test-bypass-approver:
+        description: 'GitHub username of person who can 2PR bypassing the E2E test run'
+        required: false
+        type: string
       tag:
         description: 'Staging Artifact Tag'
         required: false
@@ -146,7 +152,7 @@ jobs:
           platforms: linux/amd64, linux/arm64
 
   e2e-test:
-    if: ${{ !inputs.bypass-e2e-test }}
+    if: ${{ inputs.e2e-test-bypass-link == '' && inputs.e2e-test-bypass-approver == '' }}
     name: "Application Signals E2E Test"
     needs: [MakeBinary]
     uses: ./.github/workflows/application-signals-e2e-test.yml
@@ -164,9 +170,11 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
+    environment: 'production' # Adding this makes job require reviewer: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/reviewing-deployments.
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -23,7 +23,7 @@ on:
         required: false
         type: string
       e2e-test-bypass-approver:
-        description: 'GitHub username of person who can 2PR bypassing the E2E test run'
+        description: 'GitHub username of person who can 2PR bypass for the E2E test run'
         required: false
         type: string
       tag:
@@ -43,7 +43,7 @@ on:
         required: false
         type: string
       e2e-test-bypass-approver:
-        description: 'GitHub username of person who can 2PR bypassing the E2E test run'
+        description: 'GitHub username of person who can 2PR bypass for the E2E test run'
         required: false
         type: string
       tag:

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -180,7 +180,6 @@ jobs:
       id-token: write
       contents: read
     runs-on: ubuntu-latest
-    environment: 'production' # Adding this makes job require reviewer: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/reviewing-deployments.
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -173,13 +173,6 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
 
-  test-production-env:
-    runs-on: ubuntu-latest
-    environment: 'production'
-    steps:
-      - name: Test Production Environment
-        run: echo "Successfully accessed production environment."
-
   push-release-ecr:
     if: ${{ inputs.release }}
     needs: [MakeTABinary, e2e-test]

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      bypass-e2e-test:
+        description: "Bypass E2E Test"
+        required: false
+        default: false
+        type: boolean
       tag:
         description: 'Staging Artifact Tag'
         required: false
@@ -27,6 +32,11 @@ on:
     inputs:
       release:
         description: 'Release Artifact'
+        required: false
+        default: false
+        type: boolean
+      bypass-e2e-test:
+        description: "Bypass E2E Test"
         required: false
         default: false
         type: boolean
@@ -135,6 +145,7 @@ jobs:
           platforms: linux/amd64, linux/arm64
 
   e2e-test:
+    if: ${{ !inputs.bypass-e2e-test }}
     name: "Application Signals E2E Test"
     needs: [MakeBinary]
     uses: ./.github/workflows/application-signals-e2e-test.yml
@@ -147,7 +158,7 @@ jobs:
 
   push-release-ecr:
     if: ${{ inputs.release }}
-    needs: e2e-test
+    needs: [MakeTABinary, e2e-test]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/build-and-upload-release.yml
+++ b/.github/workflows/build-and-upload-release.yml
@@ -151,6 +151,16 @@ jobs:
           tags: ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
           platforms: linux/amd64, linux/arm64
 
+  bypass-info:
+    if: ${{ inputs.e2e-test-bypass-link != '' || inputs.e2e-test-bypass-approver != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo bypass information
+        run: |
+          echo "E2E test bypass requested" >> $GITHUB_STEP_SUMMARY
+          echo "Link: ${{ inputs.e2e-test-bypass-link }}" >> $GITHUB_STEP_SUMMARY
+          echo "Approver: ${{ inputs.e2e-test-bypass-approver }}" >> $GITHUB_STEP_SUMMARY
+
   e2e-test:
     if: ${{ inputs.e2e-test-bypass-link == '' && inputs.e2e-test-bypass-approver == '' }}
     name: "Application Signals E2E Test"


### PR DESCRIPTION
# Description of the issue
When we release our operator and target allocator, we need to run the `Build And Upload Artifact` workflow in order to push the images to the release ECRs. However, sometimes we run into errors that block our release in our E2E tests that are expected to work.

We don't have a way to release when we have a test failure, which would be problematic under an emergent release.

# Description of changes
- Added `e2e-test-bypass-link` and `e2e-test-bypass-approver` inputs to provide the failing E2E test link and the person who will 2PR the bypass.
- Added `bypass-info` job to display the `e2e-test-bypass-link` and `e2e-test-bypass-approver` inputs in the job summary.
- Added conditional to the `e2e-test` job to only run if both `e2e-test-bypass-link` and `e2e-test-bypass-approver` are empty.

# Testing
Ran the following workflow in two situations:
```
gh workflow run build-and-upload-release.yml \
  --ref bypass-e2e-test \
  --field e2e-test-bypass-link=https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/10255095727 \
  --field e2e-test-bypass-approver=musa-asad \
  --field release=false
```

Ran workflow: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/12182695411
<img width="970" alt="Screenshot 2024-12-05 at 10 25 23 AM" src="https://github.com/user-attachments/assets/02981ed1-82f9-49f8-9720-67ddf4b44951">

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
