### PR TITLE
Set goproxy to "direct" in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG NEURON_MONITOR_VERSION
 ARG TARGET_ALLOCATOR_VERSION
 
 # Set environment variables
-ENV GOPROXY="https://proxy.golang.org,direct" \
+ENV GOPROXY="direct" \
     GO111MODULE=on \
     CGO_ENABLED=0 \
     GOOS=linux \


### PR DESCRIPTION
## Details

Fixes build failure when running `make container`.

Removed `GOPROXY="https://proxy.golang.org"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
