### PR TITLE
Remove unused prometheus annotation on the cloudwatch agent

### DIFF
--- a/internal/manifests/collector/annotations.go
+++ b/internal/manifests/collector/annotations.go
@@ -15,17 +15,18 @@ func Annotations(instance v1alpha1.AmazonCloudWatchAgent) map[string]string {
 	// new map every time, so that we don't touch the instance's annotations
 	annotations := map[string]string{}
 
-	// set default prometheus annotations
-	annotations["prometheus.io/scrape"] = "true"
-	annotations["prometheus.io/port"] = "8888"
-	annotations["prometheus.io/path"] = "/metrics"
+	// do not set default prometheus annotations as the cw agent does not expose a prometheus metrics endpoint
+	// annotations["prometheus.io/scrape"] = "true"
+	// annotations["prometheus.io/port"] = "8888"
+	// annotations["prometheus.io/path"] = "/metrics"
 
-	// allow override of prometheus annotations
+	// allow override of annotations
 	if nil != instance.Annotations {
 		for k, v := range instance.Annotations {
 			annotations[k] = v
 		}
 	}
+
 	// make sure sha256 for configMap is always calculated
 	annotations["amazon-cloudwatch-agent-operator-config/sha256"] = getConfigMapSHA(instance.Spec.Config)
 

--- a/internal/manifests/collector/annotations_test.go
+++ b/internal/manifests/collector/annotations_test.go
@@ -29,14 +29,8 @@ func TestDefaultAnnotations(t *testing.T) {
 	podAnnotations := PodAnnotations(otelcol)
 
 	//verify
-	assert.Equal(t, "true", annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", annotations["prometheus.io/path"])
 	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", annotations["amazon-cloudwatch-agent-operator-config/sha256"])
 	//verify propagation from metadata.annotations to spec.template.spec.metadata.annotations
-	assert.Equal(t, "true", podAnnotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", podAnnotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", podAnnotations["prometheus.io/path"])
 	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", podAnnotations["amazon-cloudwatch-agent-operator-config/sha256"])
 }
 
@@ -46,9 +40,7 @@ func TestUserAnnotations(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-instance",
 			Namespace: "my-ns",
-			Annotations: map[string]string{"prometheus.io/scrape": "false",
-				"prometheus.io/port":                             "1234",
-				"prometheus.io/path":                             "/test",
+			Annotations: map[string]string{
 				"amazon-cloudwatch-agent-operator-config/sha256": "shouldBeOverwritten",
 			},
 		},
@@ -62,9 +54,6 @@ func TestUserAnnotations(t *testing.T) {
 	podAnnotations := PodAnnotations(otelcol)
 
 	//verify
-	assert.Equal(t, "false", annotations["prometheus.io/scrape"])
-	assert.Equal(t, "1234", annotations["prometheus.io/port"])
-	assert.Equal(t, "/test", annotations["prometheus.io/path"])
 	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", annotations["amazon-cloudwatch-agent-operator-config/sha256"])
 	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08", podAnnotations["amazon-cloudwatch-agent-operator-config/sha256"])
 }
@@ -85,7 +74,7 @@ func TestAnnotationsPropagateDown(t *testing.T) {
 	podAnnotations := PodAnnotations(otelcol)
 
 	// verify
-	assert.Len(t, annotations, 5)
+	assert.Len(t, annotations, 2)
 	assert.Equal(t, "mycomponent", annotations["myapp"])
 	assert.Equal(t, "mycomponent", podAnnotations["myapp"])
 	assert.Equal(t, "pod_annotation_value", podAnnotations["pod_annotation"])

--- a/internal/manifests/collector/daemonset_test.go
+++ b/internal/manifests/collector/daemonset_test.go
@@ -42,9 +42,6 @@ func TestDaemonSetNewDefault(t *testing.T) {
 	// verify
 	assert.Equal(t, "my-instance", d.Name)
 	assert.Equal(t, "my-instance", d.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", d.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", d.Annotations["prometheus.io/path"])
 	assert.Equal(t, testTolerationValues, d.Spec.Template.Spec.Tolerations)
 
 	assert.Len(t, d.Spec.Template.Spec.Containers, 1)
@@ -52,9 +49,6 @@ func TestDaemonSetNewDefault(t *testing.T) {
 	// verify sha256 podAnnotation
 	expectedAnnotations := map[string]string{
 		"amazon-cloudwatch-agent-operator-config/sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		"prometheus.io/path":                             "/metrics",
-		"prometheus.io/port":                             "8888",
-		"prometheus.io/scrape":                           "true",
 	}
 	assert.Equal(t, expectedAnnotations, d.Spec.Template.Annotations)
 
@@ -146,9 +140,6 @@ func TestDaemonsetPodAnnotations(t *testing.T) {
 	expectedAnnotations := map[string]string{
 		"annotation-key": "annotation-value",
 		"amazon-cloudwatch-agent-operator-config/sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		"prometheus.io/path":                             "/metrics",
-		"prometheus.io/port":                             "8888",
-		"prometheus.io/scrape":                           "true",
 	}
 
 	// verify
@@ -373,9 +364,6 @@ func TestDaemonSetInitContainer(t *testing.T) {
 	d := DaemonSet(params)
 	assert.Equal(t, "my-instance", d.Name)
 	assert.Equal(t, "my-instance", d.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", d.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", d.Annotations["prometheus.io/path"])
 	assert.Len(t, d.Spec.Template.Spec.InitContainers, 1)
 }
 
@@ -406,9 +394,6 @@ func TestDaemonSetAdditionalContainer(t *testing.T) {
 	d := DaemonSet(params)
 	assert.Equal(t, "my-instance", d.Name)
 	assert.Equal(t, "my-instance", d.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", d.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", d.Annotations["prometheus.io/path"])
 	assert.Len(t, d.Spec.Template.Spec.Containers, 2)
 	assert.Equal(t, v1.Container{Name: "test"}, d.Spec.Template.Spec.Containers[0])
 }

--- a/internal/manifests/collector/deployment_test.go
+++ b/internal/manifests/collector/deployment_test.go
@@ -82,9 +82,6 @@ func TestDeploymentNewDefault(t *testing.T) {
 	// verify
 	assert.Equal(t, "my-instance", d.Name)
 	assert.Equal(t, "my-instance", d.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", d.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", d.Annotations["prometheus.io/path"])
 	assert.Equal(t, testTolerationValues, d.Spec.Template.Spec.Tolerations)
 
 	assert.Len(t, d.Spec.Template.Spec.Containers, 1)
@@ -92,9 +89,6 @@ func TestDeploymentNewDefault(t *testing.T) {
 	// verify sha256 podAnnotation
 	expectedAnnotations := map[string]string{
 		"amazon-cloudwatch-agent-operator-config/sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		"prometheus.io/path":                             "/metrics",
-		"prometheus.io/port":                             "8888",
-		"prometheus.io/scrape":                           "true",
 	}
 	assert.Equal(t, expectedAnnotations, d.Spec.Template.Annotations)
 
@@ -150,9 +144,6 @@ func TestDeploymentPodAnnotations(t *testing.T) {
 	expectedPodAnnotationValues := map[string]string{
 		"annotation-key": "annotation-value",
 		"amazon-cloudwatch-agent-operator-config/sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		"prometheus.io/path":                             "/metrics",
-		"prometheus.io/port":                             "8888",
-		"prometheus.io/scrape":                           "true",
 	}
 
 	// verify
@@ -463,9 +454,6 @@ func TestDeploymentSetInitContainer(t *testing.T) {
 	d := Deployment(params)
 	assert.Equal(t, "my-instance", d.Name)
 	assert.Equal(t, "my-instance", d.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", d.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", d.Annotations["prometheus.io/path"])
 	assert.Len(t, d.Spec.Template.Spec.InitContainers, 1)
 }
 
@@ -539,9 +527,6 @@ func TestDeploymentAdditionalContainers(t *testing.T) {
 	d := Deployment(params)
 	assert.Equal(t, "my-instance", d.Name)
 	assert.Equal(t, "my-instance", d.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", d.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", d.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", d.Annotations["prometheus.io/path"])
 	assert.Len(t, d.Spec.Template.Spec.Containers, 2)
 	assert.Equal(t, v1.Container{Name: "test"}, d.Spec.Template.Spec.Containers[0])
 }

--- a/internal/manifests/collector/statefulset_test.go
+++ b/internal/manifests/collector/statefulset_test.go
@@ -47,9 +47,6 @@ func TestStatefulSetNewDefault(t *testing.T) {
 	// verify
 	assert.Equal(t, "my-instance", ss.Name)
 	assert.Equal(t, "my-instance", ss.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", ss.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", ss.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", ss.Annotations["prometheus.io/path"])
 	assert.Equal(t, testTolerationValues, ss.Spec.Template.Spec.Tolerations)
 
 	assert.Len(t, ss.Spec.Template.Spec.Containers, 1)
@@ -57,9 +54,6 @@ func TestStatefulSetNewDefault(t *testing.T) {
 	// verify sha256 podAnnotation
 	expectedAnnotations := map[string]string{
 		"amazon-cloudwatch-agent-operator-config/sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		"prometheus.io/path":                             "/metrics",
-		"prometheus.io/port":                             "8888",
-		"prometheus.io/scrape":                           "true",
 	}
 	assert.Equal(t, expectedAnnotations, ss.Spec.Template.Annotations)
 
@@ -190,9 +184,6 @@ func TestStatefulSetPodAnnotations(t *testing.T) {
 	expectedAnnotations := map[string]string{
 		"annotation-key": "annotation-value",
 		"amazon-cloudwatch-agent-operator-config/sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		"prometheus.io/path":                             "/metrics",
-		"prometheus.io/port":                             "8888",
-		"prometheus.io/scrape":                           "true",
 	}
 	// verify
 	assert.Equal(t, "my-instance", ss.Name)
@@ -459,9 +450,6 @@ func TestStatefulSetInitContainer(t *testing.T) {
 	s := StatefulSet(params)
 	assert.Equal(t, "my-instance", s.Name)
 	assert.Equal(t, "my-instance", s.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", s.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", s.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", s.Annotations["prometheus.io/path"])
 	assert.Len(t, s.Spec.Template.Spec.InitContainers, 1)
 }
 
@@ -536,9 +524,6 @@ func TestStatefulSetAdditionalContainers(t *testing.T) {
 	s := StatefulSet(params)
 	assert.Equal(t, "my-instance", s.Name)
 	assert.Equal(t, "my-instance", s.Labels["app.kubernetes.io/name"])
-	assert.Equal(t, "true", s.Annotations["prometheus.io/scrape"])
-	assert.Equal(t, "8888", s.Annotations["prometheus.io/port"])
-	assert.Equal(t, "/metrics", s.Annotations["prometheus.io/path"])
 	assert.Len(t, s.Spec.Template.Spec.Containers, 2)
 	assert.Equal(t, v1.Container{Name: "test"}, s.Spec.Template.Spec.Containers[0])
 }


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/aws/amazon-cloudwatch-agent-operator/issues/190

*Description of changes:*
Remove prometheus annotations on the cloudwatch agent, as the agent does not expose a prometheus metrics endpoint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
