### PR TITLE
Bump Go version from 1.25.7 to 1.25.8

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "~1.25.7"
+        go-version: "~1.25.8"
 
     - name: Cache tools
       uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM golang:1.25.7 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.8 AS builder
 
 # Set build arguments early
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-cloudwatch-agent-operator
 
-go 1.25.7
+go 1.25.8
 
 retract v1.51.0
 


### PR DESCRIPTION
## Issue #, if available:

N/A

## Description of changes:

Bump Go version from 1.25.7 to 1.25.8:
- Updated Dockerfile to use golang:1.25.8
- Updated .github/workflows/pr-build-test.yml to use go-version: "~1.25.8"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms
of your choice.