### PR TITLE
fix(ci): Add always() to push-release-ecr condition

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -240,7 +240,7 @@ jobs:
       tag: ${{ inputs.tag }}
 
   push-release-ecr:
-    if: ${{ inputs.release && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped') && needs.CreateManifest.result == 'success' && needs.MakeTABinary.result == 'success' }}
+    if: ${{ always() && inputs.release && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped') && needs.CreateManifest.result == 'success' && needs.MakeTABinary.result == 'success' }}
     needs: [ MakeTABinary, e2e-test, CreateManifest ]
     permissions:
       id-token: write


### PR DESCRIPTION
GitHub Actions does not evaluate job-level 'if' conditions when a job in the 'needs' list is skipped — it silently skips the dependent job. This means the explicit result checks for e2e-test added in #374 were never evaluated when bypass was used, and push-release-ecr was still skipped.

Adding always() forces GitHub Actions to evaluate the condition regardless of dependency status. The remaining checks ensure the job only runs when:
- e2e-test succeeded or was skipped (bypass)
- CreateManifest and MakeTABinary both succeeded
- release input is true

Verified with a test workflow reproducing the exact scenario:
- Without always(): dependent job skipped (bug)
- With always(): dependent job runs (fix)

Refs: https://github.com/actions/runner/issues/491

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
