### PR TITLE
upgrade go and deps

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:
-          go-version: ~1.19.6
+          go-version: ~1.22.7
           cache: false
 
       - name: Configure AWS Credentials

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 # set goproxy=direct
 ENV GOPROXY direct

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-cloudwatch-agent-operator
 
-go 1.21
+go 1.22
 
 retract v1.51.0
 
@@ -193,7 +193,7 @@ require (
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/net v0.26.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -838,8 +838,8 @@ golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
-golang.org/x/net v0.26.0 h1:soB7SVo0PWrY4vPW/+ay0jKDNScG2X9wFeYlXIvJsOQ=
-golang.org/x/net v0.26.0/go.mod h1:5YKkiSynbBIh3p6iOc/vibscux0x38BZDkn8sCUPxHE=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
*Issue #, if available:*
Image scanner results: https://github.com/aws-observability/helm-charts/actions/runs/12633083327/job/35197988021

*Description of changes:*
- Update go version used in build and by docker
- Upgrade `golang.org/x/net` version

Scanning the built image with `trivy` and `docker scout`
```
> trivy image aws/cloudwatch-agent-operator:2.0.1
2025-01-07T11:16:20-05:00	INFO	[vuln] Vulnerability scanning is enabled
2025-01-07T11:16:20-05:00	INFO	[secret] Secret scanning is enabled
2025-01-07T11:16:20-05:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-01-07T11:16:20-05:00	INFO	[secret] Please see also https://aquasecurity.github.io/trivy/v0.58/docs/scanner/secret#recommendation for faster secret detection
2025-01-07T11:16:21-05:00	INFO	Detected OS	family="debian" version="12.8"
2025-01-07T11:16:21-05:00	INFO	[debian] Detecting vulnerabilities...	os_version="12" pkg_num=3
2025-01-07T11:16:21-05:00	INFO	Number of language-specific files	num=1
2025-01-07T11:16:21-05:00	INFO	[gobinary] Detecting vulnerabilities...

aws/cloudwatch-agent-operator:2.0.1 (debian 12.8)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

> docker scout cves local://aws/cloudwatch-agent-operator:2.0.1
    i New version 1.16.1 available (installed version is 1.14.0) at https://github.com/docker/scout-cli
          ✓ SBOM of image already cached, 151 packages indexed
    ✗ Detected 2 vulnerable packages with a total of 3 vulnerabilities


## Overview

                    │                Analyzed Image                  
────────────────────┼────────────────────────────────────────────────
  Target            │  local://aws/cloudwatch-agent-operator:2.0.1   
    digest          │  ef7974d05321                                  
    platform        │ linux/amd64                                    
    vulnerabilities │    0C     0H     2M     1L                     
    size            │ 50 MB                                          
    packages        │ 151                                            


## Packages and Vulnerabilities

   0C     0H     1M     1L  github.com/aws/aws-sdk-go 1.45.25
pkg:golang/github.com/aws/aws-sdk-go@1.45.25

    ✗ MEDIUM CVE-2020-8911
      https://scout.docker.com/v/CVE-2020-8911
      Affected range : >=0        
      Fixed version  : not fixed  
    
    ✗ LOW CVE-2020-8912
      https://scout.docker.com/v/CVE-2020-8912
      Affected range : >=0        
      Fixed version  : not fixed  
    

   0C     0H     1M     0L  github.com/go-resty/resty/v2 2.7.0
pkg:golang/github.com/go-resty/resty@2.7.0#v2

    ✗ MEDIUM CVE-2023-45286 [OWASP Top Ten 2017 Category A9 - Using Components with Known Vulnerabilities]
      https://scout.docker.com/v/CVE-2023-45286
      Affected range : <=v2.10.0                                     
      Fixed version  : not fixed                                     
      CVSS Score     : 5.9                                           
      CVSS Vector    : CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N  
    


3 vulnerabilities found in 2 packages
  LOW       1  
  MEDIUM    2  
  HIGH      0  
  CRITICAL  0  


What's next:
    View base image update recommendations → docker scout recommendations local://aws/cloudwatch-agent-operator:2.0.1

```

Package vulnerabilities with `aws-sdk-go` caught by `scout` don't affect the operator and are not major/high, and it should be addressed in a future release. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
