### PR TITLE
Not preserve the ownership of the files copied in the autoinstrumentation for dotnet

### DIFF
--- a/pkg/instrumentation/dotnet.go
+++ b/pkg/instrumentation/dotnet.go
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	dotNetCommandLinux   = []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath}
+	dotNetCommandLinux   = []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath}
 	dotNetCommandWindows = []string{"CMD", "/c", "xcopy", "/e", "autoinstrumentation\\*", dotnetInstrMountPathWindows}
 )
 

--- a/pkg/instrumentation/dotnet_test.go
+++ b/pkg/instrumentation/dotnet_test.go
@@ -49,7 +49,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 						{
 							Name:    "opentelemetry-auto-instrumentation-dotnet",
 							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      "opentelemetry-auto-instrumentation-dotnet",
 								MountPath: "/otel-auto-instrumentation-dotnet",
@@ -154,7 +154,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 						{
 							Name:    "opentelemetry-auto-instrumentation-dotnet",
 							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      "opentelemetry-auto-instrumentation-dotnet",
 								MountPath: "/otel-auto-instrumentation-dotnet",
@@ -383,7 +383,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: "/otel-auto-instrumentation-dotnet",
@@ -462,7 +462,7 @@ func TestInjectDotNetSDK(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "foo/bar:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", "/otel-auto-instrumentation-dotnet"},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: "/otel-auto-instrumentation-dotnet",

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -1786,7 +1786,7 @@ func TestMutatePod(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
@@ -1965,7 +1965,7 @@ func TestMutatePod(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
@@ -2153,7 +2153,7 @@ func TestMutatePod(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
@@ -3429,7 +3429,7 @@ func TestMutatePod(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
@@ -4087,7 +4087,7 @@ func TestMutatePod(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,
@@ -4970,7 +4970,7 @@ func TestMutatePod(t *testing.T) {
 						{
 							Name:    dotnetInitContainerName,
 							Image:   "otel/dotnet:1",
-							Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+							Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      dotnetVolumeName,
 								MountPath: dotnetInstrMountPath,

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -1007,7 +1007,7 @@ func TestInjectDotNet(t *testing.T) {
 				{
 					Name:    dotnetInitContainerName,
 					Image:   "img:1",
-					Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+					Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      dotnetVolumeName,
 						MountPath: dotnetInstrMountPath,
@@ -1192,7 +1192,7 @@ func TestInjectJavaPythonAndDotNet(t *testing.T) {
 				{
 					Name:    dotnetInitContainerName,
 					Image:   "img:1",
-					Command: []string{"cp", "-a", "/autoinstrumentation/.", dotnetInstrMountPath},
+					Command: []string{"cp", "-r", "/autoinstrumentation/.", dotnetInstrMountPath},
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      dotnetVolumeName,
 						MountPath: dotnetInstrMountPath,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-cloudwatch-agent-operator/issues/305

*Description of changes:* Use `cp -r` instead of `cp -a` as we dont need to preserve permissions or timestamps when copying over the autoinstrumentation sdk.

Similar to https://github.com/open-telemetry/opentelemetry-operator/pull/2695.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
