### PR TITLE
Pin GitHub Actions to commit SHAs with exact patch versions

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -56,7 +56,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.target-sha }}
@@ -64,13 +64,13 @@ jobs:
 
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '>=1.25'
           cache: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: ${{inputs.region}}
@@ -78,18 +78,18 @@ jobs:
       - name: Login to ECR
         if: steps.cached_binaries.outputs.cache-hit == false
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
 
       - name: Set up Docker Buildx
         if: steps.cached_binaries.outputs.cache-hit == false
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up QEMU
         if: steps.cached_binaries.outputs.cache-hit == false
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Build Cloudwatch Agent Operator AMD64 Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         if: steps.cached_binaries.outputs.cache-hit == false
         with:
           file: ./Dockerfile
@@ -116,7 +116,7 @@ jobs:
           provenance: false
 
       - name: Build Cloudwatch Agent Operator ARM64 Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         if: steps.cached_binaries.outputs.cache-hit == false
         with:
           file: ./Dockerfile
@@ -149,20 +149,20 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.target-sha }}
           repository: ${{inputs.repository}}
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '>=1.25'
           cache: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: ${{inputs.region}}
@@ -170,15 +170,15 @@ jobs:
       - name: Login to ECR
         if: steps.cached_binaries.outputs.cache-hit == false
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
 
       - name: Set up Docker Buildx
         if: steps.cached_binaries.outputs.cache-hit == false
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Set up QEMU
         if: steps.cached_binaries.outputs.cache-hit == false
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
       - name: Build Binaries
         run: |
@@ -190,7 +190,7 @@ jobs:
           ls -la cmd/amazon-cloudwatch-agent-target-allocator/bin/
 
       - name: Build Target Allocator AMD64 Image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         if: steps.cached_binaries.outputs.cache-hit == false
         with:
           file: ./cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
@@ -205,7 +205,7 @@ jobs:
 
       - name: Build Target Allocator ARM64 Image
         if: steps.cached_binaries.outputs.cache-hit == false
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           file: ./cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
           context: ./cmd/amazon-cloudwatch-agent-target-allocator
@@ -248,12 +248,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: ${{inputs.region}}
@@ -261,7 +261,7 @@ jobs:
       - name: Login to ECR
         id: login-ecr
         if: steps.cached_binaries.outputs.cache-hit == false
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
 
       - name: Push image to release ECR
         run: |
@@ -276,26 +276,26 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.target-sha }}
           repository: ${{inputs.repository}}
 
       - name: Set up Go 1.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '>=1.25'
           cache: true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
           aws-region: ${{inputs.region}}
 
       - name: Login ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
 
       - name: Create manifests
         run: |

--- a/.github/workflows/eks-add-on-canary-test.yml
+++ b/.github/workflows/eks-add-on-canary-test.yml
@@ -24,12 +24,12 @@ jobs:
     outputs:
       eks_addon_matrix: ${{ steps.set-matrix.outputs.eks_addon_matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
@@ -51,23 +51,23 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.1.7"
 
       - name: Terraform apply
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 1
           timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
@@ -87,7 +87,7 @@ jobs:
 
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 3
           timeout_minutes: 8

--- a/.github/workflows/eks-add-on-integ-test.yml
+++ b/.github/workflows/eks-add-on-integ-test.yml
@@ -39,12 +39,12 @@ jobs:
     outputs:
       eks_addon_matrix: ${{ steps.set-matrix.outputs.eks_addon_matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
@@ -71,12 +71,12 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
@@ -97,7 +97,7 @@ jobs:
           fi
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.1.7"
           
@@ -105,7 +105,7 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 1
           timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
@@ -122,7 +122,7 @@ jobs:
 
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 3
           timeout_minutes: 8

--- a/.github/workflows/gpu-e2e-test.yml
+++ b/.github/workflows/gpu-e2e-test.yml
@@ -39,12 +39,12 @@ jobs:
     outputs:
       eks_addon_matrix: ${{ steps.set-matrix.outputs.eks_addon_matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
@@ -71,12 +71,12 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ env.TERRAFORM_AWS_ASSUME_ROLE }}
           aws-region: us-west-2
@@ -98,7 +98,7 @@ jobs:
           fi
           
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: "1.1.7"
 
@@ -106,7 +106,7 @@ jobs:
         run: terraform --version
 
       - name: Terraform apply
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 1
           timeout_minutes: 60 # EKS takes about 20 minutes to spin up a cluster and service on the cluster
@@ -123,7 +123,7 @@ jobs:
 
       - name: Terraform destroy
         if: ${{ cancelled() || failure() }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # v2.9.0
         with:
           max_attempts: 3
           timeout_minutes: 8

--- a/.github/workflows/operator-integration-test.yml
+++ b/.github/workflows/operator-integration-test.yml
@@ -28,12 +28,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
 
       - name: Deploy cert-manager to minikube
         run:
@@ -236,12 +236,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
 
       - name: Deploy cert-manager to minikube
         run:
@@ -289,12 +289,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
 
       - name: Deploy cert-manager to minikube
         run:
@@ -342,12 +342,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
 
       - name: Deploy cert-manager to minikube
         run:
@@ -396,12 +396,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        uses: medyagh/setup-minikube@e9e035a86bbc3caea26a450bd4dbf9d0c453682e # v0.0.21
 
       - name: Deploy cert-manager to minikube
         run:

--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           verbose: true
 
@@ -45,21 +45,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: "~1.25.8"
 
     - name: Cache tools
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       id: setup-go
       with:
         path: bin
         key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}-${{ steps.setup-go.outputs.go-version }}
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: |
           /home/runner/.cache/golangci-lint

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Send issue notification to Slack
         if: github.event_name == 'issues'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
           webhook-type: incoming-webhook
@@ -28,7 +28,7 @@ jobs:
 
       - name: Send pull request notification to Slack
         if: github.event_name == 'pull_request_target'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUE }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
*Description of changes:*

Pin all third-party GitHub Actions to full commit SHAs with exact patch version comments for traceability. Also standardizes actions to the highest major version already in use across workflows.

- 13 third-party actions pinned across 7 workflow files
- No functional or structural changes to workflows
- Cross-repo reusable workflows (@main) left as-is

Version upgrades (within-repo standardization):
- actions/checkout v3 → v4
- aws-actions/configure-aws-credentials v2 → v4
- aws-actions/amazon-ecr-login v1 → v2
- docker/setup-buildx-action v1 → v3
- docker/setup-qemu-action v1 → v3
- medyagh/setup-minikube master@ → v0.0.21

| Action | Version | SHA |
|--------|---------|-----|
| actions/cache | v4.3.0 | 0057852bfaa89a56745cba8c7296529d2fc39830 |
| actions/checkout | v4.3.1 | 34e114876b0b11c390a56381ad16ebd13914f8d5 |
| actions/setup-go | v5.6.0 | 40f1582b2485089dde7abd97c1529aa768e1baff |
| aws-actions/amazon-ecr-login | v2.1.1 | 183a1442edf41672e66566b7fc560e297a290896 |
| aws-actions/configure-aws-credentials | v4.3.1 | 7474bc4690e29a8392af63c5b98e7449536d5c3a |
| codecov/codecov-action | v3.1.6 | ab904c41d6ece82784817410c45d8b8c02684457 |
| docker/build-push-action | v4.2.1 | 0a97817b6ade9f46837855d676c4cca3a2471fc9 |
| docker/setup-buildx-action | v3.12.0 | 8d2750c68a42422c14e847fe6c8ac0403b4cbd6f |
| docker/setup-qemu-action | v3.7.0 | c7c53464625b32c7a7e944ae62b3e17d2b600130 |
| hashicorp/setup-terraform | v3.1.2 | b9cd54a3c349d3f38e8881555d616ced269862dd |
| medyagh/setup-minikube | v0.0.21 | e9e035a86bbc3caea26a450bd4dbf9d0c453682e |
| nick-fields/retry | v2.9.0 | 14672906e672a08bd6eeb15720e9ed3ce869cdd4 |
| slackapi/slack-github-action | v2.1.1 | 91efab103c0de0a537f72a35f6b8cda0ee76bf0a |

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
