### PR TITLE
Fix build issues

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -61,7 +61,6 @@ jobs:
           ref: ${{ inputs.target-sha }}    
           repository: ${{inputs.repository}}
 
-
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -89,6 +89,8 @@ jobs:
 
       - name: Build Binaries
         run: |
+          export GOPROXY=direct 
+          go mod download
           for platform in $(echo $PLATFORMS | tr "," "\n"); do
             arch=${platform#*/}
             echo "Building operator for $arch"
@@ -146,6 +148,7 @@ jobs:
 
       - name: Build Binaries
         run: |
+          export GOPROXY=direct 
           go mod download
           export GOARCH=arm64 && make targetallocator 
           export GOARCH=amd64 && make targetallocator 

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -138,6 +138,7 @@ jobs:
 
       - name: Build Binaries
         run: |
+          sudo date -s "2025-01-19"
           go mod download
           export GOARCH=arm64 && make targetallocator 
           export GOARCH=amd64 && make targetallocator 

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -9,6 +9,7 @@ env:
   ECR_OPERATOR_RELEASE_IMAGE: ${{ vars.ECR_OPERATOR_RELEASE_IMAGE }}
   ECR_TARGET_ALLOCATOR_STAGING_REPO: ${{ vars.ECR_TARGET_ALLOCATOR_STAGING_REPO }}
   ECR_TARGET_ALLOCATOR_RELEASE_REPO: ${{ vars.ECR_TARGET_ALLOCATOR_RELEASE_REPO }}
+  PLATFORMS: linux/amd64,linux/arm64
   
 on:
   workflow_call:
@@ -88,9 +89,11 @@ jobs:
 
       - name: Build Binaries
         run: |
-          go mod download
-          export GOARCH=arm64 && make manager 
-          export GOARCH=amd64 && make manager 
+          for platform in $(echo $PLATFORMS | tr "," "\n"); do
+            arch=${platform#*/}
+            echo "Building operator for $arch"
+            make manager ARCH=$arch
+          done 
 
       - name: Build Cloudwatch Agent Operator Image and push to ECR
         uses: docker/build-push-action@v4
@@ -99,7 +102,7 @@ jobs:
           file: ./Dockerfile
           context: .
           push: true
-          platforms: linux/amd64, linux/arm64
+          platforms: ${{ env.PLATFORMS }}
           tags: |
            ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
            ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.target-sha }}
@@ -157,7 +160,7 @@ jobs:
           tags: |
            ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
            ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.target-sha }}
-          platforms: linux/amd64, linux/arm64
+          platforms: ${{ env.PLATFORMS }}
 
   bypass-info:
     if: ${{ inputs.e2e-test-bypass-link != '' || inputs.e2e-test-bypass-approver != '' }}

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -87,6 +87,12 @@ jobs:
         if: steps.cached_binaries.outputs.cache-hit == false
         uses: docker/setup-qemu-action@v1
 
+      - name: Build Binaries
+        run: |
+          go mod download
+          export GOARCH=arm64 && make manager 
+          export GOARCH=amd64 && make manager 
+
       - name: Build Cloudwatch Agent Operator Image and push to ECR
         uses: docker/build-push-action@v4
         if: steps.cached_binaries.outputs.cache-hit == false

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -87,10 +87,6 @@ jobs:
         if: steps.cached_binaries.outputs.cache-hit == false
         uses: docker/setup-qemu-action@v1
 
-      - name: Set date
-        run: |
-          sudo date -s "2025-01-19"
-
       - name: Build Cloudwatch Agent Operator Image and push to ECR
         uses: docker/build-push-action@v4
         if: steps.cached_binaries.outputs.cache-hit == false
@@ -142,7 +138,6 @@ jobs:
 
       - name: Build Binaries
         run: |
-          sudo date -s "2025-01-19"
           go mod download
           export GOARCH=arm64 && make targetallocator 
           export GOARCH=amd64 && make targetallocator 

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -10,6 +10,7 @@ env:
   ECR_TARGET_ALLOCATOR_STAGING_REPO: ${{ vars.ECR_TARGET_ALLOCATOR_STAGING_REPO }}
   ECR_TARGET_ALLOCATOR_RELEASE_REPO: ${{ vars.ECR_TARGET_ALLOCATOR_RELEASE_REPO }}
   PLATFORMS: linux/amd64,linux/arm64
+  GOPROXY: direct
   
 on:
   workflow_call:
@@ -89,7 +90,6 @@ jobs:
 
       - name: Build Binaries
         run: |
-          export GOPROXY=direct 
           go mod download
           for platform in $(echo $PLATFORMS | tr "," "\n"); do
             arch=${platform#*/}
@@ -148,7 +148,6 @@ jobs:
 
       - name: Build Binaries
         run: |
-          export GOPROXY=direct 
           go mod download
           export GOARCH=arm64 && make targetallocator 
           export GOARCH=amd64 && make targetallocator 

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -87,6 +87,10 @@ jobs:
         if: steps.cached_binaries.outputs.cache-hit == false
         uses: docker/setup-qemu-action@v1
 
+      - name: Set date
+        run: |
+          sudo date -s "2025-01-19"
+
       - name: Build Cloudwatch Agent Operator Image and push to ECR
         uses: docker/build-push-action@v4
         if: steps.cached_binaries.outputs.cache-hit == false

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ARG NEURON_MONITOR_VERSION
 ARG TARGET_ALLOCATOR_VERSION
 
 # Build
+RUN sudo date -s "2025-01-19"
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.agent=${AGENT_VERSION} -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION} -X ${VERSION_PKG}.autoInstrumentationPython=${AUTO_INSTRUMENTATION_PYTHON_VERSION} -X ${VERSION_PKG}.autoInstrumentationDotNet=${AUTO_INSTRUMENTATION_DOTNET_VERSION} -X ${VERSION_PKG}.autoInstrumentationNodeJS=${AUTO_INSTRUMENTATION_NODEJS_VERSION} -X ${VERSION_PKG}.dcgmExporter=${DCMG_EXPORTER_VERSION} -X ${VERSION_PKG}.neuronMonitor=${NEURON_MONITOR_VERSION} -X ${VERSION_PKG}.targetAllocator=${TARGET_ALLOCATOR_VERSION}" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
+RUN date -s "2025-01-19"
 RUN go mod download
 
 # Copy the go source
@@ -33,7 +34,6 @@ ARG NEURON_MONITOR_VERSION
 ARG TARGET_ALLOCATOR_VERSION
 
 # Build
-RUN sudo date -s "2025-01-19"
 RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.agent=${AGENT_VERSION} -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION} -X ${VERSION_PKG}.autoInstrumentationPython=${AUTO_INSTRUMENTATION_PYTHON_VERSION} -X ${VERSION_PKG}.autoInstrumentationDotNet=${AUTO_INSTRUMENTATION_DOTNET_VERSION} -X ${VERSION_PKG}.autoInstrumentationNodeJS=${AUTO_INSTRUMENTATION_NODEJS_VERSION} -X ${VERSION_PKG}.dcgmExporter=${DCMG_EXPORTER_VERSION} -X ${VERSION_PKG}.neuronMonitor=${NEURON_MONITOR_VERSION} -X ${VERSION_PKG}.targetAllocator=${TARGET_ALLOCATOR_VERSION}" -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN date -s "2025-01-19"
 RUN go mod download
 
 # Copy the go source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,21 @@
-# Build the manager binary
-FROM golang:1.22 as builder
+# Get CA certificates from alpine package repo
+FROM alpine:3.21 as certificates
 
-# set goproxy=direct
-ENV GOPROXY=https://proxy.golang.org,direct
+RUN apk --no-cache add ca-certificates
 
-WORKDIR /workspace
+######## Start a new stage from scratch #######
+FROM scratch
 
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+ARG TARGETARCH
 
-# Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY controllers/ controllers/
-COPY internal/ internal/
-COPY pkg/ pkg/
-COPY versions.txt versions.txt
-
-ARG VERSION_PKG
-ARG VERSION
-ARG VERSION_DATE
-ARG AGENT_VERSION
-ARG AUTO_INSTRUMENTATION_JAVA_VERSION
-ARG AUTO_INSTRUMENTATION_PYTHON_VERSION
-ARG AUTO_INSTRUMENTATION_DOTNET_VERSION
-ARG AUTO_INSTRUMENTATION_NODEJS_VERSION
-ARG DCMG_EXPORTER_VERSION
-ARG NEURON_MONITOR_VERSION
-ARG TARGET_ALLOCATOR_VERSION
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.agent=${AGENT_VERSION} -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION} -X ${VERSION_PKG}.autoInstrumentationPython=${AUTO_INSTRUMENTATION_PYTHON_VERSION} -X ${VERSION_PKG}.autoInstrumentationDotNet=${AUTO_INSTRUMENTATION_DOTNET_VERSION} -X ${VERSION_PKG}.autoInstrumentationNodeJS=${AUTO_INSTRUMENTATION_NODEJS_VERSION} -X ${VERSION_PKG}.dcgmExporter=${DCMG_EXPORTER_VERSION} -X ${VERSION_PKG}.neuronMonitor=${NEURON_MONITOR_VERSION} -X ${VERSION_PKG}.targetAllocator=${TARGET_ALLOCATOR_VERSION}" -a -o manager main.go
-
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+
+# Copy the certs from Alpine
+COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy binary built on the host
+COPY bin/manager_${TARGETARCH} manager
+
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,16 @@
 FROM golang:1.22 as builder
 
 # set goproxy=direct
-ENV GOPROXY direct
+ENV GOPROXY=https://proxy.golang.org,direct
 
 WORKDIR /workspace
 
-ENV GOPRIVATE=go.opencensus.io
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download && \
-    go get -insecure go.opencensus.io@v0.24.0
+RUN go mod download
 
 # Copy the go source
 COPY main.go main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,15 @@ FROM golang:1.22 as builder
 ENV GOPROXY direct
 
 WORKDIR /workspace
+
+ENV GOPRIVATE=go.opencensus.io
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+RUN go mod download && \
+    go get -insecure go.opencensus.io@v0.24.0
 
 # Copy the go source
 COPY main.go main.go

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ kustomize: ## Download kustomize locally if necessary.
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	$(call go-get-tool,$(CONTROLLER_GEN), sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
+	unset GOBIN && $(call go-get-tool,$(CONTROLLER_GEN), sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: goimports
 goimports:

--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,11 @@ test: generate fmt vet envtest
 # Build manager binary
 .PHONY: manager
 manager: generate fmt vet
-	CGO_ENABLED=0 GOOS=linux GO111MODULE=on GOARCH=$(ARCH) go build -o bin/manager_${ARCH} -ldflags "${OPERATOR_LDFLAGS}" -a main.go
+	CGO_ENABLED=0 GOOS=linux GO111MODULE=on GOARCH=$(ARCH) go build -o bin/manager_${ARCH} -ldflags "${OPERATOR_LDFLAGS}" main.go
 # Build target allocator binary
 .PHONY: targetallocator
 targetallocator:
-	cd cmd/amazon-cloudwatch-agent-target-allocator && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build  -installsuffix cgo -o bin/targetallocator_${ARCH} -ldflags "${LDFLAGS}"  .
+	cd cmd/amazon-cloudwatch-agent-target-allocator && CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(ARCH) go build -installsuffix cgo -o bin/targetallocator_${ARCH} -ldflags "${LDFLAGS}"  .
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run
@@ -193,7 +193,7 @@ kustomize: ## Download kustomize locally if necessary.
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+	$(call go-get-tool,$(CONTROLLER_GEN), sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: goimports
 goimports:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ AUTO_INSTRUMENTATION_NODEJS_VERSION ?= "$(shell grep -v '\#' versions.txt | grep
 DCGM_EXPORTER_VERSION ?= "$(shell grep -v '\#' versions.txt | grep dcgm-exporter | awk -F= '{print $$2}')"
 NEURON_MONITOR_VERSION ?= "$(shell grep -v '\#' versions.txt | grep neuron-monitor | awk -F= '{print $$2}')"
 TARGET_ALLOCATOR_VERSION ?= "$(shell grep -v '\#' versions.txt | grep target-allocator |  awk -F= '{print $$2}')"
+OPERATOR_LDFLAGS ?= -X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.agent=${AGENT_VERSION} -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION} -X ${VERSION_PKG}.autoInstrumentationPython=${AUTO_INSTRUMENTATION_PYTHON_VERSION} -X ${VERSION_PKG}.autoInstrumentationDotNet=${AUTO_INSTRUMENTATION_DOTNET_VERSION} -X ${VERSION_PKG}.autoInstrumentationNodeJS=${AUTO_INSTRUMENTATION_NODEJS_VERSION} -X ${VERSION_PKG}.dcgmExporter=${DCMG_EXPORTER_VERSION} -X ${VERSION_PKG}.neuronMonitor=${NEURON_MONITOR_VERSION} -X ${VERSION_PKG}.targetAllocator=${TARGET_ALLOCATOR_VERSION}
 
 # Image URL to use all building/pushing image targets
 IMG_PREFIX ?= aws
@@ -101,7 +102,7 @@ test: generate fmt vet envtest
 # Build manager binary
 .PHONY: manager
 manager: generate fmt vet
-	go build -o bin/manager main.go
+	CGO_ENABLED=0 GOOS=linux GO111MODULE=on GOARCH=$(ARCH) go build -o bin/manager_${ARCH} -ldflags "${OPERATOR_LDFLAGS}" -a main.go
 # Build target allocator binary
 .PHONY: targetallocator
 targetallocator:

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ kustomize: ## Download kustomize locally if necessary.
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	unset GOBIN && $(call go-get-tool,$(CONTROLLER_GEN), sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
+	GOBIN=$(LOCALBIN) $(call go-get-tool,$(CONTROLLER_GEN), sigs.k8s.io/controller-tools/cmd/controller-gen,$(CONTROLLER_TOOLS_VERSION))
 
 .PHONY: goimports
 goimports:
@@ -213,7 +213,7 @@ simple-lint: checklicense impi
 install-addlicense:
 	# Using 04bfe4e to get SPDX template changes that are not present in the most recent tag v1.0.0
 	# This is required to be able to easily omit the year in our license header.
-	unset GOBIN && go install github.com/google/addlicense@04bfe4e
+	GOBIN=$(LOCALBIN) go install github.com/google/addlicense@04bfe4e
 
 addlicense: install-addlicense
 	@ADDLICENSEOUT=`$(ADDLICENSE) -y="" -s=only -l="Apache-2.0" -c="Amazon.com, Inc. or its affiliates. All Rights Reserved." $(ALL_SRC) 2>&1`; \

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ generate: controller-gen api-docs
 # Build the container image, used only for local dev purposes
 # buildx is used to ensure same results for arm based systems (m1/2 chips)
 .PHONY: container
-container:
+container: manager
 	docker buildx build --load --platform linux/${ARCH} -t ${IMG} --build-arg VERSION_PKG=${VERSION_PKG} --build-arg VERSION=${VERSION} --build-arg VERSION_DATE=${VERSION_DATE} --build-arg AGENT_VERSION=${AGENT_VERSION} --build-arg AUTO_INSTRUMENTATION_JAVA_VERSION=${AUTO_INSTRUMENTATION_JAVA_VERSION} --build-arg AUTO_INSTRUMENTATION_PYTHON_VERSION=${AUTO_INSTRUMENTATION_PYTHON_VERSION} --build-arg AUTO_INSTRUMENTATION_DOTNET_VERSION=${AUTO_INSTRUMENTATION_DOTNET_VERSION} --build-arg AUTO_INSTRUMENTATION_NODEJS_VERSION=${AUTO_INSTRUMENTATION_NODEJS_VERSION} --build-arg DCGM_EXPORTER_VERSION=${DCGM_EXPORTER_VERSION} --build-arg NEURON_MONITOR_VERSION=${NEURON_MONITOR_VERSION} --build-arg TARGET_ALLOCATOR_VERSION=${TARGET_ALLOCATOR_VERSION} .
 
 # Push the container image, used only for local dev purposes

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ simple-lint: checklicense impi
 install-addlicense:
 	# Using 04bfe4e to get SPDX template changes that are not present in the most recent tag v1.0.0
 	# This is required to be able to easily omit the year in our license header.
-	GOBIN=$(LOCALBIN) go install github.com/google/addlicense@04bfe4e
+	unset GOBIN && go install github.com/google/addlicense@04bfe4e
 
 addlicense: install-addlicense
 	@ADDLICENSEOUT=`$(ADDLICENSE) -y="" -s=only -l="Apache-2.0" -c="Amazon.com, Inc. or its affiliates. All Rights Reserved." $(ALL_SRC) 2>&1`; \

--- a/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
@@ -1,4 +1,4 @@
-# Get CA certificates from the latest Ubuntu
+# Get CA certificates from alpine package repo
 FROM alpine:3.21 as certificates
 
 RUN apk --no-cache add ca-certificates

--- a/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
@@ -1,7 +1,9 @@
 # Get CA certificates from the Alpine package repo
 FROM alpine:3.18 as certificates
 
+# Fix apk repo using https https://github.com/alpinelinux/docker-alpine/issues/98#issuecomment-2572849159
 RUN sed -i 's|https://|http://|' /etc/apk/repositories
+
 RUN apk --no-cache add ca-certificates
 
 # Start a new stage from scratch

--- a/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
@@ -1,12 +1,10 @@
 # Get CA certificates from the latest Ubuntu
-ARG CERT_IMAGE=ubuntu:latest
+FROM alpine:3.21 as certificates
 
 # Install cert and binaries
-FROM $CERT_IMAGE as cert
+FROM $CERT_IMAGE as certificates
 
-RUN apt-get update &&  \
-    apt-get install -y ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk --no-cache add ca-certificates
 
 # Start a new stage from scratch
 FROM scratch
@@ -16,9 +14,11 @@ ARG TARGETARCH
 WORKDIR /root/
 
 # Copy the certs
-COPY --from=cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binary built on the host
 COPY bin/targetallocator_${TARGETARCH} ./main
+
+USER 65532:65532
 
 ENTRYPOINT ["./main"]

--- a/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
@@ -1,9 +1,6 @@
 # Get CA certificates from the latest Ubuntu
 FROM alpine:3.21 as certificates
 
-# Install cert and binaries
-FROM $CERT_IMAGE as certificates
-
 RUN apk --no-cache add ca-certificates
 
 # Start a new stage from scratch

--- a/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
@@ -1,10 +1,12 @@
-# Get CA certificates from the Alpine package repo
-FROM alpine:3.18 as certificates
+# Get CA certificates from the latest Ubuntu
+ARG CERT_IMAGE=ubuntu:latest
 
-# Fix apk repo using https https://github.com/alpinelinux/docker-alpine/issues/98#issuecomment-2572849159
-RUN sed -i 's|https://|http://|' /etc/apk/repositories
+# Install cert and binaries
+FROM $CERT_IMAGE as cert
 
-RUN apk --no-cache add ca-certificates
+RUN apt-get update &&  \
+    apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 # Start a new stage from scratch
 FROM scratch
@@ -14,7 +16,7 @@ ARG TARGETARCH
 WORKDIR /root/
 
 # Copy the certs
-COPY --from=certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=cert /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Copy binary built on the host
 COPY bin/targetallocator_${TARGETARCH} ./main

--- a/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
@@ -1,6 +1,7 @@
 # Get CA certificates from the Alpine package repo
 FROM alpine:3.18 as certificates
 
+RUN sed -i 's|https://|http://|' /etc/apk/repositories
 RUN apk --no-cache add ca-certificates
 
 # Start a new stage from scratch


### PR DESCRIPTION
Revs:
- Move operator build to Github runner by syncing Makefile and Dockerfile with the upstream
- Drop all hacky changes since they are not needed anymore

Build and deploy test run: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/13055448538

--
- Use `ubuntu:latest` for TargetAllocator certificates to make it consistent with CWA
- Drop date change for TargetAllocator

---

Build is failing due to expired certificate with `opencensus`  and not being able to fetch alpine for certs

Example error:
```
// cert
#12 [builder  5/12] RUN go mod download
#12 233.1 go: go.opencensus.io@v0.24.0: unrecognized import path "go.opencensus.io": https fetch: Get "https://go.opencensus.io/?go-get=1": tls: failed to verify certificate: x509: certificate has expired or is not yet valid: current time 2025-01-23T20:15:07Z is after 2025-01-21T03:43:04Z

// fetching alpine for certs
 > [linux/amd64 certificates 2/2] RUN apk --no-cache add ca-certificates:
0.096 fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/x86_64/APKINDEX.tar.gz
0.161 485BF0EAC27F0000:error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:1889:
```

*Description of changes:* **Original changes that are not needed anymore**
- ~set date to past for TA build target~
- ~for alpine, fix repos to use http instead https https://github.com/alpinelinux/docker-alpine/issues/98#issuecomment-2572849159~
- ~use `ENV GOPROXY=https://proxy.golang.org,direct` for operator which gets built in a container~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
