### PR TITLE
add tf install step for actions

### DIFF
--- a/.github/workflows/eks-add-on-canary-test.yml
+++ b/.github/workflows/eks-add-on-canary-test.yml
@@ -61,6 +61,11 @@ jobs:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
+
       - name: Terraform apply
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/eks-add-on-integ-test.yml
+++ b/.github/workflows/eks-add-on-integ-test.yml
@@ -96,6 +96,11 @@ jobs:
           echo "[WARNING] Kubernetes dependencies are lower than the latest Kubernetes cluster version. Please check changelog to ensure no breaking changes: https://kubernetes.io/releases/"
           fi
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
+          
       - name: Verify Terraform version
         run: terraform --version
 

--- a/.github/workflows/gpu-e2e-test.yml
+++ b/.github/workflows/gpu-e2e-test.yml
@@ -96,6 +96,11 @@ jobs:
           echo "please run go get -u && go mod tidy"
           exit 1; 
           fi
+          
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
 
       - name: Verify Terraform version
         run: terraform --version


### PR DESCRIPTION
*Issue #, if available:*
Github actions are failing with missing terraform. https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/13164019043

*Description of changes:*
Add an action step to explicitly install tf

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
