### PR TITLE
fix: add restricted-compliant securityContext to Java init container

### DIFF
--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -220,7 +220,8 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
-							Resources: testResourceRequirements,
+							Resources:       testResourceRequirements,
+							SecurityContext: restrictedSecurityContext,
 						},
 					},
 					Containers: []corev1.Container{
@@ -408,7 +409,8 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
-							Resources: testResourceRequirements,
+							Resources:       testResourceRequirements,
+							SecurityContext: restrictedSecurityContext,
 						},
 					},
 					Containers: []corev1.Container{
@@ -3407,6 +3409,7 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
+							SecurityContext: restrictedSecurityContext,
 						},
 						{
 							Name:    nodejsInitContainerName,
@@ -4065,6 +4068,7 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
+							SecurityContext: restrictedSecurityContext,
 						},
 						{
 							Name:    nodejsInitContainerName,

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -220,7 +220,8 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
-							Resources: testResourceRequirements,
+							Resources:       testResourceRequirements,
+							SecurityContext: restrictedSecurityContext,
 						},
 					},
 					Containers: []corev1.Container{
@@ -408,7 +409,8 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
-							Resources: testResourceRequirements,
+							Resources:       testResourceRequirements,
+							SecurityContext: restrictedSecurityContext,
 						},
 					},
 					Containers: []corev1.Container{
@@ -3403,6 +3405,7 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
+							SecurityContext: restrictedSecurityContext,
 						},
 						{
 							Name:    nodejsInitContainerName,
@@ -4061,6 +4064,7 @@ func TestMutatePod(t *testing.T) {
 								Name:      javaVolumeName,
 								MountPath: javaInstrMountPath,
 							}},
+							SecurityContext: restrictedSecurityContext,
 						},
 						{
 							Name:    nodejsInitContainerName,

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
@@ -99,9 +100,11 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 			} else {
 				pod = i.injectCommonEnvVar(otelinst, pod, index)
 				pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index, index)
-				//disable setting security context in init container due to issue with runAsNonRoot conflict
-				//https://github.com/open-telemetry/opentelemetry-operator/issues/2272
-				//pod = i.setInitContainerSecurityContext(pod, pod.Spec.Containers[index].SecurityContext, javaInitContainerName)
+
+				// Set a minimal restricted-compliant securityContext without runAsNonRoot/runAsUser
+				// to avoid the runAsNonRoot conflict (https://github.com/open-telemetry/opentelemetry-operator/issues/2272)
+				// while still satisfying the restricted Pod Security Standard.
+				pod = i.setInitContainerRestrictedSecurityContext(pod, javaInitContainerName)
 			}
 		}
 	}
@@ -297,6 +300,23 @@ func (i *sdkInjector) setInitContainerSecurityContext(pod corev1.Pod, securityCo
 		}
 	}
 
+	return pod
+}
+
+func (i *sdkInjector) setInitContainerRestrictedSecurityContext(pod corev1.Pod, instrInitContainerName string) corev1.Pod {
+	for idx, initContainer := range pod.Spec.InitContainers {
+		if initContainer.Name == instrInitContainerName {
+			pod.Spec.InitContainers[idx].SecurityContext = &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.To(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
+		}
+	}
 	return pod
 }
 

--- a/pkg/instrumentation/sdk.go
+++ b/pkg/instrumentation/sdk.go
@@ -99,9 +99,8 @@ func (i *sdkInjector) inject(ctx context.Context, insts languageInstrumentations
 			} else {
 				pod = i.injectCommonEnvVar(otelinst, pod, index)
 				pod = i.injectCommonSDKConfig(ctx, otelinst, ns, pod, index, index)
-				//disable setting security context in init container due to issue with runAsNonRoot conflict
-				//https://github.com/open-telemetry/opentelemetry-operator/issues/2272
-				//pod = i.setInitContainerSecurityContext(pod, pod.Spec.Containers[index].SecurityContext, javaInitContainerName)
+
+				pod = i.setJavaInitContainerSecurityContext(pod, pod.Spec.Containers[index].SecurityContext, javaInitContainerName)
 			}
 		}
 	}
@@ -293,7 +292,47 @@ func isOtcContainer(container corev1.Container) bool {
 func (i *sdkInjector) setInitContainerSecurityContext(pod corev1.Pod, securityContext *corev1.SecurityContext, instrInitContainerName string) corev1.Pod {
 	for i, initContainer := range pod.Spec.InitContainers {
 		if initContainer.Name == instrInitContainerName {
-			pod.Spec.InitContainers[i].SecurityContext = securityContext
+			// Copy, so later edits to the init container's context cannot leak into the
+			// instrumented container through a shared pointer.
+			pod.Spec.InitContainers[i].SecurityContext = securityContext.DeepCopy()
+		}
+	}
+
+	return pod
+}
+
+// setJavaInitContainerSecurityContext derives the Java init container's securityContext from the
+// instrumented container, keeping user-specified fields such as readOnlyRootFilesystem or
+// seLinuxOptions, but dropping runAsNonRoot/runAsUser: the Java agent image runs as root and would
+// otherwise conflict with them (https://github.com/open-telemetry/opentelemetry-operator/issues/2272).
+// Fields required by the restricted Pod Security Standard are defaulted when the instrumented
+// container leaves them unset, so injection stays valid in namespaces enforcing "restricted".
+func (i *sdkInjector) setJavaInitContainerSecurityContext(pod corev1.Pod, securityContext *corev1.SecurityContext, instrInitContainerName string) corev1.Pod {
+	initSecurityContext := securityContext.DeepCopy()
+	if initSecurityContext == nil {
+		initSecurityContext = &corev1.SecurityContext{}
+	}
+
+	initSecurityContext.RunAsNonRoot = nil
+	initSecurityContext.RunAsUser = nil
+
+	if initSecurityContext.AllowPrivilegeEscalation == nil {
+		initSecurityContext.AllowPrivilegeEscalation = new(false)
+	}
+	if initSecurityContext.Capabilities == nil {
+		initSecurityContext.Capabilities = &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		}
+	}
+	if initSecurityContext.SeccompProfile == nil {
+		initSecurityContext.SeccompProfile = &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		}
+	}
+
+	for idx, initContainer := range pod.Spec.InitContainers {
+		if initContainer.Name == instrInitContainerName {
+			pod.Spec.InitContainers[idx].SecurityContext = initSecurityContext.DeepCopy()
 		}
 	}
 

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -17,6 +17,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/aws/amazon-cloudwatch-agent-operator/apis/v1alpha1"
 )
@@ -31,6 +32,16 @@ var testResourceRequirements = corev1.ResourceRequirements{
 	Requests: corev1.ResourceList{
 		corev1.ResourceCPU:    resource.MustParse("500m"),
 		corev1.ResourceMemory: resource.MustParse("128Mi"),
+	},
+}
+
+var restrictedSecurityContext = &corev1.SecurityContext{
+	AllowPrivilegeEscalation: ptr.To(false),
+	Capabilities: &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+	},
+	SeccompProfile: &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
 	},
 }
 
@@ -529,7 +540,8 @@ func TestInjectJava(t *testing.T) {
 						Name:      javaVolumeName,
 						MountPath: javaInstrMountPath,
 					}},
-					Resources: testResourceRequirements,
+					Resources:       testResourceRequirements,
+					SecurityContext: restrictedSecurityContext,
 				},
 			},
 			Containers: []corev1.Container{
@@ -876,7 +888,8 @@ func TestInjectJavaAndPython(t *testing.T) {
 						Name:      javaVolumeName,
 						MountPath: javaInstrMountPath,
 					}},
-					Resources: testResourceRequirements,
+					Resources:       testResourceRequirements,
+					SecurityContext: restrictedSecurityContext,
 				},
 				{
 					Name:    pythonInitContainerName,
@@ -1178,7 +1191,8 @@ func TestInjectJavaPythonAndDotNet(t *testing.T) {
 						Name:      javaVolumeName,
 						MountPath: javaInstrMountPath,
 					}},
-					Resources: testResourceRequirements,
+					Resources:       testResourceRequirements,
+					SecurityContext: restrictedSecurityContext,
 				},
 				{
 					Name:    pythonInitContainerName,

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -34,6 +34,16 @@ var testResourceRequirements = corev1.ResourceRequirements{
 	},
 }
 
+var restrictedSecurityContext = &corev1.SecurityContext{
+	AllowPrivilegeEscalation: new(false),
+	Capabilities: &corev1.Capabilities{
+		Drop: []corev1.Capability{"ALL"},
+	},
+	SeccompProfile: &corev1.SeccompProfile{
+		Type: corev1.SeccompProfileTypeRuntimeDefault,
+	},
+}
+
 func TestSDKInjection(t *testing.T) {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -529,7 +539,8 @@ func TestInjectJava(t *testing.T) {
 						Name:      javaVolumeName,
 						MountPath: javaInstrMountPath,
 					}},
-					Resources: testResourceRequirements,
+					Resources:       testResourceRequirements,
+					SecurityContext: restrictedSecurityContext,
 				},
 			},
 			Containers: []corev1.Container{
@@ -580,6 +591,106 @@ func TestInjectJava(t *testing.T) {
 			},
 		},
 	}, pod)
+}
+
+func TestInjectJavaSecurityContext(t *testing.T) {
+	inst := v1alpha1.Instrumentation{
+		Spec: v1alpha1.InstrumentationSpec{
+			Java: v1alpha1.Java{
+				Image:     "img:1",
+				Resources: testResourceRequirements,
+			},
+			Exporter: v1alpha1.Exporter{
+				Endpoint: "https://collector:4317",
+			},
+		},
+	}
+	insts := languageInstrumentations{
+		Java: instrumentationWithContainers{Instrumentation: &inst, Containers: ""},
+	}
+
+	for _, tt := range []struct {
+		name        string
+		containerSC *corev1.SecurityContext
+		expected    *corev1.SecurityContext
+	}{
+		{
+			name:        "no securityContext on the instrumented container",
+			containerSC: nil,
+			expected:    restrictedSecurityContext,
+		},
+		{
+			name: "runAsNonRoot and runAsUser are dropped, other fields are kept",
+			containerSC: &corev1.SecurityContext{
+				RunAsNonRoot:             new(true),
+				RunAsUser:                new(int64(1000)),
+				RunAsGroup:               new(int64(3000)),
+				AllowPrivilegeEscalation: new(false),
+				ReadOnlyRootFilesystem:   new(true),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+				SELinuxOptions: &corev1.SELinuxOptions{Level: "s0:c123,c456"},
+			},
+			expected: &corev1.SecurityContext{
+				RunAsGroup:               new(int64(3000)),
+				AllowPrivilegeEscalation: new(false),
+				ReadOnlyRootFilesystem:   new(true),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+				SELinuxOptions: &corev1.SELinuxOptions{Level: "s0:c123,c456"},
+			},
+		},
+		{
+			name: "restricted fields are defaulted when the container omits them",
+			containerSC: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem: new(true),
+			},
+			expected: &corev1.SecurityContext{
+				ReadOnlyRootFilesystem:   new(true),
+				AllowPrivilegeEscalation: new(false),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			inj := sdkInjector{
+				logger: logr.Discard(),
+			}
+			originalSC := tt.containerSC.DeepCopy()
+			pod := inj.inject(context.Background(), insts,
+				corev1.Namespace{},
+				corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:            "app",
+								Image:           "app:latest",
+								SecurityContext: tt.containerSC,
+							},
+						},
+					},
+				})
+
+			require.Len(t, pod.Spec.InitContainers, 1)
+			assert.Equal(t, tt.expected, pod.Spec.InitContainers[0].SecurityContext)
+			// The instrumented container's securityContext must not be modified, which
+			// a pointer shared with the init container would allow.
+			assert.Equal(t, originalSC, pod.Spec.Containers[0].SecurityContext)
+		})
+	}
 }
 
 func TestInjectNodeJS(t *testing.T) {
@@ -876,7 +987,8 @@ func TestInjectJavaAndPython(t *testing.T) {
 						Name:      javaVolumeName,
 						MountPath: javaInstrMountPath,
 					}},
-					Resources: testResourceRequirements,
+					Resources:       testResourceRequirements,
+					SecurityContext: restrictedSecurityContext,
 				},
 				{
 					Name:    pythonInitContainerName,
@@ -1178,7 +1290,8 @@ func TestInjectJavaPythonAndDotNet(t *testing.T) {
 						Name:      javaVolumeName,
 						MountPath: javaInstrMountPath,
 					}},
-					Resources: testResourceRequirements,
+					Resources:       testResourceRequirements,
+					SecurityContext: restrictedSecurityContext,
 				},
 				{
 					Name:    pythonInitContainerName,


### PR DESCRIPTION
Fixes #361

## Problem

The Java auto-instrumentation init container (`opentelemetry-auto-instrumentation-java`) is created without any `securityContext`, causing pod creation to fail in namespaces enforcing `pod-security.kubernetes.io/enforce: restricted`.

```
Error creating: pods "app-789564bdf9-c6wm4" is forbidden: violates PodSecurity
"restricted:latest": allowPrivilegeEscalation != false (container
"opentelemetry-auto-instrumentation-java" must set
securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container
"opentelemetry-auto-instrumentation-java" must set
securityContext.capabilities.drop=["ALL"]), seccompProfile (pod or container
"opentelemetry-auto-instrumentation-java" must set
securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```

Other languages (NodeJS, Python, DotNet, Apache) are not affected, because they all call `setInitContainerSecurityContext`, which copies the app container's security context onto the init container.

## Root Cause

In `pkg/instrumentation/sdk.go`, `setInitContainerSecurityContext` was commented out for Java to avoid a `runAsNonRoot` conflict with the root-based Java agent image (opentelemetry-operator#2272). However, this left the init container with no `securityContext` at all, violating the restricted Pod Security Standard.

## Fix

Added `setJavaInitContainerSecurityContext`, which derives the init container's context from the instrumented container instead of hardcoding one:

1. Deep-copy the instrumented container's `securityContext`, so user-specified fields (`readOnlyRootFilesystem`, `seLinuxOptions`, `runAsGroup`, `capabilities.add`, and so on) are preserved and behavior stays consistent with the other languages.
2. Strip `runAsNonRoot` and `runAsUser`, which are the fields that conflict with the root-based Java agent image (#2272).
3. Default the fields required by the restricted Pod Security Standard (`allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`, `seccompProfile.type: RuntimeDefault`), **only when the instrumented container leaves them unset**, so user values always win and a container with no `securityContext` at all still gets a compliant init container.

`setInitContainerSecurityContext` now deep-copies as well. It previously assigned the *same pointer* to both the init container and the instrumented container; stripping fields from a shared pointer would silently mutate the instrumented container. No behavior change today, since nothing mutated it before.

## Reproduction

1. Create namespace with `pod-security.kubernetes.io/enforce: restricted`
2. Install amazon-cloudwatch-observability EKS add-on
3. Deploy a Java app with `instrumentation.opentelemetry.io/inject-java: "true"` and a restricted-compliant `securityContext`
4. Observe `FailedCreate` event on the ReplicaSet

## Testing

- New `TestInjectJavaSecurityContext` covering three cases: no `securityContext` on the instrumented container (minimal restricted context applied), a full restricted context (`runAsNonRoot`/`runAsUser` dropped, everything else preserved), and a partial context (missing restricted fields defaulted). Each case also asserts the instrumented container's `securityContext` is not modified.
- Updated existing test cases that assert on the Java init container's expected pod spec (3 in `sdk_test.go`, 4 in `podmutator_test.go`) to include the resulting `securityContext`.
- `go build ./...`, `go vet ./...` and `go test ./pkg/instrumentation/...` pass.
