### PR TITLE
Fix TA Image and Operator Version

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ const (
 	autoInstrumentationNodeJSImageRepository = "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-nodejs"
 	dcgmExporterImageRepository              = "nvcr.io/nvidia/k8s/dcgm-exporter"
 	neuronMonitorImageRepository             = "public.ecr.aws/neuron"
-	targetAllocatorImageRepository           = "ghcr.io/open-telemetry/opentelemetry-operator/target-allocator"
+	targetAllocatorImageRepository           = "public.ecr.aws/cloudwatch-agent/cloudwatch-agent-target-allocator"
 )
 
 var (

--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 cloudwatch-agent=1.300045.0b810
 
 # Represents the current release of the CloudWatch Agent Operator.
-operator=1.7.0
+operator=2.0.0
 
 # Represents the current release of ADOT language instrumentation.
 aws-otel-java-instrumentation=v1.32.2

--- a/versions.txt
+++ b/versions.txt
@@ -2,7 +2,7 @@
 cloudwatch-agent=1.300045.0b810
 
 # Represents the current release of the CloudWatch Agent Operator.
-operator=2.0.0
+operator=2.0.1
 
 # Represents the current release of ADOT language instrumentation.
 aws-otel-java-instrumentation=v1.32.2


### PR DESCRIPTION
*Description of changes:*
- Use the `public.ecr.aws/cloudwatch-agent/cloudwatch-agent-target-allocator` image
- Update `operator` to `2.0.0` in `versions.txt`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
