### PR TITLE
Add Application Signals .NET runtime metrics config

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func main() {
 	pflag.Parse()
 
 	// set instrumentation cpu and memory limits in environment variables to be used for default instrumentation; default values received from https://github.com/open-telemetry/opentelemetry-operator/blob/main/apis/v1alpha1/instrumentation_webhook.go
-	autoInstrumentationConfig := map[string]map[string]map[string]string{"java": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}, "runtime_metrics": {"enabled": "true"}}, "python": {"limits": {"cpu": "500m", "memory": "32Mi"}, "requests": {"cpu": "50m", "memory": "32Mi"}, "runtime_metrics": {"enabled": "true"}}, "dotnet": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}}, "nodejs": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}}}
+	autoInstrumentationConfig := map[string]map[string]map[string]string{"java": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}, "runtime_metrics": {"enabled": "true"}}, "python": {"limits": {"cpu": "500m", "memory": "32Mi"}, "requests": {"cpu": "50m", "memory": "32Mi"}, "runtime_metrics": {"enabled": "true"}}, "dotnet": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}, "runtime_metrics": {"enabled": "true"}}, "nodejs": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}}}
 	err := json.Unmarshal([]byte(autoInstrumentationConfigStr), &autoInstrumentationConfig)
 	if err != nil {
 		setupLog.Info(fmt.Sprintf("Using default values: %v", autoInstrumentationConfig))

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -209,8 +209,13 @@ func getPythonEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exp
 func getDotNetEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exporterPrefix string, additionalEnvs map[string]string) []corev1.EnvVar {
 	var envs []corev1.EnvVar
 	if isAppSignalsEnabled {
+		isDotNetRuntimeEnabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_DOTNET_RUNTIME_ENABLED")
+		if !ok {
+			isDotNetRuntimeEnabled = "true"
+		}
 		envs = []corev1.EnvVar{
 			{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
+			{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: isDotNetRuntimeEnabled},
 			{Name: "OTEL_TRACES_SAMPLER_ARG", Value: fmt.Sprintf("endpoint=%s://%s:2000", http, cloudwatchAgentServiceEndpoint)},
 			{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 			{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -40,6 +40,7 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_MEM_REQUEST", "128Mi")
 	os.Setenv("AUTO_INSTRUMENTATION_JAVA_RUNTIME_ENABLED", "true")
 	os.Setenv("AUTO_INSTRUMENTATION_PYTHON_RUNTIME_ENABLED", "true")
+	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_RUNTIME_ENABLED", "true")
 
 	httpInst := &v1alpha1.Instrumentation{
 		Status: v1alpha1.InstrumentationStatus{},
@@ -116,6 +117,7 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Image: defaultDotNetInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
 					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
@@ -239,6 +241,7 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Image: defaultDotNetInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
 					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
@@ -369,6 +372,7 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 	os.Setenv("AUTO_INSTRUMENTATION_NODEJS_MEM_REQUEST", "128Mi")
 	os.Setenv("AUTO_INSTRUMENTATION_JAVA_RUNTIME_METRICS", "true")
 	os.Setenv("AUTO_INSTRUMENTATION_PYTHON_RUNTIME_METRICS", "true")
+	os.Setenv("AUTO_INSTRUMENTATION_DOTNET_RUNTIME_METRICS", "true")
 
 	httpInst := &v1alpha1.Instrumentation{
 		Status: v1alpha1.InstrumentationStatus{},
@@ -445,6 +449,7 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 				Image: defaultDotNetInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
 					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
@@ -568,6 +573,7 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 				Image: defaultDotNetInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
 					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},


### PR DESCRIPTION
*Description of changes:*
This PR allows customers to configure dotnet runtime metrics collection at cluster level.

*Test*

Configuration
```
--auto-instrumentation-config={"dotnet":{"runtime_metrics":{"enabled":"true"},"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"128Mi"}},"java":{"runtime_metrics":{"enabled":"true"},"limits":{"cpu":"500m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"nodejs":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"128Mi"}},"python":{"runtime_metrics":{"enabled":"true"},"limits":{"cpu":"500m","memory":"32Mi"},"requests":{"cpu":"50m","memory":"32Mi"}}}
```

Result
```
kubectl get po payment-service-dotnet-67b7c6c679-mjz5p -oyaml | grep RUNTIME -A 1
    - name: OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED
      value: "true"
```

Configuration
```
--auto-instrumentation-config={"dotnet":{"runtime_metrics":{"enabled":"false"},"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"128Mi"}},"java":{"runtime_metrics":{"enabled":"true"},"limits":{"cpu":"500m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"nodejs":{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"128Mi"}},"python":{"runtime_metrics":{"enabled":"true"},"limits":{"cpu":"500m","memory":"32Mi"},"requests":{"cpu":"50m","memory":"32Mi"}}}
```

Result
```
kubectl get po payment-service-dotnet-67b7c6c679-k4hgl -oyaml | grep RUNTIME -A 1
    - name: OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED
      value: "false"
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
