### PR TITLE
Reduce depth of GH workflows used

### DIFF
--- a/.github/workflows/build-and-upload-integration.yml
+++ b/.github/workflows/build-and-upload-integration.yml
@@ -17,11 +17,8 @@ permissions:
 
 jobs:
   BuildAndUpload:
-    uses: ./.github/workflows/build-and-upload-release.yml
+    uses: ./.github/workflows/build-and-upload.yml
     secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
     with:
       release: false
       tag: 'integration-test'


### PR DESCRIPTION
*Issue #, if available:*
The depth of GH workflows invoked is exceeding 3 and fails for build-and-upload-integration.yml
<img width="1593" alt="image" src="https://github.com/user-attachments/assets/a0b23c24-2804-4212-82de-1bb7ea273831" />


*Description of changes:*
The current flow calls: 
`build-and-upload-integration` -> `build-and-upload-release` -> `build-and-upload` -> `application-signals-e2e-test` -> `aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test`.
The new flow eliminates calling `build-and-upload-release` and now calls: 
`build-and-upload-integration` -> `build-and-upload` -> `application-signals-e2e-test` -> `aws-observability/aws-application-signals-test-framework/.github/workflows/python-eks-test`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
