### PR TITLE
Remove B3 propagator from default instrumentation

### DIFF
--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Test for default instrumentation resources for Java
         run: |
           kubectl apply -f integration-tests/java/sample-deployment-java.yaml
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Ready pod --all -n default
           kubectl get pods -A
           kubectl describe pods -n default
@@ -84,7 +84,7 @@ jobs:
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
           kubectl delete pods --all -n default
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Ready pod --all -n default
 
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals
@@ -93,7 +93,7 @@ jobs:
       - name: Test for default instrumentation resources for python
         run: |
           kubectl apply -f integration-tests/python/sample-deployment-python.yaml
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Ready pod --all -n default --timeout=120s
           kubectl get pods -A
           kubectl describe pods -n default
@@ -103,7 +103,7 @@ jobs:
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
           kubectl delete pods --all -n default
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Ready pod --all -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals
           kubectl delete instrumentation sample-instrumentation
@@ -112,7 +112,7 @@ jobs:
         run: |
           cat integration-tests/dotnet/sample-deployment-dotnet.yaml
           kubectl apply -f integration-tests/dotnet/sample-deployment-dotnet.yaml
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Available deployment/nginx -n default
           kubectl get pods -A
           kubectl describe pods -n default
@@ -122,7 +122,7 @@ jobs:
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
           kubectl delete pods --all -n default
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Ready pod --all -n default
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals
           kubectl delete instrumentation sample-instrumentation
@@ -130,10 +130,10 @@ jobs:
       - name: Test for default instrumentation resources for nodejs
         run: |
           kubectl delete pods --all -n default
-          sleep 5
+          sleep 15
           cat integration-tests/nodejs/sample-deployment-nodejs.yaml
           kubectl apply -f integration-tests/nodejs/sample-deployment-nodejs.yaml
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Available deployment/nginx -n default
           kubectl get pods -A
           kubectl describe pods -n default
@@ -143,27 +143,27 @@ jobs:
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
           kubectl delete pods --all -n default
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Available deployment/nginx -n default
-          sleep 5
+          sleep 15
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals
           kubectl delete instrumentation sample-instrumentation
 
       - name: Test for default instrumentation resources for all languages
         run: |
           kubectl apply -f integration-tests/all-languages/sample-deployment-all-languages.yaml
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Available deployment/nginx -n default
-          sleep 5
+          sleep 15
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/all-languages/default_instrumentation_all-languages_env_variables.json app_signals
 
       - name: Test for defined instrumentation resources for all languages
         run: |
           kubectl apply -f integration-tests/manifests/sample-instrumentation.yaml
           kubectl delete pods --all -n default
-          sleep 5
+          sleep 15
           kubectl wait --for=condition=Available deployment/nginx -n default
-          sleep 5
+          sleep 15
           go run integration-tests/manifests/cmd/validate_instrumentation_vars.go default integration-tests/manifests/cmd/ns_instrumentation_env_variables.json app_signals
           kubectl delete instrumentation sample-instrumentation
 

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -99,7 +99,6 @@ func getDefaultInstrumentation(agentConfig *adapters.CwaConfig, additionalEnvs m
 			Propagators: []v1alpha1.Propagator{
 				v1alpha1.TraceContext,
 				v1alpha1.Baggage,
-				v1alpha1.B3,
 				v1alpha1.XRay,
 			},
 			Java: v1alpha1.Java{

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -56,7 +56,6 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 			Propagators: []v1alpha1.Propagator{
 				v1alpha1.TraceContext,
 				v1alpha1.Baggage,
-				v1alpha1.B3,
 				v1alpha1.XRay,
 			},
 			Java: v1alpha1.Java{
@@ -180,7 +179,6 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 			Propagators: []v1alpha1.Propagator{
 				v1alpha1.TraceContext,
 				v1alpha1.Baggage,
-				v1alpha1.B3,
 				v1alpha1.XRay,
 			},
 			Java: v1alpha1.Java{
@@ -388,7 +386,6 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 			Propagators: []v1alpha1.Propagator{
 				v1alpha1.TraceContext,
 				v1alpha1.Baggage,
-				v1alpha1.B3,
 				v1alpha1.XRay,
 			},
 			Java: v1alpha1.Java{
@@ -512,7 +509,6 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 			Propagators: []v1alpha1.Propagator{
 				v1alpha1.TraceContext,
 				v1alpha1.Baggage,
-				v1alpha1.B3,
 				v1alpha1.XRay,
 			},
 			Java: v1alpha1.Java{
@@ -716,7 +712,6 @@ func Test_getDefaultInstrumentationLinuxWithApplicationSignalsDisabled(t *testin
 			Propagators: []v1alpha1.Propagator{
 				v1alpha1.TraceContext,
 				v1alpha1.Baggage,
-				v1alpha1.B3,
 				v1alpha1.XRay,
 			},
 			Java: v1alpha1.Java{
@@ -797,7 +792,6 @@ func Test_getDefaultInstrumentationLinuxWithApplicationSignalsDisabled(t *testin
 			Propagators: []v1alpha1.Propagator{
 				v1alpha1.TraceContext,
 				v1alpha1.Baggage,
-				v1alpha1.B3,
 				v1alpha1.XRay,
 			},
 			Java: v1alpha1.Java{


### PR DESCRIPTION
### Changes
B3 propagator is both no longer needed and a blocker as it currently overrides trace state and baggage which are needed for the new adaptive sampling feature.

Updated sleep time in integ test to ensure destroyed resources have had time to properly terminate. See the following run as an example of the test fetching the wrong pod: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/17743921110/job/50426338932#step:11:248

This filter is not working effectively: https://github.com/aws/amazon-cloudwatch-agent-operator/blob/main/integration-tests/manifests/cmd/validate_instrumentation_vars.go#L65

### Testing
Tested removal of B3 in Java-based sample environments by passing OTEL_PROPAGATORS environment variable with `tracecontext,baggage,xray` (in no specific order), ensuring no impact if B3 is removed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
