### PR TITLE
Export ErrNoService and handle it as expected condition to prevent error log spam

### DIFF
--- a/internal/manifests/collector/adapters/config_to_probe.go
+++ b/internal/manifests/collector/adapters/config_to_probe.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	errNoService    = errors.New("no service available as part of the configuration")
+	ErrNoService    = errors.New("no service available as part of the configuration")
 	errNoExtensions = errors.New("no extensions available as part of the configuration")
 
 	errServiceNotAMap    = errors.New("service property in the configuration doesn't contain valid services")
@@ -40,7 +40,7 @@ const (
 func ConfigToContainerProbe(config map[interface{}]interface{}) (*corev1.Probe, error) {
 	serviceProperty, withService := config["service"]
 	if !withService {
-		return nil, errNoService
+		return nil, ErrNoService
 	}
 	service, withSvcProperty := serviceProperty.(map[interface{}]interface{})
 	if !withSvcProperty {

--- a/internal/manifests/collector/adapters/config_to_probe_test.go
+++ b/internal/manifests/collector/adapters/config_to_probe_test.go
@@ -159,7 +159,7 @@ service: [hi]`,
 			desc: "NoService",
 			config: `extensions:
   health_check:`,
-			expectedErr: errNoService,
+			expectedErr: ErrNoService,
 		},
 	}
 

--- a/internal/manifests/collector/container.go
+++ b/internal/manifests/collector/container.go
@@ -104,6 +104,8 @@ func Container(cfg config.Config, logger logr.Logger, agent v1alpha1.AmazonCloud
 			logger.Info("extensions not configured, skipping liveness probe creation")
 		} else if errors.Is(err, adapters.ErrNoServiceExtensionHealthCheck) {
 			logger.Info("healthcheck extension not configured, skipping liveness probe creation")
+		} else if errors.Is(err, adapters.ErrNoService) {
+			logger.Info("no service in otel config, skipping liveness probe creation")
 		} else {
 			logger.Error(err, "cannot create liveness probe.")
 		}

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -216,3 +216,21 @@ service:
 	assert.Equal(t, int32(13133), c.LivenessProbe.HTTPGet.Port.IntVal)
 	assert.Equal(t, "", c.LivenessProbe.HTTPGet.Host)
 }
+
+func TestContainerProbeNoService(t *testing.T) {
+	// prepare
+	otelcol := v1alpha1.AmazonCloudWatchAgent{
+		Spec: v1alpha1.AmazonCloudWatchAgentSpec{
+			OtelConfig: `extensions:
+  health_check:`,
+		},
+	}
+	cfg := config.New()
+
+	// test
+	c := Container(cfg, logger, otelcol, true)
+
+	// verify
+	assert.Nil(t, c.LivenessProbe)
+	assert.NotEmpty(t, c.Name)
+}


### PR DESCRIPTION
When the OTel config has no service block, ConfigToContainerProbe returns errNoService which was unexported and not matched by the sentinel error checks in Container(). This caused it to fall through to logger.Error() on every reconcile loop, spamming the operator logs with error-level messages and full stacktraces.

Export errNoService as ErrNoService and add a dedicated check in Container() that logs at Info level, consistent with how ErrNoServiceExtensions and ErrNoServiceExtensionHealthCheck are handled.

*Issue #, if available:*
https://github.com/aws/amazon-cloudwatch-agent-operator/issues/269

*Testing*
Tested on my dev cluster

Before fix (operator v3.3.3 — ERROR on every reconcile with full stacktrace):
{"level":"error","ts":"2026-04-10T11:11:59Z","logger":"controllers.AmazonCloudWatchAgent","msg":"cannot create liveness probe.","error":"no service available as part of the configuration","stacktrace":"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/collector.Container\n\t...container.go:108\n\t...daemonset.go:42\n\t...builder.go:20\n\t...collector.go:50\n\t...common.go:52\n\t...amazoncloudwatchagent_controller.go:183\n\t...controller.go:119\n\t...controller.go:340\n\t...controller.go:300\n\t...controller.go:202"}
{"level":"error","ts":"2026-04-10T11:11:59Z","logger":"controllers.AmazonCloudWatchAgent","msg":"cannot create liveness probe.","error":"no service available as part of the configuration","stacktrace":"..."}
{"level":"error","ts":"2026-04-10T15:04:02Z","logger":"controllers.AmazonCloudWatchAgent","msg":"cannot create liveness probe.","error":"no service available as part of the configuration","stacktrace":"..."}
(repeats on every reconcile loop indefinitely)

After fix (patched operator deployed to EKS my-dev-cluster — info level, no stacktrace):
{"level":"info","ts":"2026-04-10T17:47:28Z","logger":"controllers.AmazonCloudWatchAgent","msg":"no service in otel config, skipping liveness probe creation"}
{"level":"info","ts":"2026-04-10T17:47:28Z","logger":"controllers.AmazonCloudWatchAgent","msg":"hpa field is unset in Spec, skipping autoscaler creation"}



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
