### PR TITLE
Fix test 1 33

### DIFF
--- a/integration-tests/terraform/eks/main.tf
+++ b/integration-tests/terraform/eks/main.tf
@@ -41,7 +41,7 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type = var.k8s_version >= "1.33" ? "AL2023_x86_64" : "AL2_x86_64"
+  ami_type = var.k8s_version >= "1.33" ? "AL2023_x86_64_STANDARD" : "AL2_x86_64"
   capacity_type  = "ON_DEMAND"
   disk_size      = 20
   instance_types = ["t3.medium"]

--- a/integration-tests/terraform/eks/main.tf
+++ b/integration-tests/terraform/eks/main.tf
@@ -41,7 +41,7 @@ resource "aws_eks_node_group" "this" {
     min_size     = 1
   }
 
-  ami_type       = "AL2_x86_64"
+  ami_type = var.k8s_version >= "1.33" ? "AL2023_x86_64" : "AL2_x86_64"
   capacity_type  = "ON_DEMAND"
   disk_size      = 20
   instance_types = ["t3.medium"]


### PR DESCRIPTION
*Description of changes:*
Our EKS addon integration test is failing for k8s version 1.33. This is because we are using AL2 which is only supported on 1.32 or earlier. We need to modify our tests to use AL2023 for 1.33 and after.

Tested in https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/15309748285/job/43071353694


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
