### PR TITLE
Revert port 4311 and GH workflow pinning changes

### DIFF
--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   java-eks-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@ce5d8f4a86568cc48c386fc156d56bc35b79ab33
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@a4de9f9a4992e1f50f4d320c6bd670c9215a78a2
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/.github/workflows/application-signals-e2e-test.yml
+++ b/.github/workflows/application-signals-e2e-test.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   java-eks-e2e-test:
-    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@a4de9f9a4992e1f50f4d320c6bd670c9215a78a2
+    uses: aws-observability/aws-application-signals-test-framework/.github/workflows/java-eks-test.yml@main
     secrets: inherit
     with:
       aws-region: us-east-1

--- a/internal/manifests/collector/container_test.go
+++ b/internal/manifests/collector/container_test.go
@@ -19,12 +19,6 @@ var metricContainerPort = corev1.ContainerPort{
 	Protocol:      corev1.ProtocolTCP,
 }
 
-var serverContainerPort = corev1.ContainerPort{
-	Name:          Server,
-	ContainerPort: 4311,
-	Protocol:      corev1.ProtocolTCP,
-}
-
 var emfContainerPort = []corev1.ContainerPort{
 	{
 		Name:          "emf-tcp",
@@ -90,7 +84,7 @@ service:
 			description:   "bad otel spec config",
 			specConfig:    "🦄",
 			specPorts:     nil,
-			expectedPorts: append(emfContainerPort, serverContainerPort),
+			expectedPorts: emfContainerPort,
 		},
 		{
 			description: "couldn't build ports from spec config",
@@ -102,13 +96,13 @@ service:
 					Protocol: corev1.ProtocolTCP,
 				},
 			},
-			expectedPorts: append(emfContainerPort, serverContainerPort, metricContainerPort),
+			expectedPorts: append(emfContainerPort, metricContainerPort),
 		},
 		{
 			description: "ports in spec Config",
 			specConfig:  goodOtelConfig,
 			specPorts:   nil,
-			expectedPorts: append(emfContainerPort, serverContainerPort, corev1.ContainerPort{
+			expectedPorts: append(emfContainerPort, corev1.ContainerPort{
 				Name:          "examplereceiver",
 				ContainerPort: 12345,
 			}),

--- a/internal/manifests/collector/ports.go
+++ b/internal/manifests/collector/ports.go
@@ -126,7 +126,6 @@ func getContainerPorts(logger logr.Logger, cfg string, otelCfg string, specPorts
 func getServicePortsFromCWAgentConfig(logger logr.Logger, config *adapters.CwaConfig) []corev1.ServicePort {
 	servicePortsMap := make(map[int32][]corev1.ServicePort)
 
-	getReceiverServicePort(logger, "", Server, corev1.ProtocolTCP, servicePortsMap)
 	getApplicationSignalsReceiversServicePorts(logger, config, servicePortsMap)
 	getMetricsReceiversServicePorts(logger, config, servicePortsMap)
 	getLogsReceiversServicePorts(logger, config, servicePortsMap)
@@ -291,6 +290,7 @@ func getApplicationSignalsReceiversServicePorts(logger logr.Logger, config *adap
 	if isAppSignalEnabledMetrics(config) || isAppSignalEnabledTraces(config) {
 		getReceiverServicePort(logger, "", AppSignalsGrpc, corev1.ProtocolTCP, servicePortsMap)
 		getReceiverServicePort(logger, "", AppSignalsHttp, corev1.ProtocolTCP, servicePortsMap)
+		getReceiverServicePort(logger, "", Server, corev1.ProtocolTCP, servicePortsMap)
 	}
 
 	if isAppSignalEnabledTraces(config) {

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -15,8 +15,7 @@ import (
 func TestStatsDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/statsDAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 1, len(containerPorts))
 	assert.Equal(t, int32(8135), containerPorts[CWA+StatsD].ContainerPort)
 	assert.Equal(t, CWA+StatsD, containerPorts[CWA+StatsD].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+StatsD].Protocol)
@@ -25,8 +24,7 @@ func TestStatsDGetContainerPorts(t *testing.T) {
 func TestDefaultStatsDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/statsDDefaultAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 1, len(containerPorts))
 	assert.Equal(t, int32(8125), containerPorts[StatsD].ContainerPort)
 	assert.Equal(t, StatsD, containerPorts[StatsD].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[StatsD].Protocol)
@@ -35,8 +33,7 @@ func TestDefaultStatsDGetContainerPorts(t *testing.T) {
 func TestCollectDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/collectDAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 1, len(containerPorts))
 	assert.Equal(t, int32(25936), containerPorts[CWA+CollectD].ContainerPort)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+CollectD].Protocol)
 }
@@ -44,8 +41,7 @@ func TestCollectDGetContainerPorts(t *testing.T) {
 func TestDefaultCollectDGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/collectDDefaultAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 1, len(containerPorts))
 	assert.Equal(t, int32(25826), containerPorts[CollectD].ContainerPort)
 	assert.Equal(t, CollectD, containerPorts[CollectD].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CollectD].Protocol)
@@ -138,8 +134,7 @@ func TestApplicationSignalsXRayTracesCustom(t *testing.T) {
 func TestXRayCustomUDP(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xRayCustomUDP.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 2, len(containerPorts))
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
@@ -151,8 +146,7 @@ func TestXRayCustomUDP(t *testing.T) {
 func TestEMFGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/emfAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 2, len(containerPorts))
 	assert.Equal(t, int32(25888), containerPorts[EMFTcp].ContainerPort)
 	assert.Equal(t, EMFTcp, containerPorts[EMFTcp].Name)
 	assert.Equal(t, int32(25888), containerPorts[EMFUdp].ContainerPort)
@@ -163,11 +157,6 @@ func TestEMFGetContainerPorts(t *testing.T) {
 func TestXrayAndOTLPGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAndOTLPAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
-		{
-			Name:          Server,
-			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: int32(4311),
-		},
 		{
 			Name:          CWA + XrayTraces,
 			Protocol:      corev1.ProtocolUDP,
@@ -196,8 +185,7 @@ func TestXrayAndOTLPGetContainerPorts(t *testing.T) {
 func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAndOTLPDefaultAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 5, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 4, len(containerPorts))
 	assert.Equal(t, int32(2000), containerPorts[XrayTraces].ContainerPort)
 	assert.Equal(t, XrayTraces, containerPorts[XrayTraces].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[XrayTraces].Protocol)
@@ -215,8 +203,7 @@ func TestDefaultXRayAndOTLPGetContainerPorts(t *testing.T) {
 func TestXRayGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 2, len(containerPorts))
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, corev1.ProtocolUDP, containerPorts[CWA+XrayTraces].Protocol)
@@ -229,8 +216,7 @@ func TestXRayWithBindAddressDefaultGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAgentConfig.json")
 	cfg = strings.Replace(cfg, "2800", "2000", 1) // set Xray trace port to 2000
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 2, len(containerPorts))
 	assert.Equal(t, int32(2000), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, int32(2900), containerPorts[CWA+XrayProxy].ContainerPort)
@@ -242,8 +228,7 @@ func TestXRayWithTCPProxyBindAddressDefaultGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/xrayAgentConfig.json")
 	cfg = strings.Replace(cfg, "2900", "2000", 1) // set Xray proxy port to 2000
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 3, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 2, len(containerPorts))
 	assert.Equal(t, int32(2800), containerPorts[CWA+XrayTraces].ContainerPort)
 	assert.Equal(t, CWA+XrayTraces, containerPorts[CWA+XrayTraces].Name)
 	assert.Equal(t, int32(2000), containerPorts[CWA+XrayProxy].ContainerPort)
@@ -254,8 +239,7 @@ func TestXRayWithTCPProxyBindAddressDefaultGetContainerPorts(t *testing.T) {
 func TestNilMetricsGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/nilMetrics.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 1, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 0, len(containerPorts))
 }
 
 func TestMultipleReceiversGetContainerPorts(t *testing.T) {
@@ -335,8 +319,7 @@ func TestSpecPortsOverrideGetContainerPorts(t *testing.T) {
 		},
 	}
 	containerPorts := getContainerPorts(logger, cfg, "", specPorts)
-	assert.Equal(t, 4, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 3, len(containerPorts))
 	assert.Equal(t, int32(12345), containerPorts[AppSignalsGrpc].ContainerPort)
 	assert.Equal(t, AppSignalsGrpc, containerPorts[AppSignalsGrpc].Name)
 	assert.Equal(t, int32(12346), containerPorts[AppSignalsProxy].ContainerPort)
@@ -357,11 +340,6 @@ func TestValidOTLPMetricsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpMetricsAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
 		{
-			Name:          Server,
-			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: int32(4311),
-		},
-		{
 			Name:          OtlpGrpc + "-1234",
 			Protocol:      corev1.ProtocolTCP,
 			ContainerPort: int32(1234),
@@ -380,11 +358,6 @@ func TestValidOTLPLogsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpLogsAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
 		{
-			Name:          Server,
-			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: int32(4311),
-		},
-		{
 			Name:          OtlpGrpc + "-1234",
 			Protocol:      corev1.ProtocolTCP,
 			ContainerPort: int32(1234),
@@ -402,11 +375,6 @@ func TestValidOTLPLogsPort(t *testing.T) {
 func TestValidOTLPLogsAndMetricsPort(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/otlpMetricsLogsAgentConfig.json")
 	wantPorts := []corev1.ContainerPort{
-		{
-			Name:          Server,
-			Protocol:      corev1.ProtocolTCP,
-			ContainerPort: int32(4311),
-		},
 		{
 			Name:          OtlpGrpc + "-1234",
 			Protocol:      corev1.ProtocolTCP,
@@ -511,8 +479,7 @@ func TestIsDuplicatePort(t *testing.T) {
 func TestJMXGetContainerPorts(t *testing.T) {
 	cfg := getJSONStringFromFile("./test-resources/jmxAgentConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 1, len(containerPorts))
 	assert.Equal(t, int32(4314), containerPorts[JmxHttp].ContainerPort)
 	assert.Equal(t, JmxHttp, containerPorts[JmxHttp].Name)
 	assert.Equal(t, corev1.ProtocolTCP, containerPorts[JmxHttp].Protocol)
@@ -521,8 +488,7 @@ func TestJMXGetContainerPorts(t *testing.T) {
 func TestJMXContainerInsightsGetContainerPorts(t *testing.T) {
 	cfg := getJSONStringFromFile("./test-resources/jmxContainerInsightsConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
-	assert.Equal(t, 2, len(containerPorts))
-	assert.Equal(t, int32(4311), containerPorts[Server].ContainerPort)
+	assert.Equal(t, 1, len(containerPorts))
 	assert.Equal(t, int32(4314), containerPorts[JmxHttp].ContainerPort)
 	assert.Equal(t, JmxHttp, containerPorts[JmxHttp].Name)
 	assert.Equal(t, corev1.ProtocolTCP, containerPorts[JmxHttp].Protocol)


### PR DESCRIPTION
*Description of changes:*
This PR reverts three recent commits:

  - 3749579 — fix commit sha
  - fec500b — pin appsignals java-eks e2e to previous commit (#371)
  - d515fea — Always include server port 4311 in Service (#368)

Reverts 1 & 2 (e2e test pinning): The java-eks e2e workflow was pinned to a specific SHA in the test framework repo. This pinning is no longer needed — restoring @main tracking.

Revert 3 (port 4311): The change to unconditionally include server port 4311 in the cloudwatch-agent Service is not safe for all deployment topologies. When both a Deployment and a DaemonSet run with hostNetwork: true, they will attempt to bind to the same host port 4311, causing one pod to be stuck in Pending.
This reverts the Server port back to being included only when Application Signals is enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
