### PR TITLE
pin to commit before updates

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   java-eks-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@main
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@a4de9f9a4992e1f50f4d320c6bd670c9215a78a2
     secrets: inherit
     with:
       aws-region: us-east-1


### PR DESCRIPTION
*Issue #, if available:*
Application Signals jave eks e2e test is failing due to the addon using an older version of java SDK. example failure: https://github.com/aws/amazon-cloudwatch-agent-operator/actions/runs/24527396637/job/71821911131

*Description of changes:*
Pin to previous version of test suite only for java-eks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
