### PR TITLE
Update Service Events env var Config

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,9 +120,6 @@ func setLangEnvVarsForServiceEvents(langStr string, cfg map[string]string) {
 	if functionInstrumentEnabled, ok := cfg["function_instrument_enabled"]; ok && functionInstrumentEnabled != "" {
 		_ = os.Setenv("AUTO_INSTRUMENTATION_"+langStr+"_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", functionInstrumentEnabled)
 	}
-	if profilerEnabled, ok := cfg["profiler_enabled"]; ok && profilerEnabled != "" {
-		_ = os.Setenv("AUTO_INSTRUMENTATION_"+langStr+"_SERVICE_EVENTS_PROFILER_ENABLED", profilerEnabled)
-	}
 }
 
 func setLangEnvVarsForDynamicInstrumentation(langStr string, cfg map[string]string) {

--- a/main_test.go
+++ b/main_test.go
@@ -16,7 +16,6 @@ func Test_setLangEnvVars_serviceEvents(t *testing.T) {
 	const (
 		enabledVar  = "AUTO_INSTRUMENTATION_JAVA_SERVICE_EVENTS_ENABLED"
 		functionVar = "AUTO_INSTRUMENTATION_JAVA_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED"
-		profilerVar = "AUTO_INSTRUMENTATION_JAVA_SERVICE_EVENTS_PROFILER_ENABLED"
 		dynamicVar  = "AUTO_INSTRUMENTATION_JAVA_DYNAMIC_INSTRUMENTATION_ENABLED"
 	)
 	tests := []struct {
@@ -25,7 +24,6 @@ func Test_setLangEnvVars_serviceEvents(t *testing.T) {
 		dynamicInst  map[string]string
 		wantEnabled  *string // nil = expect unset
 		wantFunction *string
-		wantProfiler *string
 		wantDynamic  *string
 	}{
 		{
@@ -42,11 +40,6 @@ func Test_setLangEnvVars_serviceEvents(t *testing.T) {
 			wantEnabled:  ptr("false"),
 		},
 		{
-			name:         "profiler_enabled=false is forwarded",
-			serviceEvent: map[string]string{"profiler_enabled": "false"},
-			wantProfiler: ptr("false"),
-		},
-		{
 			name:        "dynamic_instrumentation enabled=true is forwarded",
 			dynamicInst: map[string]string{"enabled": "true"},
 			wantDynamic: ptr("true"),
@@ -60,16 +53,14 @@ func Test_setLangEnvVars_serviceEvents(t *testing.T) {
 			serviceEvent: map[string]string{
 				"enabled":                     "true",
 				"function_instrument_enabled": "true",
-				"profiler_enabled":            "false",
 			},
 			dynamicInst:  map[string]string{"enabled": "true"},
 			wantEnabled:  ptr("true"),
 			wantFunction: ptr("true"),
-			wantProfiler: ptr("false"),
 			wantDynamic:  ptr("true"),
 		},
 	}
-	envVars := []string{enabledVar, functionVar, profilerVar, dynamicVar}
+	envVars := []string{enabledVar, functionVar, dynamicVar}
 	unsetAll := func() {
 		for _, v := range envVars {
 			_ = os.Unsetenv(v)
@@ -87,7 +78,6 @@ func Test_setLangEnvVars_serviceEvents(t *testing.T) {
 
 			assertEnv(t, enabledVar, tt.wantEnabled)
 			assertEnv(t, functionVar, tt.wantFunction)
-			assertEnv(t, profilerVar, tt.wantProfiler)
 			assertEnv(t, dynamicVar, tt.wantDynamic)
 		})
 	}

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -154,9 +154,6 @@ func getServiceEventsEnvs(langStr string) []corev1.EnvVar {
 	if functionInstrumentEnabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_" + langStr + "_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED"); ok {
 		envs = append(envs, corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: functionInstrumentEnabled})
 	}
-	if profilerEnabled, ok := os.LookupEnv("AUTO_INSTRUMENTATION_" + langStr + "_SERVICE_EVENTS_PROFILER_ENABLED"); ok {
-		envs = append(envs, corev1.EnvVar{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: profilerEnabled})
-	}
 	return envs
 }
 

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -972,11 +972,6 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 			want: []corev1.EnvVar{{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "false"}},
 		},
 		{
-			name: "profiler_enabled=false emitted on its own",
-			env:  map[string]string{"SERVICE_EVENTS_PROFILER_ENABLED": "false"},
-			want: []corev1.EnvVar{{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "false"}},
-		},
-		{
 			name: "function_instrument_enabled=true emitted on its own",
 			env:  map[string]string{"SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "true"},
 			want: []corev1.EnvVar{{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "true"}},
@@ -985,13 +980,11 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 			name: "all toggles emitted when set",
 			env: map[string]string{
 				"SERVICE_EVENTS_ENABLED":                     "true",
-				"SERVICE_EVENTS_PROFILER_ENABLED":            "true",
 				"SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED": "false",
 			},
 			want: []corev1.EnvVar{
 				{Name: "OTEL_AWS_SERVICE_EVENTS_ENABLED", Value: "true"},
 				{Name: "OTEL_AWS_SERVICE_EVENTS_FUNCTION_INSTRUMENT_ENABLED", Value: "false"},
-				{Name: "OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED", Value: "true"},
 			},
 		},
 	}


### PR DESCRIPTION
*Issue #, if available:*
- Amendment to https://github.com/aws/amazon-cloudwatch-agent-operator/pull/382

*Description of changes:*
- Removes configuration for `OTEL_AWS_SERVICE_EVENTS_PROFILER_ENABLED`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
