### PR TITLE
fix(collector): roll pods when Prometheus config changes

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,12 @@
 ========================================================================
+Amazon CloudWatch Agent Operator (Unreleased)
+========================================================================
+Bug Fixes:
+* Roll agent pods when the Prometheus config changes: the pod-template config
+  hash now folds in the serialized Spec.Prometheus, so a Prometheus-only change
+  triggers a rolling restart (previously only Spec.Config changes did)
+
+========================================================================
 Amazon CloudWatch Agent Operator v3.5.0 (2026-06-05)
 ========================================================================
 Enhancements:

--- a/internal/manifests/collector/annotations.go
+++ b/internal/manifests/collector/annotations.go
@@ -28,7 +28,7 @@ func Annotations(instance v1alpha1.AmazonCloudWatchAgent) map[string]string {
 	}
 
 	// make sure sha256 for configMap is always calculated
-	annotations["amazon-cloudwatch-agent-operator-config/sha256"] = getConfigMapSHA(instance.Spec.Config)
+	annotations["amazon-cloudwatch-agent-operator-config/sha256"] = getConfigMapSHA(configHashInput(instance))
 
 	return annotations
 }
@@ -51,9 +51,26 @@ func PodAnnotations(instance v1alpha1.AmazonCloudWatchAgent) map[string]string {
 	}
 
 	// make sure sha256 for configMap is always calculated
-	podAnnotations["amazon-cloudwatch-agent-operator-config/sha256"] = getConfigMapSHA(instance.Spec.Config)
+	podAnnotations["amazon-cloudwatch-agent-operator-config/sha256"] = getConfigMapSHA(configHashInput(instance))
 
 	return podAnnotations
+}
+
+// configHashInput returns the string whose sha256 is used as the pod-template
+// restart trigger. It folds the serialized Prometheus config into the agent
+// config so that a Prometheus-only change (written to a separate ConfigMap)
+// bumps the pod-template hash and triggers a rolling restart, matching the
+// behavior of an agent-config change. When no Prometheus config is set
+// (Spec.Prometheus.IsEmpty()), the input is byte-identical to the agent config
+// alone, so non-Prometheus agents are unaffected.
+func configHashInput(instance v1alpha1.AmazonCloudWatchAgent) string {
+	config := instance.Spec.Config
+	if !instance.Spec.Prometheus.IsEmpty() {
+		if promYaml, err := instance.Spec.Prometheus.Yaml(); err == nil {
+			config += promYaml
+		}
+	}
+	return config
 }
 
 func getConfigMapSHA(config string) string {

--- a/internal/manifests/collector/annotations_test.go
+++ b/internal/manifests/collector/annotations_test.go
@@ -79,3 +79,68 @@ func TestAnnotationsPropagateDown(t *testing.T) {
 	assert.Equal(t, "mycomponent", podAnnotations["myapp"])
 	assert.Equal(t, "pod_annotation_value", podAnnotations["pod_annotation"])
 }
+
+func promConfig(t *testing.T, replacement string) v1alpha1.PrometheusConfig {
+	t.Helper()
+	cfg := map[string]interface{}{
+		"scrape_configs": []interface{}{
+			map[string]interface{}{
+				"job_name": "kubernetes-pods-annotated",
+				"relabel_configs": []interface{}{
+					map[string]interface{}{
+						"target_label": "bug2probe",
+						"replacement":  replacement,
+					},
+				},
+			},
+		},
+	}
+	return v1alpha1.PrometheusConfig{
+		Config: &v1alpha1.AnyConfig{Object: cfg},
+	}
+}
+
+// TestPrometheusConfigChangeBumpsHash asserts that changing only Spec.Prometheus
+// changes the pod-template config hash (so the pods roll on a Prometheus-only
+// change), while an unchanged spec yields a stable hash.
+func TestPrometheusConfigChangeBumpsHash(t *testing.T) {
+	base := v1alpha1.AmazonCloudWatchAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-instance", Namespace: "my-ns"},
+		Spec: v1alpha1.AmazonCloudWatchAgentSpec{
+			Config:     "agent-config",
+			Prometheus: promConfig(t, "value2"),
+		},
+	}
+
+	// same spec twice -> stable hash
+	h1 := PodAnnotations(base)["amazon-cloudwatch-agent-operator-config/sha256"]
+	h2 := PodAnnotations(base)["amazon-cloudwatch-agent-operator-config/sha256"]
+	assert.Equal(t, h1, h2, "hash must be stable when nothing changes")
+
+	// change ONLY the prometheus config -> hash must change
+	changed := base
+	changed.Spec.Prometheus = promConfig(t, "value3")
+	h3 := PodAnnotations(changed)["amazon-cloudwatch-agent-operator-config/sha256"]
+	assert.NotEqual(t, h1, h3, "pod annotation hash must change when only Spec.Prometheus changes")
+
+	// metadata annotations hash must also reflect the prometheus change
+	a1 := Annotations(base)["amazon-cloudwatch-agent-operator-config/sha256"]
+	a3 := Annotations(changed)["amazon-cloudwatch-agent-operator-config/sha256"]
+	assert.NotEqual(t, a1, a3, "metadata annotation hash must change when only Spec.Prometheus changes")
+}
+
+// TestEmptyPrometheusHashUnchanged asserts that when no Prometheus config is set,
+// the hash is byte-identical to the agent-config-only sha256 (non-Prometheus
+// agents are unaffected by the fix).
+func TestEmptyPrometheusHashUnchanged(t *testing.T) {
+	otelcol := v1alpha1.AmazonCloudWatchAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-instance", Namespace: "my-ns"},
+		Spec:       v1alpha1.AmazonCloudWatchAgentSpec{Config: "test"},
+	}
+
+	// sha256("test") == 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+		Annotations(otelcol)["amazon-cloudwatch-agent-operator-config/sha256"])
+	assert.Equal(t, "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+		PodAnnotations(otelcol)["amazon-cloudwatch-agent-operator-config/sha256"])
+}


### PR DESCRIPTION
## Summary

Roll agent pods when the Prometheus scrape config changes.

The pod-template restart-trigger `sha256` was computed from `instance.Spec.Config`
only. A change to `instance.Spec.Prometheus` is rendered into a **separate**
ConfigMap, so the pod template stayed byte-identical and the workload controller
never rolled the pods. As a result, editing only the Prometheus scrape config did
not take effect until the pods were restarted by some other means — whereas an
agent-config (`Spec.Config`) change correctly rolls them.

This fixes that asymmetry so a Prometheus-only change triggers a rolling restart,
matching agent-config behavior, while leaving non-Prometheus agents unaffected.

## Changes

`internal/manifests/collector/annotations.go`:

- `Annotations()` (line ~31): hash input changed from
  `getConfigMapSHA(instance.Spec.Config)` → `getConfigMapSHA(configHashInput(instance))`.
- `PodAnnotations()` (line ~54, the map applied to the pod template): same change.
- New `configHashInput()` helper (lines ~58–72): returns `instance.Spec.Config`, and
  when `!instance.Spec.Prometheus.IsEmpty()` appends the serialized
  `instance.Spec.Prometheus.Yaml()` (the existing `PrometheusConfig.Yaml()` serializer).

```go
func configHashInput(instance v1alpha1.AmazonCloudWatchAgent) string {
	config := instance.Spec.Config
	if !instance.Spec.Prometheus.IsEmpty() {
		if promYaml, err := instance.Spec.Prometheus.Yaml(); err == nil {
			config += promYaml
		}
	}
	return config
}
```

The `IsEmpty()` guard keeps the hash input byte-identical to the agent config alone
for non-Prometheus agents, so they are unaffected: with no Prometheus config the hash
is still `sha256(Spec.Config)` (`sha256("test") = 9f86d081…`, unchanged). The
pre-existing `TestDefaultAnnotations` / `TestUserAnnotations` (which assert that same
`9f86d081…` value) continue to pass.

`RELEASE_NOTES`: added a Bug Fixes entry noting Prometheus-config changes now trigger a
rolling restart.

## Test Output

### Scenario reference — Test 2 (Prometheus-config tweak must roll pods)

From a DaemonSet doing Prometheus scraping, a small tweak to the Prometheus scrape
config (e.g. changing a relabel `replacement` value) must cause the agent pods to roll
so the new config takes effect. The `configuration-values` for this scenario:

```yaml
agent:
  config:
    {
      "logs": { "metrics_collected": { "prometheus": {
        "log_group_name": "prometheus_test",
        "emf_processor": {
          "metric_namespace": "PrometheusTest",
          "metric_declaration": [
            { "source_labels": ["label1"], "label_matcher": "^value1$",
              "dimensions": [["datapoint_id"], ["datapoint_id","foo_0"]],
              "metric_selectors": ["^test_*"] }
          ]
        }
      } } }
    }
  prometheus:
    config:
      scrape_configs:
        - job_name: 'prometheus-sample-app'
          kubernetes_sd_configs:
            - role: pod
          relabel_configs:
            - source_labels: [__meta_kubernetes_pod_label_app]
              regex: prometheus-sample-app
              action: keep
            - target_label: label1
              replacement: value1
            - target_label: bug2probe       # benign relabel probe
              replacement: value3            # the "small tweak": value2 -> value3
```

### Before / after (live test EKS cluster, no-TA DaemonSet)

A Prometheus-only change (`value2 → value3`) on the fixed operator image:

```
                         BEFORE (value2)             AFTER (value3)
prom-cm sha256   54f854b7...265971af7        a30400e3...77bd40f9d   CHANGED
value2 / value3  value2=1 value3=0           value2=0 value3=1      CHANGED
generation       64                          65                     BUMPED
podTemplateSha   b8fdb19a...565a1466c        211cc51e...0a06a6a0    CHANGED
pod uids         740c2e61 3e2c4dbc 60595d4a  0c3601a9 c1707fe3 8fa2350f   ALL NEW (rolled)
```

BEFORE the fix, the same Prometheus-only tweak changed the Prometheus ConfigMap hash
but left `podTemplateSha` and the pod uids **unchanged** (no restart). AFTER the fix the
Prometheus ConfigMap hash changes **and** the pod-template hash changes **and** the pods
roll (all-new uids, generation bump).

No regression — a subsequent agent-config change (`agent.debug=true`) still rolls the
pods (generation `65→66`, `podTemplateSha` changes, all-new uids), exactly as before.

### Unit tests

```
$ go test ./internal/manifests/collector/ -run 'PrometheusConfigChangeBumpsHash|EmptyPrometheusHashUnchanged|DefaultAnnotations|UserAnnotations' -v
=== RUN   TestDefaultAnnotations
--- PASS: TestDefaultAnnotations (0.00s)
=== RUN   TestUserAnnotations
--- PASS: TestUserAnnotations (0.00s)
=== RUN   TestPrometheusConfigChangeBumpsHash
--- PASS: TestPrometheusConfigChangeBumpsHash (0.00s)
=== RUN   TestEmptyPrometheusHashUnchanged
--- PASS: TestEmptyPrometheusHashUnchanged (0.00s)
PASS
ok  github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/collector  0.028s

$ go build ./...
(build OK)
```

- `TestPrometheusConfigChangeBumpsHash` — hash is stable when nothing changes and
  **changes** when only `Spec.Prometheus` changes.
- `TestEmptyPrometheusHashUnchanged` — with no Prometheus config the hash is
  byte-identical to `sha256(Spec.Config)` (`9f86d081…`), proving non-Prometheus agents
  are unaffected.

### Test pass matrix (full Prometheus-on-EKS scenario suite)

| Test | Scenario | Result |
|------|----------|--------|
| Test 1 | DaemonSet, Prometheus scraping, Target Allocator disabled (baseline) | PASS |
| Test 2 | Small Prometheus-config tweak → pods must roll (**this PR**) | PASS |
| Test 3 | Single Deployment (1 replica), no Target Allocator → no spurious TA warning | PASS |
| Test 4 | StatefulSet, 2 replicas, Target Allocator disabled (baseline) | PASS |
| Test 5 | StatefulSet, 2 replicas, Target Allocator enabled → agent must not crash | PASS |
