### PR TITLE
fix(ci): Allow push-release-ecr to run when e2e tests are bypassed

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -240,7 +240,7 @@ jobs:
       tag: ${{ inputs.tag }}
 
   push-release-ecr:
-    if: ${{ inputs.release }}
+    if: ${{ inputs.release && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped') && needs.CreateManifest.result == 'success' && needs.MakeTABinary.result == 'success' }}
     needs: [ MakeTABinary, e2e-test, CreateManifest ]
     permissions:
       id-token: write
@@ -260,14 +260,19 @@ jobs:
 
       - name: Login to ECR
         id: login-ecr
-        if: steps.cached_binaries.outputs.cache-hit == false
         uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
 
-      - name: Push image to release ECR
+      - name: Push operator image to release ECR
         run: |
           docker buildx imagetools create \
           -t ${{ env.ECR_OPERATOR_RELEASE_IMAGE }} \
           ${{ env.ECR_OPERATOR_STAGING_REPO }}:${{ inputs.tag }}
+
+      - name: Push target allocator image to release ECR
+        run: |
+          docker buildx imagetools create \
+          -t ${{ env.ECR_TARGET_ALLOCATOR_RELEASE_REPO }} \
+          ${{ env.ECR_TARGET_ALLOCATOR_STAGING_REPO }}:${{ inputs.tag }}
 
   CreateManifest:
     needs: [ MakeBinary, MakeTABinary ]


### PR DESCRIPTION
## Fix: Allow push-release-ecr to run when e2e tests are bypassed

### Problem

When the e2e test bypass mechanism is used during a release, the `e2e-test` job is skipped. GitHub Actions silently skips any downstream job when a job in its `needs` list has a `skipped` result. This caused `push-release-ecr` to be skipped as well, meaning **release images were never copied from the staging ECR to the release ECR** when bypass was used.

This bug was introduced in `23146e74` (Dec 5, 2024) — the same commit that added the bypass mechanism. **The bypass has never actually worked for a full release.**

Additionally, the target allocator release push step was dropped during the workflow refactor in `271c60af` (Dec 11, 2024), so the TA release ECR has not been updated since Dec 7, 2024.

### Changes

1. **Explicit result check on `push-release-ecr`**: Only runs when `e2e-test` result is `success` or `skipped` (bypass), and all other dependencies succeeded. Blocks on actual test failures or cancellations.
2. **Restored target allocator release push step**: Re-adds the TA push that was lost in the Dec 2024 refactor.
3. **Removed stale `cached_binaries` condition**: The ECR login step referenced a non-existent `cached_binaries` step output.

### Testing

- [Pending] Verify by running the workflow with `Release Artifact = true` and bypass parameters populated — `push-release-ecr` should now execute instead of being skipped.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
