### PR TITLE
Add Service Events and Dynamic Instrumentation env var injection

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,6 +105,30 @@ func setLangEnvVars(langStr string, cfg map[string]map[string]string) {
 	if runtimeMetrics, ok := cfg["runtime_metrics"]; ok {
 		setLangEnvVarsForResource(langStr, "", runtimeMetrics)
 	}
+	if serviceEvents, ok := cfg["service_events"]; ok {
+		setLangEnvVarsForServiceEvents(langStr, serviceEvents)
+	}
+	if dynamicInstrumentation, ok := cfg["dynamic_instrumentation"]; ok {
+		setLangEnvVarsForDynamicInstrumentation(langStr, dynamicInstrumentation)
+	}
+}
+
+func setLangEnvVarsForServiceEvents(langStr string, cfg map[string]string) {
+	if enabled, ok := cfg["enabled"]; ok && enabled != "" {
+		_ = os.Setenv("AUTO_INSTRUMENTATION_"+langStr+"_SERVICE_EVENTS_ENABLED", enabled)
+	}
+	if functionInstrumentEnabled, ok := cfg["function_instrument_enabled"]; ok && functionInstrumentEnabled != "" {
+		_ = os.Setenv("AUTO_INSTRUMENTATION_"+langStr+"_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", functionInstrumentEnabled)
+	}
+	if profilerEnabled, ok := cfg["profiler_enabled"]; ok && profilerEnabled != "" {
+		_ = os.Setenv("AUTO_INSTRUMENTATION_"+langStr+"_SERVICE_EVENTS_PROFILER_ENABLED", profilerEnabled)
+	}
+}
+
+func setLangEnvVarsForDynamicInstrumentation(langStr string, cfg map[string]string) {
+	if enabled, ok := cfg["enabled"]; ok && enabled != "" {
+		_ = os.Setenv("AUTO_INSTRUMENTATION_"+langStr+"_DYNAMIC_INSTRUMENTATION_ENABLED", enabled)
+	}
 }
 
 func main() {
@@ -154,7 +178,7 @@ func main() {
 	pflag.Parse()
 
 	// set instrumentation cpu and memory limits in environment variables to be used for default instrumentation; default values received from https://github.com/open-telemetry/opentelemetry-operator/blob/main/apis/v1alpha1/instrumentation_webhook.go
-	autoInstrumentationConfig := map[string]map[string]map[string]string{"java": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}, "runtime_metrics": {"enabled": "true"}}, "python": {"limits": {"cpu": "500m", "memory": "32Mi"}, "requests": {"cpu": "50m", "memory": "32Mi"}, "runtime_metrics": {"enabled": "true"}}, "dotnet": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}, "runtime_metrics": {"enabled": "true"}}, "nodejs": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}}}
+	autoInstrumentationConfig := map[string]map[string]map[string]string{"java": {"limits": {"cpu": "500m", "memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}, "runtime_metrics": {"enabled": "true"}, "service_events": {}, "dynamic_instrumentation": {}}, "python": {"limits": {"cpu": "500m", "memory": "32Mi"}, "requests": {"cpu": "50m", "memory": "32Mi"}, "runtime_metrics": {"enabled": "true"}, "service_events": {}, "dynamic_instrumentation": {}}, "dotnet": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}, "runtime_metrics": {"enabled": "true"}}, "nodejs": {"limits": {"cpu": "500m", "memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "128Mi"}, "service_events": {}, "dynamic_instrumentation": {}}}
 	err := json.Unmarshal([]byte(autoInstrumentationConfigStr), &autoInstrumentationConfig)
 	if err != nil {
 		setupLog.Info(fmt.Sprintf("Using default values: %v", autoInstrumentationConfig))

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// Test_setLangEnvVars_serviceEvents verifies that the service_events sub-map from
+// --auto-instrumentation-config is translated into the AUTO_INSTRUMENTATION_<LANG>_SERVICE_EVENTS_*
+// env vars the instrumentation package reads, and that empty/absent values are treated as unset
+// (so the SDK default applies — Service Events follows OTEL_AWS_APPLICATION_SIGNALS_ENABLED).
+func Test_setLangEnvVars_serviceEvents(t *testing.T) {
+	const (
+		enabledVar  = "AUTO_INSTRUMENTATION_JAVA_SERVICE_EVENTS_ENABLED"
+		functionVar = "AUTO_INSTRUMENTATION_JAVA_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED"
+		profilerVar = "AUTO_INSTRUMENTATION_JAVA_SERVICE_EVENTS_PROFILER_ENABLED"
+		dynamicVar  = "AUTO_INSTRUMENTATION_JAVA_DYNAMIC_INSTRUMENTATION_ENABLED"
+	)
+	tests := []struct {
+		name         string
+		serviceEvent map[string]string
+		dynamicInst  map[string]string
+		wantEnabled  *string // nil = expect unset
+		wantFunction *string
+		wantProfiler *string
+		wantDynamic  *string
+	}{
+		{
+			name:         "absent keys leave env unset",
+			serviceEvent: map[string]string{},
+		},
+		{
+			name:         "empty enabled treated as unset",
+			serviceEvent: map[string]string{"enabled": ""},
+		},
+		{
+			name:         "enabled=false is forwarded",
+			serviceEvent: map[string]string{"enabled": "false"},
+			wantEnabled:  ptr("false"),
+		},
+		{
+			name:         "profiler_enabled=false is forwarded",
+			serviceEvent: map[string]string{"profiler_enabled": "false"},
+			wantProfiler: ptr("false"),
+		},
+		{
+			name:        "dynamic_instrumentation enabled=true is forwarded",
+			dynamicInst: map[string]string{"enabled": "true"},
+			wantDynamic: ptr("true"),
+		},
+		{
+			name:        "empty dynamic_instrumentation enabled treated as unset",
+			dynamicInst: map[string]string{"enabled": ""},
+		},
+		{
+			name: "all toggles forwarded",
+			serviceEvent: map[string]string{
+				"enabled":                     "true",
+				"function_instrument_enabled": "true",
+				"profiler_enabled":            "false",
+			},
+			dynamicInst:  map[string]string{"enabled": "true"},
+			wantEnabled:  ptr("true"),
+			wantFunction: ptr("true"),
+			wantProfiler: ptr("false"),
+			wantDynamic:  ptr("true"),
+		},
+	}
+	envVars := []string{enabledVar, functionVar, profilerVar, dynamicVar}
+	unsetAll := func() {
+		for _, v := range envVars {
+			_ = os.Unsetenv(v)
+		}
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unsetAll()
+			t.Cleanup(unsetAll)
+
+			setLangEnvVars("JAVA", map[string]map[string]string{
+				"service_events":          tt.serviceEvent,
+				"dynamic_instrumentation": tt.dynamicInst,
+			})
+
+			assertEnv(t, enabledVar, tt.wantEnabled)
+			assertEnv(t, functionVar, tt.wantFunction)
+			assertEnv(t, profilerVar, tt.wantProfiler)
+			assertEnv(t, dynamicVar, tt.wantDynamic)
+		})
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+func assertEnv(t *testing.T, name string, want *string) {
+	t.Helper()
+	got, ok := os.LookupEnv(name)
+	if want == nil {
+		if ok {
+			t.Errorf("%s: expected unset, got %q", name, got)
+		}
+		return
+	}
+	if !ok {
+		t.Errorf("%s: expected %q, but it was unset", name, *want)
+		return
+	}
+	if got != *want {
+		t.Errorf("%s: got %q, want %q", name, got, *want)
+	}
+}

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -137,11 +137,17 @@ func getDefaultInstrumentation(agentConfig *adapters.CwaConfig, additionalEnvs m
 	}, nil
 }
 
-func getServiceEventsEnvs(langStr, cloudwatchAgentServiceEndpoint, exporterPrefix string) []corev1.EnvVar {
-	envs := []corev1.EnvVar{
+// getSharedOtlpEndpointEnvs returns the OTLP logs/metrics endpoints routed to the CloudWatch Agent.
+// Shared by Service Events and Dynamic Instrumentation
+func getSharedOtlpEndpointEnvs(cloudwatchAgentServiceEndpoint, exporterPrefix string) []corev1.EnvVar {
+	return []corev1.EnvVar{
 		{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: fmt.Sprintf("%s://%s:4316/v1/logs", exporterPrefix, cloudwatchAgentServiceEndpoint)},
 		{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: fmt.Sprintf("%s://%s:4316/v1/metrics", exporterPrefix, cloudwatchAgentServiceEndpoint)},
 	}
+}
+
+func getServiceEventsEnvs(langStr string) []corev1.EnvVar {
+	var envs []corev1.EnvVar
 	if enabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_" + langStr + "_SERVICE_EVENTS_ENABLED"); ok {
 		envs = append(envs, corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: enabled})
 	}
@@ -187,7 +193,8 @@ func getJavaEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, expor
 			{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: isJavaRuntimeEnabled},
 		}
 		envs = append(envs, appSignalsEnvs...)
-		envs = append(envs, getServiceEventsEnvs(java, cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getSharedOtlpEndpointEnvs(cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getServiceEventsEnvs(java)...)
 		envs = append(envs, getDynamicInstrumentationEnvs(java, cloudwatchAgentServiceEndpoint)...)
 	} else {
 		envs = append(envs, corev1.EnvVar{
@@ -230,7 +237,8 @@ func getPythonEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exp
 			{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 			{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 		}
-		envs = append(envs, getServiceEventsEnvs(python, cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getSharedOtlpEndpointEnvs(cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getServiceEventsEnvs(python)...)
 		envs = append(envs, getDynamicInstrumentationEnvs(python, cloudwatchAgentServiceEndpoint)...)
 	}
 	return envs
@@ -275,7 +283,8 @@ func getNodeJSEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exp
 			{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 			{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 		}
-		envs = append(envs, getServiceEventsEnvs(nodeJS, cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getSharedOtlpEndpointEnvs(cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getServiceEventsEnvs(nodeJS)...)
 		envs = append(envs, getDynamicInstrumentationEnvs(nodeJS, cloudwatchAgentServiceEndpoint)...)
 	}
 	return envs

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -137,6 +137,33 @@ func getDefaultInstrumentation(agentConfig *adapters.CwaConfig, additionalEnvs m
 	}, nil
 }
 
+func getServiceEventsEnvs(langStr, cloudwatchAgentServiceEndpoint, exporterPrefix string) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
+		{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: fmt.Sprintf("%s://%s:4316/v1/logs", exporterPrefix, cloudwatchAgentServiceEndpoint)},
+		{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: fmt.Sprintf("%s://%s:4316/v1/metrics", exporterPrefix, cloudwatchAgentServiceEndpoint)},
+	}
+	if enabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_" + langStr + "_SERVICE_EVENTS_ENABLED"); ok {
+		envs = append(envs, corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: enabled})
+	}
+	if functionInstrumentEnabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_" + langStr + "_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED"); ok {
+		envs = append(envs, corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: functionInstrumentEnabled})
+	}
+	if profilerEnabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_" + langStr + "_SERVICE_EVENTS_PROFILER_ENABLED"); ok {
+		envs = append(envs, corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: profilerEnabled})
+	}
+	return envs
+}
+
+func getDynamicInstrumentationEnvs(langStr, cloudwatchAgentServiceEndpoint string) []corev1.EnvVar {
+	envs := []corev1.EnvVar{
+		{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: fmt.Sprintf("%s://%s:2000", http, cloudwatchAgentServiceEndpoint)},
+	}
+	if enabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_" + langStr + "_DYNAMIC_INSTRUMENTATION_ENABLED"); ok {
+		envs = append(envs, corev1.EnvVar{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED", Value: enabled})
+	}
+	return envs
+}
+
 func getJavaEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exporterPrefix string, additionalEnvs map[string]string) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
 		{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
@@ -160,6 +187,8 @@ func getJavaEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, expor
 			{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: isJavaRuntimeEnabled},
 		}
 		envs = append(envs, appSignalsEnvs...)
+		envs = append(envs, getServiceEventsEnvs(java, cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getDynamicInstrumentationEnvs(java, cloudwatchAgentServiceEndpoint)...)
 	} else {
 		envs = append(envs, corev1.EnvVar{
 			Name: "OTEL_TRACES_EXPORTER", Value: "none",
@@ -201,6 +230,8 @@ func getPythonEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exp
 			{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 			{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 		}
+		envs = append(envs, getServiceEventsEnvs(python, cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getDynamicInstrumentationEnvs(python, cloudwatchAgentServiceEndpoint)...)
 	}
 	return envs
 }
@@ -244,6 +275,8 @@ func getNodeJSEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exp
 			{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 			{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 		}
+		envs = append(envs, getServiceEventsEnvs(nodeJS, cloudwatchAgentServiceEndpoint, exporterPrefix)...)
+		envs = append(envs, getDynamicInstrumentationEnvs(nodeJS, cloudwatchAgentServiceEndpoint)...)
 	}
 	return envs
 }

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -275,7 +275,7 @@ func getNodeJSEnvs(isAppSignalsEnabled bool, cloudwatchAgentServiceEndpoint, exp
 	if isAppSignalsEnabled {
 		envs = []corev1.EnvVar{
 			{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-			{Name: "OTEL_TRACES_SAMPLER_ARG", Value: fmt.Sprintf("endpoint=%s://%s:2000", exporterPrefix, cloudwatchAgentServiceEndpoint)},
+			{Name: "OTEL_TRACES_SAMPLER_ARG", Value: fmt.Sprintf("endpoint=%s://%s:2000", http, cloudwatchAgentServiceEndpoint)},
 			{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 			{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
 			{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: fmt.Sprintf("%s://%s:4316/v1/traces", exporterPrefix, cloudwatchAgentServiceEndpoint)},

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -1027,6 +1027,11 @@ func Test_getDynamicInstrumentationEnvs(t *testing.T) {
 			env:  map[string]string{"DYNAMIC_INSTRUMENTATION_ENABLED": "true"},
 			want: []corev1.EnvVar{apiURLEnv, {Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED", Value: "true"}},
 		},
+		{
+			name: "enabled=false opt-out emitted",
+			env:  map[string]string{"DYNAMIC_INSTRUMENTATION_ENABLED": "false"},
+			want: []corev1.EnvVar{apiURLEnv, {Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED", Value: "false"}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -282,7 +282,7 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Image: defaultNodeJSInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=https://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
 					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
@@ -630,7 +630,7 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 				Image: defaultNodeJSInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
 					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -990,8 +990,8 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 			},
 			want: []corev1.EnvVar{
 				{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "true"},
-				{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "true"},
 				{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "false"},
+				{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "true"},
 			},
 		},
 	}

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -952,10 +952,6 @@ func Test_getDefaultInstrumentationLinuxWithApplicationSignalsDisabled(t *testin
 }
 
 func Test_getServiceEventsEnvs(t *testing.T) {
-	endpointEnvs := []corev1.EnvVar{
-		{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
-		{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
-	}
 	tests := []struct {
 		name string
 		// env maps the AUTO_INSTRUMENTATION_JAVA_* suffix to its value; absent keys stay unset so
@@ -966,21 +962,19 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 		want []corev1.EnvVar
 	}{
 		{
-			name: "unset toggles - only endpoints emitted",
+			name: "unset toggles - nothing emitted",
 			env:  map[string]string{},
-			want: endpointEnvs,
+			want: nil,
 		},
 		{
 			name: "enabled=false opt-out emitted",
 			env:  map[string]string{"SERVICE_EVENTS_ENABLED": "false"},
-			want: append(append([]corev1.EnvVar{}, endpointEnvs...),
-				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "false"}),
+			want: []corev1.EnvVar{{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "false"}},
 		},
 		{
 			name: "profiler_enabled=false emitted on its own",
 			env:  map[string]string{"SERVICE_EVENTS_PROFILER_ENABLED": "false"},
-			want: append(append([]corev1.EnvVar{}, endpointEnvs...),
-				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"}),
+			want: []corev1.EnvVar{{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"}},
 		},
 		{
 			name: "all toggles emitted when set",
@@ -989,10 +983,11 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 				"SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "true",
 				"SERVICE_EVENTS_PROFILER_ENABLED":            "false",
 			},
-			want: append(append([]corev1.EnvVar{}, endpointEnvs...),
-				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "true"},
-				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "true"},
-				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"}),
+			want: []corev1.EnvVar{
+				{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "true"},
+				{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "true"},
+				{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1000,7 +995,7 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 			for suffix, v := range tt.env {
 				t.Setenv("AUTO_INSTRUMENTATION_JAVA_"+suffix, v)
 			}
-			got := getServiceEventsEnvs(java, "cloudwatch-agent.amazon-cloudwatch", http)
+			got := getServiceEventsEnvs(java)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getServiceEventsEnvs() got = %v, want %v", got, tt.want)
 			}
@@ -1009,11 +1004,11 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 }
 
 func Test_getDynamicInstrumentationEnvs(t *testing.T) {
+	// The API URL is always emitted; the ENABLED toggle is emit-when-set.
 	apiURLEnv := corev1.EnvVar{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"}
 	tests := []struct {
 		name string
 		// env maps the AUTO_INSTRUMENTATION_JAVA_* suffix to its value; absent keys stay unset.
-		// The API URL is always emitted; the ENABLED toggle is emit-when-set.
 		env  map[string]string
 		want []corev1.EnvVar
 	}{

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -977,16 +977,21 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 			want: []corev1.EnvVar{{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"}},
 		},
 		{
+			name: "function_instrument_enabled=true emitted on its own",
+			env:  map[string]string{"SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "true"},
+			want: []corev1.EnvVar{{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "true"}},
+		},
+		{
 			name: "all toggles emitted when set",
 			env: map[string]string{
 				"SERVICE_EVENTS_ENABLED":                     "true",
-				"SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "true",
-				"SERVICE_EVENTS_PROFILER_ENABLED":            "false",
+				"SERVICE_EVENTS_PROFILER_ENABLED":            "true",
+				"SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "false",
 			},
 			want: []corev1.EnvVar{
 				{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "true"},
-				{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "true"},
-				{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"},
+				{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "true"},
+				{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "false"},
 			},
 		},
 	}

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -72,6 +72,9 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -100,6 +103,9 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_PYTHON_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -151,6 +157,9 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -195,6 +204,9 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -223,6 +235,9 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_PYTHON_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -274,6 +289,9 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -402,6 +420,9 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -430,6 +451,9 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_PYTHON_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -481,6 +505,9 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -525,6 +552,9 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -553,6 +583,9 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_PYTHON_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -604,6 +637,9 @@ func Test_getDefaultInstrumentationWindows(t *testing.T) {
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -910,6 +946,96 @@ func Test_getDefaultInstrumentationLinuxWithApplicationSignalsDisabled(t *testin
 			}
 			if !reflect.DeepEqual(got.Spec.Java.Env, tt.want.Spec.Java.Env) {
 				t.Errorf("getDefaultInstrumentation() Java environment vars got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getServiceEventsEnvs(t *testing.T) {
+	endpointEnvs := []corev1.EnvVar{
+		{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
+		{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+	}
+	tests := []struct {
+		name string
+		// env maps the AUTO_INSTRUMENTATION_JAVA_* suffix to its value; absent keys stay unset so
+		// os.LookupEnv returns ok=false. getServiceEventsEnvs emits a toggle whenever its backing env
+		// var is present (the empty-value-means-unset guard lives in main.go's setLangEnvVars, covered
+		// in main_test.go); these cases exercise the present/absent contract of this function.
+		env  map[string]string
+		want []corev1.EnvVar
+	}{
+		{
+			name: "unset toggles - only endpoints emitted",
+			env:  map[string]string{},
+			want: endpointEnvs,
+		},
+		{
+			name: "enabled=false opt-out emitted",
+			env:  map[string]string{"SERVICE_EVENTS_ENABLED": "false"},
+			want: append(append([]corev1.EnvVar{}, endpointEnvs...),
+				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "false"}),
+		},
+		{
+			name: "profiler_enabled=false emitted on its own",
+			env:  map[string]string{"SERVICE_EVENTS_PROFILER_ENABLED": "false"},
+			want: append(append([]corev1.EnvVar{}, endpointEnvs...),
+				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"}),
+		},
+		{
+			name: "all toggles emitted when set",
+			env: map[string]string{
+				"SERVICE_EVENTS_ENABLED":                     "true",
+				"SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "true",
+				"SERVICE_EVENTS_PROFILER_ENABLED":            "false",
+			},
+			want: append(append([]corev1.EnvVar{}, endpointEnvs...),
+				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "true"},
+				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "true"},
+				corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for suffix, v := range tt.env {
+				t.Setenv("AUTO_INSTRUMENTATION_JAVA_"+suffix, v)
+			}
+			got := getServiceEventsEnvs(java, "cloudwatch-agent.amazon-cloudwatch", http)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getServiceEventsEnvs() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getDynamicInstrumentationEnvs(t *testing.T) {
+	apiURLEnv := corev1.EnvVar{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"}
+	tests := []struct {
+		name string
+		// env maps the AUTO_INSTRUMENTATION_JAVA_* suffix to its value; absent keys stay unset.
+		// The API URL is always emitted; the ENABLED toggle is emit-when-set.
+		env  map[string]string
+		want []corev1.EnvVar
+	}{
+		{
+			name: "unset toggle - only API URL emitted",
+			env:  map[string]string{},
+			want: []corev1.EnvVar{apiURLEnv},
+		},
+		{
+			name: "enabled=true emitted",
+			env:  map[string]string{"DYNAMIC_INSTRUMENTATION_ENABLED": "true"},
+			want: []corev1.EnvVar{apiURLEnv, {Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED", Value: "true"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for suffix, v := range tt.env {
+				t.Setenv("AUTO_INSTRUMENTATION_JAVA_"+suffix, v)
+			}
+			got := getDynamicInstrumentationEnvs(java, "cloudwatch-agent.amazon-cloudwatch")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getDynamicInstrumentationEnvs() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## *Description of changes:*

Inject env vars for two Application Signals subfeatures into instrumented application pods (only for Java/Python/Node.js):

Service Events (getServiceEventsEnvs):

- Only emit if configured: `OTEL_AWS_SERVICE_EVENTS_ENABLED`, `OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED`, `OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED`.

Dynamic Instrumentation (getDynamicInstrumentationEnvs):
- Always emit `OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL` to point to the CloudWatch Agent proxy at
  port 2000 with fixed http scheme (same host/port as `OTEL_TRACES_SAMPLER_ARG`).
- Only emit if configured: `OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED`.

Common Env Vars:
- Always emit `OTEL_AWS_OTLP_LOGS_ENDPOINT` and `OTEL_AWS_OTLP_METRICS_ENDPOINT` to point to the CloudWatch Agent OTLP receiver. It is used only for both `Service Events` and `Dynamic Instrumentation`.

Toggles are configured through `autoInstrumentationConfiguration.<lang>.{service_events,dynamic_instrumentation}`. No env vars are set if the respective setting is not configured.

Added unit tests for both helpers and the main.go config translation, and tested change via helm-chart in test EKS cluster.

## Kubectl env var output

Using:
```
metadata:
  annotations:
    instrumentation.opentelemetry.io/inject-java: "true"
    instrumentation.opentelemetry.io/inject-python: "true"
    instrumentation.opentelemetry.io/inject-nodejs: "true"
    instrumentation.opentelemetry.io/inject-dotnet: "true"
```

- diff between Prod Add-on and this PR's changes with default configuration for `autoInstrumentationConfiguration`

```diff
@@ -9,6 +9,9 @@
 OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
 OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
 OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=true
+OTEL_AWS_OTLP_LOGS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs
+OTEL_AWS_OTLP_METRICS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL=http://cloudwatch-agent.amazon-cloudwatch:2000
 JAVA_TOOL_OPTIONS= -javaagent:/otel-auto-instrumentation-java/javaagent.jar
 OTEL_SERVICE_NAME=js-simple-sample-eks
 OTEL_RESOURCE_ATTRIBUTES_POD_NAME=<no value>
@@ -22,6 +25,9 @@
 OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
 OTEL_METRICS_EXPORTER=none
 OTEL_LOGS_EXPORTER=none
+OTEL_AWS_OTLP_LOGS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs
+OTEL_AWS_OTLP_METRICS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL=http://cloudwatch-agent.amazon-cloudwatch:2000
 NODE_OPTIONS= --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js
 OTEL_AWS_APP_SIGNALS_ENABLED=true
 OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
@@ -36,6 +42,9 @@
 OTEL_PYTHON_DISTRO=aws_distro
 OTEL_PYTHON_CONFIGURATOR=aws_configurator
 OTEL_LOGS_EXPORTER=none
+OTEL_AWS_OTLP_LOGS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs
+OTEL_AWS_OTLP_METRICS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL=http://cloudwatch-agent.amazon-cloudwatch:2000
 PYTHONPATH=/otel-auto-instrumentation-python/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation-python
 OTEL_TRACES_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
@@ -60,4 +69,4 @@
 DOTNET_ADDITIONAL_DEPS=/otel-auto-instrumentation-dotnet/AdditionalDeps
 OTEL_DOTNET_AUTO_HOME=/otel-auto-instrumentation-dotnet
 DOTNET_SHARED_STORE=/otel-auto-instrumentation-dotnet/store
-OTEL_RESOURCE_ATTRIBUTES=com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=js-simple-sample-eks,k8s.deployment.name=js-simple-sample-eks,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.replicaset.name=js-simple-sample-eks-875bcd66d,service.version=latest
+OTEL_RESOURCE_ATTRIBUTES=com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=js-simple-sample-eks,k8s.deployment.name=js-simple-sample-eks,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.replicaset.name=js-simple-sample-eks-c85688549,service.version=latest
```

- diff between Prod Add-on and this PR's changes with all possible setting configured for `autoInstrumentationConfiguration`

Config:
```
manager:
  autoInstrumentationConfiguration:
    java:
      runtime_metrics: { enabled: "true" }
      service_events:
        enabled: "true"
        function_instrument_enabled: "true"
        profiler_enabled: "true"
      dynamic_instrumentation:
        enabled: "true"
    python:
      runtime_metrics: { enabled: "true" }
      service_events:
        enabled: "true"
        function_instrument_enabled: "true"
        profiler_enabled: "true"
      dynamic_instrumentation:
        enabled: "true"
    nodejs:
      service_events:
        enabled: "true"
        function_instrument_enabled: "true"
        profiler_enabled: "true"
      dynamic_instrumentation:
        enabled: "true"
```

```diff
@@ -9,6 +9,13 @@
 OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
 OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
 OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=true
+OTEL_AWS_OTLP_LOGS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs
+OTEL_AWS_OTLP_METRICS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
+OTEL_AWS_SERVICE_EVENTS_ENABLED=true
+OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED=true
+OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED=true
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL=http://cloudwatch-agent.amazon-cloudwatch:2000
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED=true
 JAVA_TOOL_OPTIONS= -javaagent:/otel-auto-instrumentation-java/javaagent.jar
 OTEL_SERVICE_NAME=js-simple-sample-eks
 OTEL_RESOURCE_ATTRIBUTES_POD_NAME=<no value>
@@ -22,6 +29,13 @@
 OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
 OTEL_METRICS_EXPORTER=none
 OTEL_LOGS_EXPORTER=none
+OTEL_AWS_OTLP_LOGS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs
+OTEL_AWS_OTLP_METRICS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
+OTEL_AWS_SERVICE_EVENTS_ENABLED=true
+OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED=true
+OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED=true
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL=http://cloudwatch-agent.amazon-cloudwatch:2000
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED=true
 NODE_OPTIONS= --require /otel-auto-instrumentation-nodejs/autoinstrumentation.js
 OTEL_AWS_APP_SIGNALS_ENABLED=true
 OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
@@ -36,6 +50,13 @@
 OTEL_PYTHON_DISTRO=aws_distro
 OTEL_PYTHON_CONFIGURATOR=aws_configurator
 OTEL_LOGS_EXPORTER=none
+OTEL_AWS_OTLP_LOGS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs
+OTEL_AWS_OTLP_METRICS_ENDPOINT=http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
+OTEL_AWS_SERVICE_EVENTS_ENABLED=true
+OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED=true
+OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED=true
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL=http://cloudwatch-agent.amazon-cloudwatch:2000
+OTEL_AWS_DYNAMIC_INSTRUMENTATION_ENABLED=true
 PYTHONPATH=/otel-auto-instrumentation-python/opentelemetry/instrumentation/auto_instrumentation:/otel-auto-instrumentation-python
 OTEL_TRACES_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
@@ -60,4 +81,4 @@
 DOTNET_ADDITIONAL_DEPS=/otel-auto-instrumentation-dotnet/AdditionalDeps
 OTEL_DOTNET_AUTO_HOME=/otel-auto-instrumentation-dotnet
 DOTNET_SHARED_STORE=/otel-auto-instrumentation-dotnet/store
-OTEL_RESOURCE_ATTRIBUTES=com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=js-simple-sample-eks,k8s.deployment.name=js-simple-sample-eks,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.replicaset.name=js-simple-sample-eks-875bcd66d,service.version=latest
+OTEL_RESOURCE_ATTRIBUTES=com.amazonaws.cloudwatch.entity.internal.service.name.source=K8sWorkload,k8s.container.name=js-simple-sample-eks,k8s.deployment.name=js-simple-sample-eks,k8s.namespace.name=default,k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME),k8s.replicaset.name=js-simple-sample-eks-56b6f74bd4,service.version=latest
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
