### PR TITLE
Optimize dockerfile to prevent timeouts

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ inputs.target-sha }}    
+          ref: ${{ inputs.target-sha }}
           repository: ${{inputs.repository}}
 
 
@@ -94,10 +94,27 @@ jobs:
           file: ./Dockerfile
           context: .
           push: true
-          platforms: linux/amd64, linux/arm64
+          platforms: linux/amd64,linux/arm64
           tags: |
-           ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
-           ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.target-sha }}
+            ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
+            ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.target-sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION_PKG=${{ env.VERSION_PKG }}
+            VERSION=${{ inputs.tag }}
+            VERSION_DATE=${{ env.VERSION_DATE }}
+            AGENT_VERSION=${{ env.AGENT_VERSION }}
+            AUTO_INSTRUMENTATION_JAVA_VERSION=${{ env.AUTO_INSTRUMENTATION_JAVA_VERSION }}
+            AUTO_INSTRUMENTATION_PYTHON_VERSION=${{ env.AUTO_INSTRUMENTATION_PYTHON_VERSION }}
+            AUTO_INSTRUMENTATION_DOTNET_VERSION=${{ env.AUTO_INSTRUMENTATION_DOTNET_VERSION }}
+            AUTO_INSTRUMENTATION_NODEJS_VERSION=${{ env.AUTO_INSTRUMENTATION_NODEJS_VERSION }}
+            DCMG_EXPORTER_VERSION=${{ env.DCMG_EXPORTER_VERSION }}
+            NEURON_MONITOR_VERSION=${{ env.NEURON_MONITOR_VERSION }}
+            TARGET_ALLOCATOR_VERSION=${{ env.TARGET_ALLOCATOR_VERSION }}
+          outputs: type=image,push=true
+          provenance: false
+
   MakeTABinary:
     name: 'MakeTargetAllocatorImage'
     runs-on: ubuntu-latest
@@ -151,8 +168,8 @@ jobs:
           context: ./cmd/amazon-cloudwatch-agent-target-allocator
           push: true
           tags: |
-           ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
-           ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.target-sha }}
+            ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
+            ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.target-sha }}
           platforms: linux/amd64, linux/arm64
 
   bypass-info:
@@ -179,7 +196,7 @@ jobs:
 
   push-release-ecr:
     if: ${{ inputs.release }}
-    needs: [MakeTABinary, e2e-test]
+    needs: [ MakeTABinary, e2e-test ]
     permissions:
       id-token: write
       contents: read
@@ -194,7 +211,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
-          aws-region: ${{inputs.region}} 
+          aws-region: ${{inputs.region}}
 
       - name: Login ECR
         id: login-ecr

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -435,4 +435,4 @@ jobs:
           sleep 5
           go test -v -run TestNodeJSOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
-          go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 30m
+          go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 60m

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -429,10 +429,10 @@ jobs:
           sleep 5
           go test -v -run TestJavaOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
-          go test -v -run TestPythonOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
+          go test -v -run TestPythonOnlyNamespace ./integration-tests/manifests/annotations -timeout 45m
           sleep 5
           go test -v -run TestDotNetOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
           go test -v -run TestNodeJSOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
-          go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 60m
+          go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 45m

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -61,7 +61,7 @@ jobs:
           kubectl apply -f integration-tests/manifests/cloudwatch-agent-daemonset.yaml -n amazon-cloudwatch
           sleep 20
           kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
-          
+
           pod_name="$(kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/component=amazon-cloudwatch-agent,app.kubernetes.io/instance=amazon-cloudwatch.cloudwatch-agent -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
           if [ -z "$pod_name" ]; then
             echo "Pod $pod_name is not created. Exiting with ERROR."
@@ -74,9 +74,9 @@ jobs:
       - name: Test for default instrumentation resources for Java
         run: |
           kubectl apply -f integration-tests/java/sample-deployment-java.yaml
-          sleep 5 
+          sleep 5
           kubectl wait --for=condition=Ready pod --all -n default
-          kubectl get pods -A 
+          kubectl get pods -A
           kubectl describe pods -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/java/default_instrumentation_java_env_variables.json app_signals
 
@@ -86,8 +86,8 @@ jobs:
           kubectl delete pods --all -n default
           sleep 5
           kubectl wait --for=condition=Ready pod --all -n default
-          
-          go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals    
+
+          go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals
           kubectl delete instrumentation sample-instrumentation
 
       - name: Test for default instrumentation resources for python
@@ -95,7 +95,7 @@ jobs:
           kubectl apply -f integration-tests/python/sample-deployment-python.yaml
           sleep 5
           kubectl wait --for=condition=Ready pod --all -n default --timeout=120s
-          kubectl get pods -A 
+          kubectl get pods -A
           kubectl describe pods -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/python/default_instrumentation_python_env_variables.json app_signals
 
@@ -114,7 +114,7 @@ jobs:
           kubectl apply -f integration-tests/dotnet/sample-deployment-dotnet.yaml
           sleep 5
           kubectl wait --for=condition=Available deployment/nginx -n default
-          kubectl get pods -A 
+          kubectl get pods -A
           kubectl describe pods -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/dotnet/default_instrumentation_dotnet_env_variables.json app_signals
 
@@ -123,7 +123,7 @@ jobs:
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
           kubectl delete pods --all -n default
           sleep 5
-          kubectl wait --for=condition=Ready pod --all -n default  
+          kubectl wait --for=condition=Ready pod --all -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals
           kubectl delete instrumentation sample-instrumentation
 
@@ -135,7 +135,7 @@ jobs:
           kubectl apply -f integration-tests/nodejs/sample-deployment-nodejs.yaml
           sleep 5
           kubectl wait --for=condition=Available deployment/nginx -n default
-          kubectl get pods -A 
+          kubectl get pods -A
           kubectl describe pods -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/nodejs/default_instrumentation_nodejs_env_variables.json app_signals
 
@@ -175,7 +175,7 @@ jobs:
           kubectl apply -f integration-tests/jmx/sample-deployment-jmx.yaml
           sleep 5
           kubectl wait --for=condition=Available deployment/nginx -n default
-          kubectl get pods -A 
+          kubectl get pods -A
           kubectl describe pods -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/jmx/default_instrumentation_jmx_env_variables.json app_signals
 
@@ -196,7 +196,7 @@ jobs:
           kubectl apply -f integration-tests/manifests/cloudwatch-agent-daemonset-no-app-signals.yaml -n amazon-cloudwatch
           sleep 20
           kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
-          
+
           pod_name="$(kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/component=amazon-cloudwatch-agent,app.kubernetes.io/instance=amazon-cloudwatch.cloudwatch-agent -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
           if [ -z "$pod_name" ]; then
             echo "Pod $pod_name is not created. Exiting with ERROR."
@@ -214,7 +214,7 @@ jobs:
           kubectl apply -f integration-tests/jmx/sample-deployment-jmx.yaml
           sleep 5
           kubectl wait --for=condition=Available deployment/nginx -n default
-          kubectl get pods -A 
+          kubectl get pods -A
           kubectl describe pods -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/jmx/default_instrumentation_jmx_env_variables_no_app_signals.json no_app_signals
 
@@ -435,4 +435,4 @@ jobs:
           sleep 5
           go test -v -run TestNodeJSOnlyNamespace ./integration-tests/manifests/annotations -timeout 30m
           sleep 5
-          go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 45m
+          go test -v -run TestAlreadyAutoAnnotatedResourceShouldNotRestart ./integration-tests/manifests/annotations -timeout 30m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,8 @@
-# Build the manager binary
-FROM golang:1.23 as builder
+# syntax=docker/dockerfile:1.4
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 
-# set goproxy=direct
-ENV GOPROXY direct
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY controllers/ controllers/
-COPY internal/ internal/
-COPY pkg/ pkg/
-COPY versions.txt versions.txt
-
+# Set build arguments early
+ARG TARGETARCH
 ARG VERSION_PKG
 ARG VERSION
 ARG VERSION_DATE
@@ -32,14 +15,45 @@ ARG DCMG_EXPORTER_VERSION
 ARG NEURON_MONITOR_VERSION
 ARG TARGET_ALLOCATOR_VERSION
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -ldflags="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.agent=${AGENT_VERSION} -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION} -X ${VERSION_PKG}.autoInstrumentationPython=${AUTO_INSTRUMENTATION_PYTHON_VERSION} -X ${VERSION_PKG}.autoInstrumentationDotNet=${AUTO_INSTRUMENTATION_DOTNET_VERSION} -X ${VERSION_PKG}.autoInstrumentationNodeJS=${AUTO_INSTRUMENTATION_NODEJS_VERSION} -X ${VERSION_PKG}.dcgmExporter=${DCMG_EXPORTER_VERSION} -X ${VERSION_PKG}.neuronMonitor=${NEURON_MONITOR_VERSION} -X ${VERSION_PKG}.targetAllocator=${TARGET_ALLOCATOR_VERSION}" -a -o manager main.go
+# Set environment variables
+ENV GOPROXY="https://proxy.golang.org,direct" \
+    GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=$TARGETARCH \
+    GOPRIVATE="" \
+    GOSUMDB=off
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
+WORKDIR /workspace
+
+# Download dependencies with cache mount
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+# Copy only necessary files
+COPY . .
+
+# Build with cache mount
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build \
+    -trimpath \
+    -ldflags="-w -s \
+    -X ${VERSION_PKG}.version=${VERSION} \
+    -X ${VERSION_PKG}.buildDate=${VERSION_DATE} \
+    -X ${VERSION_PKG}.agent=${AGENT_VERSION} \
+    -X ${VERSION_PKG}.autoInstrumentationJava=${AUTO_INSTRUMENTATION_JAVA_VERSION} \
+    -X ${VERSION_PKG}.autoInstrumentationPython=${AUTO_INSTRUMENTATION_PYTHON_VERSION} \
+    -X ${VERSION_PKG}.autoInstrumentationDotNet=${AUTO_INSTRUMENTATION_DOTNET_VERSION} \
+    -X ${VERSION_PKG}.autoInstrumentationNodeJS=${AUTO_INSTRUMENTATION_NODEJS_VERSION} \
+    -X ${VERSION_PKG}.dcgmExporter=${DCMG_EXPORTER_VERSION} \
+    -X ${VERSION_PKG}.neuronMonitor=${NEURON_MONITOR_VERSION} \
+    -X ${VERSION_PKG}.targetAllocator=${TARGET_ALLOCATOR_VERSION}" \
+    -o manager main.go
+
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
-
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
     go build \
     -trimpath \
-    -ldflags="-w -s \
+    -ldflags="\
     -X ${VERSION_PKG}.version=${VERSION} \
     -X ${VERSION_PKG}.buildDate=${VERSION_DATE} \
     -X ${VERSION_PKG}.agent=${AGENT_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV GOPROXY="https://proxy.golang.org,direct" \
     GOOS=linux \
     GOARCH=$TARGETARCH \
     GOPRIVATE="" \
-    GOSUMDB=off
+    GOSUMDB=on
 
 WORKDIR /workspace
 

--- a/integration-tests/util/util.go
+++ b/integration-tests/util/util.go
@@ -15,8 +15,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const TimoutDuration = 2 * time.Minute
-const TimeBetweenRetries = 2 * time.Second
+const TimoutDuration = 3 * time.Minute
+const TimeBetweenRetries = 5 * time.Second
 
 // WaitForNewPodCreation takes in a resource either Deployment, DaemonSet, or StatefulSet wait until it is in running stage
 func WaitForNewPodCreation(clientSet *kubernetes.Clientset, resource interface{}, startTime time.Time) error {


### PR DESCRIPTION
*Description of changes:*
Adding a retry to `go mod download` in the dockerfile.  

This should help prevent flakiness in the MakeContainerImage step of the E2E tests

Increases timeout in test: `TestAlreadyAutoAnnotatedResourceShouldNotRestart`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
