### PR TITLE
Always include server port 4311 in Service

### DIFF
--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -19,6 +19,12 @@ var metricContainerPort = corev1.ContainerPort{
 	Protocol:      corev1.ProtocolTCP,
 }
 
+var serverContainerPort = corev1.ContainerPort{
+	Name:          Server,
+	ContainerPort: 4311,
+	Protocol:      corev1.ProtocolTCP,
+}
+
 var emfContainerPort = []corev1.ContainerPort{
 	{
 		Name:          "emf-tcp",
@@ -84,7 +90,7 @@ service:
 			description:   "bad otel spec config",
 			specConfig:    "🦄",
 			specPorts:     nil,
-			expectedPorts: emfContainerPort,
+			expectedPorts: append(emfContainerPort, serverContainerPort),
 		},
 		{
 			description: "couldn't build ports from spec config",
@@ -96,13 +102,13 @@ service:
 					Protocol: corev1.ProtocolTCP,
 				},
 			},
-			expectedPorts: append(emfContainerPort, metricContainerPort),
+			expectedPorts: append(emfContainerPort, serverContainerPort, metricContainerPort),
 		},
 		{
 			description: "ports in spec Config",
 			specConfig:  goodOtelConfig,
 			specPorts:   nil,
-			expectedPorts: append(emfContainerPort, corev1.ContainerPort{
+			expectedPorts: append(emfContainerPort, serverContainerPort, corev1.ContainerPort{
 				Name:          "examplereceiver",
 				ContainerPort: 12345,
 			}),

--- a/internal/manifests/collector/ports.go
+++ b/internal/manifests/collector/ports.go
@@ -126,6 +126,7 @@ func getContainerPorts(logger logr.Logger, cfg string, otelCfg string, specPorts
 func getServicePortsFromCWAgentConfig(logger logr.Logger, config *adapters.CwaConfig) []corev1.ServicePort {
 	servicePortsMap := make(map[int32][]corev1.ServicePort)
 
+	getReceiverServicePort(logger, "", Server, corev1.ProtocolTCP, servicePortsMap)
 	getApplicationSignalsReceiversServicePorts(logger, config, servicePortsMap)
 	getMetricsReceiversServicePorts(logger, config, servicePortsMap)
 	getLogsReceiversServicePorts(logger, config, servicePortsMap)
@@ -290,7 +291,6 @@ func getApplicationSignalsReceiversServicePorts(logger logr.Logger, config *adap
 	if isAppSignalEnabledMetrics(config) || isAppSignalEnabledTraces(config) {
 		getReceiverServicePort(logger, "", AppSignalsGrpc, corev1.ProtocolTCP, servicePortsMap)
 		getReceiverServicePort(logger, "", AppSignalsHttp, corev1.ProtocolTCP, servicePortsMap)
-		getReceiverServicePort(logger, "", Server, corev1.ProtocolTCP, servicePortsMap)
 	}
 
 	if isAppSignalEnabledTraces(config) {

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -15,7 +15,8 @@ import (
 func TestStatsDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/statsDAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(8135), containerPorts[CWA+StatsD].ContainerPort)
 	assert.Equal(t, CWA+StatsD, containerPorts[CWA+StatsD].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+StatsD].Protocol)
@@ -24,7 +25,8 @@ func TestStatsDGetContainerPorts(t *testing.T) {
 func TestDefaultStatsDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/statsDDefaultAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(8125), containerPorts[StatsD].ContainerPort)
 	assert.Equal(t, StatsD, containerPorts[StatsD].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[StatsD].Protocol)
@@ -33,7 +35,8 @@ func TestDefaultStatsDGetContainerPorts(t *testing.T) {
 func TestCollectDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/collectDAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(25936), containerPorts[CWA+CollectD].ContainerPort)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+CollectD].Protocol)
 }
@@ -41,7 +44,8 @@ func TestCollectDGetContainerPorts(t *testing.T) {
 func TestDefaultCollectDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/collectDDefaultAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(25826), containerPorts[CollectD].ContainerPort)
 	assert.Equal(t, CollectD, containerPorts[CollectD].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CollectD].Protocol)
@@ -134,7 +138,8 @@ func TestApplicationSignalsXRayTracesCustom(t *testing.T) {
 func TestXRayCustomUDP(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xRayCustomUDP.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
@@ -146,7 +151,8 @@ func TestXRayCustomUDP(t *testing.T) {
 func TestEMFGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/emfAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(25888), containerPorts[EMFTcp].ContainerPort)
 	assert.Equal(t, EMFTcp, containerPorts[EMFTcp].Name)
 	assert.Equal(t, int32(25888), containerPorts[EMFUdp].ContainerPort)
@@ -157,6 +163,11 @@ func TestEMFGetContainerPorts(t *testing.T) {
 func TestXrayAndOTLPGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAndOTLPAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          Server,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4311),
+		},
 		{
 			Name:          CWA + XrayTraces,
 			Protocol:      corev1.ProtocolUDP,
@@ -185,7 +196,8 @@ func TestXrayAndOTLPGetContainerPorts(t *testing.T) {
 func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAndOTLPDefaultAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, 5, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(2000), containerPorts[XrayTraces].ContainerPort)
 	assert.Equal(t, XrayTraces, containerPorts[XrayTraces].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[XrayTraces].Protocol)
@@ -203,7 +215,8 @@ func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
 func TestXRayGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
@@ -216,7 +229,8 @@ func TestXRayWithBindAddressDefaultGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAgentConfig.json")
 	cfg = strings.Replace(cfg, "2800", "2000", 1) // set Xray trace port to 2000
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(2000), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
@@ -228,7 +242,8 @@ func TestXRayWithTCPProxyBindAddressDefaultGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAgentConfig.json")
 	cfg = strings.Replace(cfg, "2900", "2000", 1) // set Xray proxy port to 2000
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, int32(2000), containerPorts[CWA+XrayProxy].ContainerPort)
@@ -239,7 +254,8 @@ func TestXRayWithTCPProxyBindAddressDefaultGetContainerPorts(t *testing.T) {
 func TestNilMetricsGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/nilMetrics.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 0, len(containerPorts))
+	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 }
 
 func TestMultipleReceiversGetContainerPorts(t *testing.T) {
@@ -319,7 +335,8 @@ func TestSpecPortsOverrideGetContainerPorts(t *testing.T) {
 		},
 	}
 	containerPorts := getContainerPorts(logger, cfg, "", specPorts)
-	assert.Equal(t, 3, len(containerPorts))
+	assert.Equal(t, 4, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(12345), containerPorts[AppSignalsGrpc].ContainerPort)
 	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
 	assert.Equal(t, int32(12346), containerPorts[AppSignalsProxy].ContainerPort)
@@ -340,6 +357,11 @@ func TestValidOTLPMetricsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpMetricsAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
 		{
+			Name:          Server,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4311),
+		},
+		{
 			Name:          OtlpGrpc + "-1234",
 			Protocol:      corev1.ProtocolTCP,
 			ContainerPort: int32(1234),
@@ -358,6 +380,11 @@ func TestValidOTLPLogsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpLogsAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
 		{
+			Name:          Server,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4311),
+		},
+		{
 			Name:          OtlpGrpc + "-1234",
 			Protocol:      corev1.ProtocolTCP,
 			ContainerPort: int32(1234),
@@ -375,6 +402,11 @@ func TestValidOTLPLogsPort(t *testing.T) {
 func TestValidOTLPLogsAndMetricsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpMetricsLogsAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          Server,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4311),
+		},
 		{
 			Name:          OtlpGrpc + "-1234",
 			Protocol:      corev1.ProtocolTCP,
@@ -479,7 +511,8 @@ func TestIsDuplicatePort(t *testing.T) {
 func TestJMXGetContainerPorts(t *testing.T) {
 	cfg := getJSONStringFromFile("./test-resources/jmxAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(4314), containerPorts[JmxHttp].ContainerPort)
 	assert.Equal(t, JmxHttp, containerPorts[JmxHttp].Name)
 	assert.Equal(t, corev1.ProtocolTCP, containerPorts[JmxHttp].Protocol)
@@ -488,7 +521,8 @@ func TestJMXGetContainerPorts(t *testing.T) {
 func TestJMXContainerInsightsGetContainerPorts(t *testing.T) {
 	cfg := getJSONStringFromFile("./test-resources/jmxContainerInsightsConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, 2, len(containerPorts))
+	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
 	assert.Equal(t, int32(4314), containerPorts[JmxHttp].ContainerPort)
 	assert.Equal(t, JmxHttp, containerPorts[JmxHttp].Name)
 	assert.Equal(t, corev1.ProtocolTCP, containerPorts[JmxHttp].Protocol)


### PR DESCRIPTION
*Issue #, if available:* The agent starts the server extension on `:4311` unconditionally in K8s mode, but the operator only included this port when Application Signals was enabled. This caused the `cloudwatch-agent` Service to not be created for Container Insights-only configurations, leading to fluent-bit DNS errors when trying to reach `cloudwatch-agent.amazon-cloudwatch:4311`.

*Description of changes:* Move the Server port from `getApplicationSignalsReceiversServicePorts` to `getServicePortsFromCWAgentConfig` so it is always present.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
