### PR TITLE
Allocation Strategy and TA resilience

### DIFF
--- a/.github/workflows/build-ta-test.yml
+++ b/.github/workflows/build-ta-test.yml
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# build-ta-test.yml — manually build the Target Allocator from THIS branch and
+# push it to a test ECR repo, so it can be deployed for PodMonitor/ServiceMonitor
+# testing via:
+#
+#   USE_CUSTOM_IMAGES=true TA_TAG=<tag> ./scripts/deploy-all.sh
+#
+# Why this exists: enabling otelContainerInsights / prometheusCR makes the
+# operator launch the Target Allocator with `--enable-prometheus-cr-watcher`.
+# The pinned PUBLIC target-allocator:1.0.0 image predates that flag and
+# CrashLoops with `unknown flag`. The TA source on this branch DOES support it,
+# so we build it here. This is intentionally decoupled from the release/e2e
+# machinery in build-and-upload.yml — it only builds + pushes a test image.
+#
+# Prerequisites (one-time, in the GitHub repo settings):
+#   - Secret  AWS_ASSUME_ROLE : an IAM role ARN this repo's OIDC can assume,
+#       with ECR push perms (ecr:GetAuthorizationToken, ecr:BatchCheckLayer*,
+#       ecr:PutImage, ecr:InitiateLayerUpload, ecr:UploadLayerPart,
+#       ecr:CompleteLayerUpload) for the target repo.
+#   - The ECR repo (default below) must already exist in the account/region.
+
+name: Build TA Test Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      ecr_repo:
+        description: 'ECR repository path (without registry host)'
+        required: true
+        default: 'wenepra/cwagent-test/cloudwatch-agent-target-allocator'
+        type: string
+      tag:
+        description: 'Image tag to push'
+        required: true
+        default: 'test'
+        type: string
+      account_id:
+        description: 'AWS account ID that owns the ECR repo'
+        required: true
+        default: '037647485236'
+        type: string
+      region:
+        description: 'AWS region of the ECR repo'
+        required: true
+        default: 'us-west-2'
+        type: string
+      platforms:
+        description: 'Target platforms (m5.large test nodes are amd64)'
+        required: true
+        default: 'linux/amd64'
+        type: string
+
+env:
+  AWS_ASSUME_ROLE: ${{ secrets.AWS_ASSUME_ROLE }}
+
+jobs:
+  build-ta:
+    name: 'Build & push Target Allocator test image'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version: '>=1.25'
+          cache: true
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ env.AWS_ASSUME_ROLE }}
+          aws-region: ${{ inputs.region }}
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2.1.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Build TA binaries (per requested arch)
+        # The TA Dockerfile copies a prebuilt bin/targetallocator_${TARGETARCH},
+        # so build every arch named in the platforms input before docker build.
+        run: |
+          set -euo pipefail
+          go mod download
+          mkdir -p cmd/amazon-cloudwatch-agent-target-allocator/bin
+          IFS=',' read -ra PLATS <<< "${{ inputs.platforms }}"
+          for p in "${PLATS[@]}"; do
+            arch="${p##*/}"   # linux/amd64 -> amd64
+            echo ">> building targetallocator for ${arch}"
+            GOARCH="${arch}" ARCH="${arch}" make targetallocator
+          done
+          ls -la cmd/amazon-cloudwatch-agent-target-allocator/bin/
+
+      - name: Build & push Target Allocator image
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
+        with:
+          file: ./cmd/amazon-cloudwatch-agent-target-allocator/Dockerfile
+          context: ./cmd/amazon-cloudwatch-agent-target-allocator
+          push: true
+          platforms: ${{ inputs.platforms }}
+          tags: |
+            ${{ inputs.account_id }}.dkr.ecr.${{ inputs.region }}.amazonaws.com/${{ inputs.ecr_repo }}:${{ inputs.tag }}
+            ${{ inputs.account_id }}.dkr.ecr.${{ inputs.region }}.amazonaws.com/${{ inputs.ecr_repo }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Summary
+        run: |
+          IMG="${{ inputs.account_id }}.dkr.ecr.${{ inputs.region }}.amazonaws.com/${{ inputs.ecr_repo }}:${{ inputs.tag }}"
+          {
+            echo "### Target Allocator test image pushed"
+            echo ""
+            echo "\`${IMG}\`"
+            echo ""
+            echo "Deploy it:"
+            echo "\`\`\`"
+            echo "USE_CUSTOM_IMAGES=true TA_TAG=${{ inputs.tag }} \\"
+            echo "  TA_REPO=${{ inputs.ecr_repo }} \\"
+            echo "  CLUSTER_NAME=podmon-test REGION=${{ inputs.region }} \\"
+            echo "  ./scripts/deploy-all.sh"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apis/v1alpha1/allocation_strategy.go
+++ b/apis/v1alpha1/allocation_strategy.go
@@ -5,11 +5,15 @@ package v1alpha1
 
 type (
 	// AmazonCloudWatchAgentTargetAllocatorAllocationStrategy represent which strategy to distribute target to each collector
-	// +kubebuilder:validation:Enum=consistent-hashing
+	// +kubebuilder:validation:Enum=consistent-hashing;per-node
 	AmazonCloudWatchAgentTargetAllocatorAllocationStrategy string
 )
 
 const (
 	// AmazonCloudWatchAgentTargetAllocatorAllocationStrategyConsistentHashing targets will be consistently added to collectors, which allows a high-availability setup.
 	AmazonCloudWatchAgentTargetAllocatorAllocationStrategyConsistentHashing AmazonCloudWatchAgentTargetAllocatorAllocationStrategy = "consistent-hashing"
+
+	// AmazonCloudWatchAgentTargetAllocatorAllocationStrategyPerNode targets will be allocated to the collector running on the same node as the target.
+	// Targets without a resolvable node fall back to the configured fallback strategy (consistent-hashing).
+	AmazonCloudWatchAgentTargetAllocatorAllocationStrategyPerNode AmazonCloudWatchAgentTargetAllocatorAllocationStrategy = "per-node"
 )

--- a/cmd/amazon-cloudwatch-agent-target-allocator/allocation/consistent_hashing.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/allocation/consistent_hashing.go
@@ -150,7 +150,7 @@ func (c *consistentHashingAllocator) handleCollectors(diff diff.Changes[*Collect
 	}
 	// Insert the new collectors
 	for _, i := range diff.Additions() {
-		c.collectors[i.Name] = NewCollector(i.Name)
+		c.collectors[i.Name] = NewCollector(i.Name, i.NodeName)
 		c.consistentHasher.Add(c.collectors[i.Name])
 	}
 

--- a/cmd/amazon-cloudwatch-agent-target-allocator/allocation/per_node.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/allocation/per_node.go
@@ -1,0 +1,396 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package allocation
+
+import (
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/buraksezer/consistent"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/diff"
+	"github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/target"
+)
+
+var _ Allocator = &perNodeAllocator{}
+
+const perNodeStrategyName = "per-node"
+
+// placement is the outcome of allocating a single target, used for per-cycle
+// log summaries describing what the per-node strategy did.
+type placement int
+
+const (
+	placedByNode     placement = iota // assigned to the collector on the target's node
+	placedByFallback                  // assigned via the consistent-hashing fallback
+	unplaced                          // left unassigned (no node match, no fallback)
+)
+
+// perNodeAllocator assigns each target to the collector running on the same
+// Kubernetes node as the target. It mirrors the node-lookup logic of the
+// upstream OpenTelemetry target allocator's per-node strategy
+// (cmd/otel-allocator/internal/allocation/per_node.go), adapted to this fork's
+// fused Allocator model (see consistent_hashing.go where the allocator and the
+// placement strategy are a single type).
+//
+// Placement: a target's node comes from target.Item.GetNodeName() (the
+// __meta_kubernetes_*_node_name discovery labels); a collector's node comes from
+// Collector.NodeName (pod.Spec.NodeName, captured by the collector watcher).
+//
+// Unassigned targets: targets that carry no node (GetNodeName == "") or whose
+// node has no matching collector are placed via the fallback strategy when one
+// is configured (SetFallbackStrategy("consistent-hashing")); otherwise they are
+// retained in targetItems but assigned to no collector, re-evaluated on every
+// collector change, and surfaced via the
+// cloudwatch_agent_allocator_targets_unassigned gauge.
+type perNodeAllocator struct {
+	// m protects collectors, targetItems, targetItemsPerJobPerCollector,
+	// collectorByNode and fallbackHasher for concurrent use.
+	m sync.RWMutex
+
+	// collectors is a map from a Collector's name to a Collector instance.
+	collectors map[string]*Collector
+
+	// targetItems is a map from a target item's hash to the target item.
+	targetItems map[string]*target.Item
+
+	// collectorKey -> job -> target item hash -> true
+	targetItemsPerJobPerCollector map[string]map[string]map[string]bool
+
+	// collectorByNode indexes collectors by their NodeName for O(1) placement.
+	collectorByNode map[string]*Collector
+
+	// fallbackHasher, when non-nil, is a consistent-hashing ring over all
+	// collectors used to place targets that cannot be matched to a node.
+	fallbackHasher *consistent.Consistent
+
+	log logr.Logger
+
+	filter Filter
+}
+
+func newPerNodeAllocator(log logr.Logger, opts ...AllocationOption) Allocator {
+	pnAllocator := &perNodeAllocator{
+		collectors:                    make(map[string]*Collector),
+		targetItems:                   make(map[string]*target.Item),
+		targetItemsPerJobPerCollector: make(map[string]map[string]map[string]bool),
+		collectorByNode:               make(map[string]*Collector),
+		log:                           log,
+	}
+	for _, opt := range opts {
+		opt(pnAllocator)
+	}
+	return pnAllocator
+}
+
+// SetFilter sets the filtering hook to use.
+func (pn *perNodeAllocator) SetFilter(filter Filter) {
+	pn.filter = filter
+}
+
+// SetFallbackStrategy enables a fallback placement strategy for targets that
+// cannot be matched to a node. Only "consistent-hashing" is supported; any other
+// (or empty) name leaves the fallback disabled, so unmatched targets stay
+// unassigned. Mirrors the upstream per-node strategy's optional fallbackStrategy.
+func (pn *perNodeAllocator) SetFallbackStrategy(name string) {
+	pn.m.Lock()
+	defer pn.m.Unlock()
+	if name != consistentHashingStrategyName {
+		pn.log.Info("Unsupported fallback strategy for per-node, fallback disabled", "fallback", name)
+		pn.fallbackHasher = nil
+		return
+	}
+	cfg := consistent.Config{
+		PartitionCount:    1061,
+		ReplicationFactor: 5,
+		Load:              1.1,
+		Hasher:            hasher{},
+	}
+	pn.fallbackHasher = consistent.New(nil, cfg)
+	// Seed the ring with any collectors already known.
+	for _, c := range pn.collectors {
+		pn.fallbackHasher.Add(c)
+	}
+	pn.log.Info("Per-node fallback strategy enabled", "fallback", name)
+}
+
+// addCollectorTargetItemMapping tracks which collector has which jobs and targets.
+// The caller has to acquire a lock.
+func (pn *perNodeAllocator) addCollectorTargetItemMapping(tg *target.Item) {
+	if pn.targetItemsPerJobPerCollector[tg.CollectorName] == nil {
+		pn.targetItemsPerJobPerCollector[tg.CollectorName] = make(map[string]map[string]bool)
+	}
+	if pn.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] == nil {
+		pn.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] = make(map[string]bool)
+	}
+	pn.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName][tg.Hash()] = true
+}
+
+// addTargetToTargetItems assigns a target to the collector on the same node and
+// stores it in targetItems. The caller has to acquire a lock. Targets with no
+// resolvable node, or whose node has no matching collector, are placed via the
+// consistent-hashing fallback if configured, otherwise left unassigned.
+// It returns how the target was placed, for per-cycle log summaries.
+func (pn *perNodeAllocator) addTargetToTargetItems(tg *target.Item) placement {
+	// If this is a reassignment, decrement the previous collector's NumTargets.
+	if previousCol, ok := pn.collectors[tg.CollectorName]; ok && tg.CollectorName != "" {
+		previousCol.NumTargets--
+		delete(pn.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName], tg.Hash())
+		TargetsPerCollector.WithLabelValues(previousCol.String(), perNodeStrategyName).Set(float64(previousCol.NumTargets))
+	}
+
+	// Always keep the target in the pool so it can be (re)assigned later.
+	tg.CollectorName = ""
+	pn.targetItems[tg.Hash()] = tg
+
+	nodeName := tg.GetNodeName()
+	colOwner, ok := pn.collectorByNode[nodeName]
+	if nodeName != "" && ok {
+		tg.CollectorName = colOwner.Name
+		pn.addCollectorTargetItemMapping(tg)
+		colOwner.NumTargets++
+		TargetsPerCollector.WithLabelValues(colOwner.String(), perNodeStrategyName).Set(float64(colOwner.NumTargets))
+		pn.log.V(2).Info("per-node: assigned target to node-local collector",
+			"target", strings.Join(tg.TargetURL, ","), "job", tg.JobName, "node", nodeName, "collector", colOwner.Name)
+		return placedByNode
+	}
+
+	// No node, or no collector on that node. Use the consistent-hashing fallback
+	// if configured; otherwise leave the target unassigned.
+	if pn.fallbackHasher != nil && len(pn.collectors) > 0 {
+		member := pn.fallbackHasher.LocateKey([]byte(strings.Join(tg.TargetURL, "")))
+		if fallbackCol, exists := pn.collectors[member.String()]; exists {
+			tg.CollectorName = fallbackCol.Name
+			pn.addCollectorTargetItemMapping(tg)
+			fallbackCol.NumTargets++
+			TargetsPerCollector.WithLabelValues(fallbackCol.String(), perNodeStrategyName).Set(float64(fallbackCol.NumTargets))
+			reason := "target has no node label"
+			if nodeName != "" {
+				reason = "no collector running on node " + nodeName
+			}
+			pn.log.V(1).Info("per-node: no node-local collector, used consistent-hashing fallback",
+				"target", strings.Join(tg.TargetURL, ","), "job", tg.JobName, "node", nodeName, "collector", fallbackCol.Name, "reason", reason)
+			return placedByFallback
+		}
+	}
+	pn.log.V(1).Info("per-node: target left UNASSIGNED (no node-local collector and no usable fallback)",
+		"target", strings.Join(tg.TargetURL, ","), "job", tg.JobName, "node", nodeName)
+	return unplaced
+}
+
+// handleTargets reconciles added and removed targets against the current state.
+func (pn *perNodeAllocator) handleTargets(diff diff.Changes[*target.Item]) {
+	// Check for removals.
+	for k, item := range pn.targetItems {
+		if _, ok := diff.Removals()[k]; ok {
+			if col, ok := pn.collectors[item.CollectorName]; ok && item.CollectorName != "" {
+				col.NumTargets--
+				delete(pn.targetItemsPerJobPerCollector[item.CollectorName][item.JobName], item.Hash())
+				TargetsPerCollector.WithLabelValues(item.CollectorName, perNodeStrategyName).Set(float64(col.NumTargets))
+			}
+			delete(pn.targetItems, k)
+		}
+	}
+
+	// Check for additions.
+	var byNode, byFallback, unassigned, added int
+	for k, item := range diff.Additions() {
+		if _, ok := pn.targetItems[k]; ok {
+			continue
+		}
+		added++
+		switch pn.addTargetToTargetItems(item) {
+		case placedByNode:
+			byNode++
+		case placedByFallback:
+			byFallback++
+		case unplaced:
+			unassigned++
+		}
+	}
+
+	if added > 0 || len(diff.Removals()) > 0 {
+		pn.log.Info("per-node: target reconcile complete",
+			"added", added, "removed", len(diff.Removals()),
+			"assigned_by_node", byNode, "assigned_by_fallback", byFallback, "unassigned", unassigned,
+			"total_targets", len(pn.targetItems), "collectors", len(pn.collectors))
+	}
+
+	pn.recordUnassigned()
+}
+
+// handleCollectors reconciles added and removed collectors, rebuilds the node
+// index and re-allocates all known targets.
+func (pn *perNodeAllocator) handleCollectors(diff diff.Changes[*Collector]) {
+	// Clear removed collectors.
+	for _, k := range diff.Removals() {
+		delete(pn.collectors, k.Name)
+		delete(pn.targetItemsPerJobPerCollector, k.Name)
+		if pn.fallbackHasher != nil {
+			pn.fallbackHasher.Remove(k.Name)
+		}
+		TargetsPerCollector.WithLabelValues(k.Name, perNodeStrategyName).Set(0)
+	}
+	// Insert the new collectors.
+	for _, i := range diff.Additions() {
+		pn.collectors[i.Name] = NewCollector(i.Name, i.NodeName)
+		if pn.fallbackHasher != nil {
+			pn.fallbackHasher.Add(pn.collectors[i.Name])
+		}
+	}
+
+	// Rebuild the node index from the current collector set.
+	pn.collectorByNode = make(map[string]*Collector)
+	for _, c := range pn.collectors {
+		if c.NodeName != "" {
+			pn.collectorByNode[c.NodeName] = c
+		}
+	}
+
+	// Log the node->collector index so it's clear which node each agent owns.
+	mapping := make([]string, 0, len(pn.collectorByNode))
+	for node, c := range pn.collectorByNode {
+		mapping = append(mapping, node+"="+c.Name)
+	}
+	sort.Strings(mapping)
+	noNode := len(pn.collectors) - len(pn.collectorByNode)
+	pn.log.Info("per-node: collector node index rebuilt",
+		"collectors", len(pn.collectors), "nodes_indexed", len(pn.collectorByNode),
+		"collectors_without_node", noNode, "mapping", strings.Join(mapping, ","))
+
+	// Re-allocate all targets against the new collector set.
+	var byNode, byFallback, unassigned int
+	for _, item := range pn.targetItems {
+		switch pn.addTargetToTargetItems(item) {
+		case placedByNode:
+			byNode++
+		case placedByFallback:
+			byFallback++
+		case unplaced:
+			unassigned++
+		}
+	}
+	pn.log.Info("per-node: re-allocated all targets after collector change",
+		"added_collectors", len(diff.Additions()), "removed_collectors", len(diff.Removals()),
+		"assigned_by_node", byNode, "assigned_by_fallback", byFallback, "unassigned", unassigned,
+		"total_targets", len(pn.targetItems))
+
+	pn.recordUnassigned()
+}
+
+// recordUnassigned updates the unassigned-targets gauge. Caller must hold the lock.
+func (pn *perNodeAllocator) recordUnassigned() {
+	var count float64
+	for _, item := range pn.targetItems {
+		if item.CollectorName == "" {
+			count++
+		}
+	}
+	targetsUnassigned.Set(count)
+}
+
+// SetTargets accepts a list of targets that will be used to make load balancing
+// decisions. This method should be called when there are new targets discovered
+// or existing targets are shutdown.
+func (pn *perNodeAllocator) SetTargets(targets map[string]*target.Item) {
+	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", perNodeStrategyName))
+	defer timer.ObserveDuration()
+
+	if pn.filter != nil {
+		targets = pn.filter.Apply(targets)
+	}
+	RecordTargetsKept(targets)
+
+	pn.m.Lock()
+	defer pn.m.Unlock()
+
+	// If there are no collectors, just track the targets so they can be assigned
+	// once collectors appear.
+	if len(pn.collectors) == 0 {
+		pn.log.Info("No collector instances present, saving targets to allocate to collector(s)")
+		targetsDiff := diff.Maps(pn.targetItems, targets)
+		for k, item := range targetsDiff.Additions() {
+			if _, ok := pn.targetItems[k]; !ok {
+				pn.targetItems[k] = item
+			}
+		}
+		for k := range targetsDiff.Removals() {
+			delete(pn.targetItems, k)
+		}
+		pn.recordUnassigned()
+		return
+	}
+
+	// Check for target changes.
+	targetsDiff := diff.Maps(pn.targetItems, targets)
+	if len(targetsDiff.Additions()) != 0 || len(targetsDiff.Removals()) != 0 {
+		pn.handleTargets(targetsDiff)
+	}
+}
+
+// SetCollectors sets the set of collectors with key=collectorName, value=Collector object.
+// This method is called when Collectors are added or removed.
+func (pn *perNodeAllocator) SetCollectors(collectors map[string]*Collector) {
+	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetCollectors", perNodeStrategyName))
+	defer timer.ObserveDuration()
+
+	CollectorsAllocatable.WithLabelValues(perNodeStrategyName).Set(float64(len(collectors)))
+	if len(collectors) == 0 {
+		pn.log.Info("No collector instances present")
+		return
+	}
+
+	pn.m.Lock()
+	defer pn.m.Unlock()
+
+	// Check for collector changes.
+	collectorsDiff := diff.Maps(pn.collectors, collectors)
+	if len(collectorsDiff.Additions()) != 0 || len(collectorsDiff.Removals()) != 0 {
+		pn.handleCollectors(collectorsDiff)
+	}
+	pn.log.Info("Setting collector completed")
+}
+
+func (pn *perNodeAllocator) GetTargetsForCollectorAndJob(collector string, job string) []*target.Item {
+	pn.m.RLock()
+	defer pn.m.RUnlock()
+	if _, ok := pn.targetItemsPerJobPerCollector[collector]; !ok {
+		return []*target.Item{}
+	}
+	if _, ok := pn.targetItemsPerJobPerCollector[collector][job]; !ok {
+		return []*target.Item{}
+	}
+	targetItemsCopy := make([]*target.Item, len(pn.targetItemsPerJobPerCollector[collector][job]))
+	index := 0
+	for targetHash := range pn.targetItemsPerJobPerCollector[collector][job] {
+		targetItemsCopy[index] = pn.targetItems[targetHash]
+		index++
+	}
+	return targetItemsCopy
+}
+
+// TargetItems returns a shallow copy of the targetItems map.
+func (pn *perNodeAllocator) TargetItems() map[string]*target.Item {
+	pn.m.RLock()
+	defer pn.m.RUnlock()
+	targetItemsCopy := make(map[string]*target.Item)
+	for k, v := range pn.targetItems {
+		targetItemsCopy[k] = v
+	}
+	return targetItemsCopy
+}
+
+// Collectors returns a shallow copy of the collectors map.
+func (pn *perNodeAllocator) Collectors() map[string]*Collector {
+	pn.m.RLock()
+	defer pn.m.RUnlock()
+	collectorsCopy := make(map[string]*Collector)
+	for k, v := range pn.collectors {
+		collectorsCopy[k] = v
+	}
+	return collectorsCopy
+}

--- a/cmd/amazon-cloudwatch-agent-target-allocator/allocation/per_node_test.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/allocation/per_node_test.go
@@ -1,0 +1,161 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package allocation
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/cmd/amazon-cloudwatch-agent-target-allocator/target"
+)
+
+// nodeTarget builds a target carrying the pod node-name discovery label.
+func nodeTarget(job, url, node string) *target.Item {
+	lbls := model.LabelSet{}
+	if node != "" {
+		lbls[model.LabelName("__meta_kubernetes_pod_node_name")] = model.LabelValue(node)
+	}
+	return target.NewItem(job, url, lbls, "")
+}
+
+func newPerNodeTestAllocator() *perNodeAllocator {
+	return newPerNodeAllocator(logger).(*perNodeAllocator)
+}
+
+// TestPerNodeRegistered ensures the strategy is wired into the registry.
+func TestPerNodeRegistered(t *testing.T) {
+	a, err := New(perNodeStrategyName, logger)
+	require.NoError(t, err)
+	require.NotNil(t, a)
+}
+
+// TestPerNodeAssignsToMatchingNode verifies each target lands on the collector
+// running on the target's node, and only that collector.
+func TestPerNodeAssignsToMatchingNode(t *testing.T) {
+	c := newPerNodeTestAllocator()
+	c.SetCollectors(map[string]*Collector{
+		"collector-a": NewCollector("collector-a", "node-a"),
+		"collector-b": NewCollector("collector-b", "node-b"),
+	})
+
+	targets := map[string]*target.Item{}
+	for _, tg := range []*target.Item{
+		nodeTarget("job1", "10.0.0.1:8080", "node-a"),
+		nodeTarget("job1", "10.0.0.2:8080", "node-a"),
+		nodeTarget("job1", "10.0.0.3:8080", "node-b"),
+	} {
+		targets[tg.Hash()] = tg
+	}
+	c.SetTargets(targets)
+
+	assert.Len(t, c.TargetItems(), 3)
+
+	aTargets := c.GetTargetsForCollectorAndJob("collector-a", "job1")
+	bTargets := c.GetTargetsForCollectorAndJob("collector-b", "job1")
+	assert.Len(t, aTargets, 2, "node-a collector should own both node-a targets")
+	assert.Len(t, bTargets, 1, "node-b collector should own the single node-b target")
+
+	for _, ti := range aTargets {
+		assert.Equal(t, "collector-a", ti.CollectorName)
+		assert.Equal(t, "node-a", ti.GetNodeName())
+	}
+	for _, ti := range bTargets {
+		assert.Equal(t, "collector-b", ti.CollectorName)
+		assert.Equal(t, "node-b", ti.GetNodeName())
+	}
+}
+
+// TestPerNodeLeavesNodelessTargetUnassigned verifies a target without a node
+// label is retained but assigned to no collector.
+func TestPerNodeLeavesNodelessTargetUnassigned(t *testing.T) {
+	c := newPerNodeTestAllocator()
+	c.SetCollectors(map[string]*Collector{
+		"collector-a": NewCollector("collector-a", "node-a"),
+	})
+
+	onNode := nodeTarget("job1", "10.0.0.1:8080", "node-a")
+	noNode := nodeTarget("job1", "10.0.0.9:8080", "") // external/non-pod endpoint
+	c.SetTargets(map[string]*target.Item{
+		onNode.Hash(): onNode,
+		noNode.Hash(): noNode,
+	})
+
+	// Both are tracked.
+	assert.Len(t, c.TargetItems(), 2)
+	// Only the node-matched target is assigned to the collector.
+	assigned := c.GetTargetsForCollectorAndJob("collector-a", "job1")
+	assert.Len(t, assigned, 1)
+	assert.Equal(t, onNode.Hash(), assigned[0].Hash())
+
+	// The node-less target carries no collector.
+	for _, ti := range c.TargetItems() {
+		if ti.Hash() == noNode.Hash() {
+			assert.Equal(t, "", ti.CollectorName, "node-less target must stay unassigned")
+		}
+	}
+}
+
+// TestPerNodeFallbackAssignsNodelessTarget verifies that, with a consistent-hashing
+// fallback configured, a target without a node is still placed on some collector
+// rather than left unassigned.
+func TestPerNodeFallbackAssignsNodelessTarget(t *testing.T) {
+	a, err := New(perNodeStrategyName, logger, WithFallbackStrategy(consistentHashingStrategyName))
+	require.NoError(t, err)
+	c := a.(*perNodeAllocator)
+
+	c.SetCollectors(map[string]*Collector{
+		"collector-a": NewCollector("collector-a", "node-a"),
+		"collector-b": NewCollector("collector-b", "node-b"),
+	})
+
+	onNode := nodeTarget("job1", "10.0.0.1:8080", "node-a")
+	noNode := nodeTarget("job1", "10.0.0.9:8080", "") // external/non-pod endpoint
+	c.SetTargets(map[string]*target.Item{
+		onNode.Hash(): onNode,
+		noNode.Hash(): noNode,
+	})
+
+	// node-matched target lands on its node's collector.
+	assert.Equal(t, "collector-a", onNode.CollectorName)
+
+	// node-less target is assigned to *some* collector via the fallback (not "").
+	var found *target.Item
+	for _, ti := range c.TargetItems() {
+		if ti.Hash() == noNode.Hash() {
+			found = ti
+		}
+	}
+	require.NotNil(t, found)
+	assert.NotEqual(t, "", found.CollectorName, "node-less target must be placed by the consistent-hashing fallback")
+	_, isRealCollector := c.Collectors()[found.CollectorName]
+	assert.True(t, isRealCollector, "fallback must assign to a known collector")
+}
+
+// target (its node had no collector) gets placed once a matching collector joins.
+func TestPerNodeReallocatesWhenCollectorAppears(t *testing.T) {
+	c := newPerNodeTestAllocator()
+	// Only node-a has a collector initially.
+	c.SetCollectors(map[string]*Collector{
+		"collector-a": NewCollector("collector-a", "node-a"),
+	})
+
+	onB := nodeTarget("job1", "10.0.0.3:8080", "node-b")
+	c.SetTargets(map[string]*target.Item{onB.Hash(): onB})
+
+	// node-b target cannot be placed yet.
+	assert.Empty(t, c.GetTargetsForCollectorAndJob("collector-b", "job1"))
+
+	// node-b collector joins; target should now be assigned to it.
+	c.SetCollectors(map[string]*Collector{
+		"collector-a": NewCollector("collector-a", "node-a"),
+		"collector-b": NewCollector("collector-b", "node-b"),
+	})
+
+	bTargets := c.GetTargetsForCollectorAndJob("collector-b", "job1")
+	require.Len(t, bTargets, 1)
+	assert.Equal(t, "collector-b", bTargets[0].CollectorName)
+}

--- a/cmd/amazon-cloudwatch-agent-target-allocator/allocation/strategy.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/allocation/strategy.go
@@ -38,6 +38,14 @@ var (
 		Name: "cloudwatch_agent_allocator_targets_remaining",
 		Help: "Number of targets kept after filtering.",
 	})
+	// targetsUnassigned records targets that could not be placed on any collector
+	// (e.g. per-node strategy: target has no node label, or no collector runs on
+	// the target's node). Such targets are retained and re-evaluated on the next
+	// collector change, but are not scraped until they can be assigned.
+	targetsUnassigned = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cloudwatch_agent_allocator_targets_unassigned",
+		Help: "Number of targets that could not be assigned to a collector.",
+	})
 )
 
 type AllocationOption func(Allocator)
@@ -49,6 +57,26 @@ type Filter interface {
 func WithFilter(filter Filter) AllocationOption {
 	return func(allocator Allocator) {
 		allocator.SetFilter(filter)
+	}
+}
+
+// fallbackStrategySetter is implemented by allocators that support a fallback
+// placement strategy for targets the primary strategy cannot assign.
+type fallbackStrategySetter interface {
+	SetFallbackStrategy(name string)
+}
+
+// WithFallbackStrategy configures a fallback placement strategy by name. It is a
+// no-op for an empty name or for allocators that don't support a fallback
+// (only per-node does today).
+func WithFallbackStrategy(name string) AllocationOption {
+	return func(allocator Allocator) {
+		if name == "" {
+			return
+		}
+		if setter, ok := allocator.(fallbackStrategySetter); ok {
+			setter.SetFallbackStrategy(name)
+		}
 	}
 }
 
@@ -92,9 +120,12 @@ var _ consistent.Member = Collector{}
 
 // Collector Creates a struct that holds Collector information.
 // This struct will be parsed into endpoint with Collector and jobs info.
+// NodeName is the Kubernetes node the collector pod runs on; it is used by the
+// per-node allocation strategy to match targets to the collector on their node.
 // This struct can be extended with information like annotations and labels in the future.
 type Collector struct {
 	Name       string
+	NodeName   string
 	NumTargets int
 }
 
@@ -106,12 +137,16 @@ func (c Collector) String() string {
 	return c.Name
 }
 
-func NewCollector(name string) *Collector {
-	return &Collector{Name: name}
+func NewCollector(name, node string) *Collector {
+	return &Collector{Name: name, NodeName: node}
 }
 
 func init() {
 	err := Register(consistentHashingStrategyName, newConsistentHashingAllocator)
+	if err != nil {
+		panic(err)
+	}
+	err = Register(perNodeStrategyName, newPerNodeAllocator)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/amazon-cloudwatch-agent-target-allocator/allocation/strategy_test.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/allocation/strategy_test.go
@@ -78,11 +78,11 @@ func Benchmark_Setting(b *testing.B) {
 }
 
 func TestCollectorDiff(t *testing.T) {
-	collector0 := NewCollector("collector-0")
-	collector1 := NewCollector("collector-1")
-	collector2 := NewCollector("collector-2")
-	collector3 := NewCollector("collector-3")
-	collector4 := NewCollector("collector-4")
+	collector0 := NewCollector("collector-0", "")
+	collector1 := NewCollector("collector-1", "")
+	collector2 := NewCollector("collector-2", "")
+	collector3 := NewCollector("collector-3", "")
+	collector4 := NewCollector("collector-4", "")
 	type args struct {
 		current map[string]*Collector
 		new     map[string]*Collector

--- a/cmd/amazon-cloudwatch-agent-target-allocator/collector/collector.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/collector/collector.go
@@ -65,8 +65,11 @@ func (k *Client) Watch(ctx context.Context, labelMap map[string]string, fn func(
 	}
 	for i := range pods.Items {
 		pod := pods.Items[i]
-		if pod.GetObjectMeta().GetDeletionTimestamp() == nil {
-			collectorMap[pod.Name] = allocation.NewCollector(pod.Name)
+		// Only register a collector once its pod is scheduled (NodeName set); an
+		// unscheduled pod has no node, so the per-node strategy could not match
+		// targets to it. It is picked up later via the Modified watch event.
+		if pod.GetObjectMeta().GetDeletionTimestamp() == nil && pod.Spec.NodeName != "" {
+			collectorMap[pod.Name] = allocation.NewCollector(pod.Name, pod.Spec.NodeName)
 		}
 	}
 	fn(collectorMap)
@@ -117,8 +120,15 @@ func runWatch(ctx context.Context, k *Client, c <-chan watch.Event, collectorMap
 			}
 
 			switch event.Type { //nolint:exhaustive
-			case watch.Added:
-				collectorMap[pod.Name] = allocation.NewCollector(pod.Name)
+			case watch.Added, watch.Modified:
+				// Register/refresh the collector only once its pod is scheduled
+				// (NodeName set). Handling Modified captures the node when a pod that
+				// was Added while still unscheduled is later assigned to a node, so the
+				// per-node strategy can match this collector's node without needing a
+				// Target Allocator restart after agent (re)scheduling.
+				if pod.Spec.NodeName != "" {
+					collectorMap[pod.Name] = allocation.NewCollector(pod.Name, pod.Spec.NodeName)
+				}
 			case watch.Deleted:
 				delete(collectorMap, pod.Name)
 			}

--- a/cmd/amazon-cloudwatch-agent-target-allocator/collector/collector_test.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/collector/collector_test.go
@@ -58,6 +58,9 @@ func pod(name string) *v1.Pod {
 			Namespace: "test-ns",
 			Labels:    labelSet,
 		},
+		Spec: v1.PodSpec{
+			NodeName: name + "-node",
+		},
 	}
 }
 
@@ -86,13 +89,16 @@ func Test_runWatch(t *testing.T) {
 			},
 			want: map[string]*allocation.Collector{
 				"test-pod1": {
-					Name: "test-pod1",
+					Name:     "test-pod1",
+					NodeName: "test-pod1-node",
 				},
 				"test-pod2": {
-					Name: "test-pod2",
+					Name:     "test-pod2",
+					NodeName: "test-pod2-node",
 				},
 				"test-pod3": {
-					Name: "test-pod3",
+					Name:     "test-pod3",
+					NodeName: "test-pod3-node",
 				},
 			},
 		},
@@ -120,7 +126,8 @@ func Test_runWatch(t *testing.T) {
 			},
 			want: map[string]*allocation.Collector{
 				"test-pod1": {
-					Name: "test-pod1",
+					Name:     "test-pod1",
+					NodeName: "test-pod1-node",
 				},
 			},
 		},

--- a/cmd/amazon-cloudwatch-agent-target-allocator/config/config.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	LabelSelector          map[string]string     `yaml:"label_selector,omitempty"`
 	PromConfig             *promconfig.Config    `yaml:"config"`
 	AllocationStrategy     *string               `yaml:"allocation_strategy,omitempty"`
+	FallbackAllocationStrategy *string           `yaml:"allocation_fallback_strategy,omitempty"`
 	FilterStrategy         *string               `yaml:"filter_strategy,omitempty"`
 	PrometheusCR           PrometheusCRConfig    `yaml:"prometheus_cr,omitempty"`
 	PodMonitorSelector     map[string]string     `yaml:"pod_monitor_selector,omitempty"`
@@ -76,6 +77,16 @@ func (c Config) GetAllocationStrategy() string {
 		return *c.AllocationStrategy
 	}
 	return DefaultAllocationStrategy
+}
+
+// GetAllocationFallbackStrategy returns the strategy used to place targets that
+// the primary strategy cannot assign (e.g. per-node targets with no node match).
+// Empty means no fallback (such targets are left unassigned).
+func (c Config) GetAllocationFallbackStrategy() string {
+	if c.FallbackAllocationStrategy != nil {
+		return *c.FallbackAllocationStrategy
+	}
+	return ""
 }
 
 func (c Config) GetTargetsFilterStrategy() string {

--- a/cmd/amazon-cloudwatch-agent-target-allocator/config/config.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/config/config.go
@@ -144,6 +144,14 @@ func LoadFromCLI(target *Config, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	prometheusCREnabled, err := getPrometheusCREnabled(flagSet)
+	if err != nil {
+		return err
+	}
+	// The configmap only carries prometheus_cr settings (scrape_interval/selectors),
+	// never "enabled"; the operator signals CR watching exclusively via this flag.
+	target.PrometheusCR.Enabled = target.PrometheusCR.Enabled || prometheusCREnabled
+
 	return nil
 }
 

--- a/cmd/amazon-cloudwatch-agent-target-allocator/config/flags.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/config/flags.go
@@ -34,6 +34,7 @@ func getFlagSet(errorHandling pflag.ErrorHandling) *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet(targetAllocatorName, errorHandling)
 	flagSet.String(configFilePathFlagName, DefaultConfigFilePath, "The path to the config file.")
 	flagSet.String(kubeConfigPathFlagName, filepath.Join(homedir.HomeDir(), ".kube", "config"), "absolute path to the KubeconfigPath file")
+	flagSet.Bool(prometheusCREnabledFlagName, false, "Enable the Prometheus CR (ServiceMonitor/PodMonitor) discovery watcher.")
 	flagSet.Bool(reloadConfigFlagName, false, "Enable automatic configuration reloading. This functionality is deprecated and will be removed in a future release.")
 	flagSet.Bool(httpsEnabledFlagName, true, "Enable HTTPS additional server")
 	flagSet.String(listenAddrHttpsFlagName, ":8443", "The address where this service serves over HTTPS.")
@@ -56,6 +57,10 @@ func getKubeConfigFilePath(flagSet *pflag.FlagSet) (string, error) {
 
 func getConfigReloadEnabled(flagSet *pflag.FlagSet) (bool, error) {
 	return flagSet.GetBool(reloadConfigFlagName)
+}
+
+func getPrometheusCREnabled(flagSet *pflag.FlagSet) (bool, error) {
+	return flagSet.GetBool(prometheusCREnabledFlagName)
 }
 
 func getHttpsListenAddr(flagSet *pflag.FlagSet) (string, error) {

--- a/cmd/amazon-cloudwatch-agent-target-allocator/main.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/main.go
@@ -73,7 +73,9 @@ func main() {
 	log := ctrl.Log.WithName("allocator")
 
 	allocatorPrehook = prehook.New(cfg.GetTargetsFilterStrategy(), log)
-	allocator, err = allocation.New(cfg.GetAllocationStrategy(), log, allocation.WithFilter(allocatorPrehook))
+	allocator, err = allocation.New(cfg.GetAllocationStrategy(), log,
+		allocation.WithFilter(allocatorPrehook),
+		allocation.WithFallbackStrategy(cfg.GetAllocationFallbackStrategy()))
 	if err != nil {
 		setupLog.Error(err, "Unable to initialize allocation strategy")
 		os.Exit(1)

--- a/cmd/amazon-cloudwatch-agent-target-allocator/main.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -88,7 +89,18 @@ func main() {
 	srv := server.NewServer(log, allocator, cfg.ListenAddr, httpOptions...)
 
 	discoveryCtx, discoveryCancel := context.WithCancel(ctx)
-	discoveryManager = discovery.NewManager(discoveryCtx, nil, prometheus.NewRegistry(), nil)
+	// The discovery manager requires registered SD metrics; passing nil causes
+	// every SD provider (e.g. kubernetes_sd) to fail creation and silently
+	// resolve zero targets. A real logger is passed so any SD failure surfaces
+	// instead of going to the manager's default no-op logger.
+	discoveryRegistry := prometheus.NewRegistry()
+	sdMetrics, sdMetricsErr := discovery.CreateAndRegisterSDMetrics(discoveryRegistry)
+	if sdMetricsErr != nil {
+		setupLog.Error(sdMetricsErr, "Unable to register service discovery metrics")
+		os.Exit(1)
+	}
+	discoveryLogger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	discoveryManager = discovery.NewManager(discoveryCtx, discoveryLogger, discoveryRegistry, sdMetrics)
 
 	targetDiscoverer = target.NewDiscoverer(log, discoveryManager, allocatorPrehook, srv)
 	collectorWatcher, collectorWatcherErr := collector.NewClient(log, cfg.ClusterConfig)

--- a/cmd/amazon-cloudwatch-agent-target-allocator/target/target.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/target/target.go
@@ -10,6 +10,19 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+// nodeLabels are the discovery meta-labels that identify the node a target
+// resides on. They mirror the upstream OpenTelemetry target allocator's
+// per-node node-label set. See:
+// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
+const (
+	nodeNameLabelPod      model.LabelName = "__meta_kubernetes_pod_node_name"
+	nodeNameLabelNode     model.LabelName = "__meta_kubernetes_node_name"
+	nodeNameLabelEndpoint model.LabelName = "__meta_kubernetes_endpoint_node_name"
+
+	endpointSliceTargetKindLabel model.LabelName = "__meta_kubernetes_endpointslice_address_target_kind"
+	endpointSliceTargetNameLabel model.LabelName = "__meta_kubernetes_endpointslice_address_target_name"
+)
+
 // LinkJSON This package contains common structs and methods that relate to scrape targets.
 type LinkJSON struct {
 	Link string `json:"_link"`
@@ -26,6 +39,25 @@ type Item struct {
 
 func (t *Item) Hash() string {
 	return t.hash
+}
+
+// GetNodeName returns the Kubernetes node a target resides on, derived from its
+// service-discovery meta labels. Pod targets (PodMonitor, role: pod) always carry
+// a node; endpoint targets (ServiceMonitor, role: endpoints/endpointslice) only
+// carry one when the endpoint is backed by a pod on a node. Returns "" when no
+// node can be determined (e.g. non-pod / external endpoints), in which case the
+// per-node strategy leaves the target unassigned.
+func (t *Item) GetNodeName() string {
+	for _, labelName := range []model.LabelName{nodeNameLabelPod, nodeNameLabelNode, nodeNameLabelEndpoint} {
+		if val := t.Labels[labelName]; val != "" {
+			return string(val)
+		}
+	}
+
+	if t.Labels[endpointSliceTargetKindLabel] != "Node" {
+		return ""
+	}
+	return string(t.Labels[endpointSliceTargetNameLabel])
 }
 
 // NewItem Creates a new target item.

--- a/cmd/amazon-cloudwatch-agent-target-allocator/watcher/promOperator.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/watcher/promOperator.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -20,9 +21,14 @@ import (
 	promconfig "github.com/prometheus/prometheus/config"
 	kubeDiscovery "github.com/prometheus/prometheus/discovery/kubernetes"
 	"gopkg.in/yaml.v2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -30,6 +36,22 @@ import (
 )
 
 const minEventInterval = time.Second * 5
+
+// monitoringResources maps the prometheus-operator resource name to the
+// GroupVersionResource used to build its informer.
+var monitoringResources = map[string]schema.GroupVersionResource{
+	monitoringv1.ServiceMonitorName: monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName),
+	monitoringv1.PodMonitorName:     monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName),
+}
+
+// crdNameToResource maps a CustomResourceDefinition object name to the
+// prometheus-operator resource key whose informer it backs. The TA watches
+// these CRDs so it can start/stop each informer independently as the CRD
+// appears or disappears, rather than requiring both CRDs to exist at startup.
+var crdNameToResource = map[string]string{
+	monitoringv1.ServiceMonitorName + "." + monitoringv1.SchemeGroupVersion.Group: monitoringv1.ServiceMonitorName,
+	monitoringv1.PodMonitorName + "." + monitoringv1.SchemeGroupVersion.Group:     monitoringv1.PodMonitorName,
+}
 
 func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*PrometheusCRWatcher, error) {
 	mClient, err := monitoringclient.NewForConfig(cfg.ClusterConfig)
@@ -42,9 +64,7 @@ func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*Pr
 		return nil, err
 	}
 
-	factory := informers.NewMonitoringInformerFactories(map[string]struct{}{v1.NamespaceAll: {}}, map[string]struct{}{}, mClient, allocatorconfig.DefaultResyncTime, nil) //TODO decide what strategy to use regarding namespaces
-
-	monitoringInformers, err := getInformers(factory)
+	crdClient, err := apiextensionsclient.NewForConfig(cfg.ClusterConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -83,11 +103,17 @@ func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*Pr
 
 	podMonSelector := getSelector(cfg.PodMonitorSelector)
 
+	// Informers are NOT built here. Each ServiceMonitor/PodMonitor informer is
+	// started lazily, only once its CRD is observed to exist (see Watch). This
+	// lets the TA start and run healthily whether or not the CRDs are present,
+	// and pick up each type independently when its CRD appears.
 	return &PrometheusCRWatcher{
 		logger:                 logger,
 		kubeMonitoringClient:   mClient,
 		k8sClient:              clientset,
-		informers:              monitoringInformers,
+		crdClient:              crdClient,
+		informers:              map[string]*informers.ForResource{},
+		informerStopChannels:   map[string]chan struct{}{},
 		stopChannel:            make(chan struct{}),
 		eventInterval:          minEventInterval,
 		configGenerator:        generator,
@@ -102,12 +128,18 @@ type PrometheusCRWatcher struct {
 	logger               logr.Logger
 	kubeMonitoringClient monitoringclient.Interface
 	k8sClient            kubernetes.Interface
-	informers            map[string]*informers.ForResource
+	crdClient            apiextensionsclient.Interface
 	eventInterval        time.Duration
 	stopChannel          chan struct{}
 	configGenerator      *prometheus.ConfigGenerator
 	prom                 *monitoringv1.Prometheus
 	kubeConfigPath       string
+
+	// informersMtx guards informers and informerStopChannels, which are mutated
+	// from CRD-watch event handlers (separate goroutines) and read by LoadConfig.
+	informersMtx         sync.RWMutex
+	informers            map[string]*informers.ForResource
+	informerStopChannels map[string]chan struct{}
 
 	serviceMonitorSelector labels.Selector
 	podMonitorSelector     labels.Selector
@@ -120,64 +152,197 @@ func getSelector(s map[string]string) labels.Selector {
 	return labels.SelectorFromSet(s)
 }
 
-// getInformers returns a map of informers for the given resources.
-func getInformers(factory informers.FactoriesForNamespaces) (map[string]*informers.ForResource, error) {
-	serviceMonitorInformers, err := informers.NewInformersForResource(factory, monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.ServiceMonitorName))
-	if err != nil {
-		return nil, err
-	}
-
-	podMonitorInformers, err := informers.NewInformersForResource(factory, monitoringv1.SchemeGroupVersion.WithResource(monitoringv1.PodMonitorName))
-	if err != nil {
-		return nil, err
-	}
-
-	return map[string]*informers.ForResource{
-		monitoringv1.ServiceMonitorName: serviceMonitorInformers,
-		monitoringv1.PodMonitorName:     podMonitorInformers,
-	}, nil
+// newMonitoringFactory builds a fresh monitoring informer factory. A new factory
+// is created per informer start so that a stopped informer (its CRD was deleted)
+// can be cleanly restarted later if the CRD is recreated — shared informers
+// cannot be restarted once their stop channel is closed.
+func (w *PrometheusCRWatcher) newMonitoringFactory() informers.FactoriesForNamespaces {
+	return informers.NewMonitoringInformerFactories(
+		map[string]struct{}{v1.NamespaceAll: {}},
+		map[string]struct{}{},
+		w.kubeMonitoringClient,
+		allocatorconfig.DefaultResyncTime,
+		nil,
+	) //TODO decide what strategy to use regarding namespaces
 }
 
-// Watch wrapped informers and wait for an initial sync.
+// crdExists reports whether the named CustomResourceDefinition is currently
+// registered in the cluster.
+func (w *PrometheusCRWatcher) crdExists(ctx context.Context, crdName string) (bool, error) {
+	_, err := w.crdClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, crdName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// startMonitorInformer builds and starts the informer for a single monitoring
+// resource (ServiceMonitor or PodMonitor), waits for its cache to sync, wires up
+// the notification handler, and records it for use by LoadConfig. It is
+// idempotent: calling it for an already-running informer is a no-op.
+func (w *PrometheusCRWatcher) startMonitorInformer(resourceName string, notifyEvents chan struct{}) error {
+	w.informersMtx.Lock()
+	defer w.informersMtx.Unlock()
+
+	if _, running := w.informers[resourceName]; running {
+		return nil
+	}
+
+	gvr, ok := monitoringResources[resourceName]
+	if !ok {
+		return fmt.Errorf("unknown monitoring resource %q", resourceName)
+	}
+
+	informer, err := informers.NewInformersForResource(w.newMonitoringFactory(), gvr)
+	if err != nil {
+		return err
+	}
+
+	stopCh := make(chan struct{})
+	informer.Start(stopCh)
+	if ok := cache.WaitForNamedCacheSync(resourceName, stopCh, informer.HasSynced); !ok {
+		close(stopCh)
+		return fmt.Errorf("failed to sync %s informer cache", resourceName)
+	}
+
+	informer.AddEventHandler(notifyHandler(notifyEvents))
+
+	w.informers[resourceName] = informer
+	w.informerStopChannels[resourceName] = stopCh
+
+	// A new resource type just became available; trigger a config reload.
+	notify(notifyEvents)
+	return nil
+}
+
+// stopMonitorInformer stops the informer for a single monitoring resource (its
+// CRD was removed) and drops it from the active set so its targets are no longer
+// generated. It is idempotent.
+func (w *PrometheusCRWatcher) stopMonitorInformer(resourceName string, notifyEvents chan struct{}) {
+	w.informersMtx.Lock()
+	defer w.informersMtx.Unlock()
+
+	stopCh, running := w.informerStopChannels[resourceName]
+	if !running {
+		return
+	}
+	close(stopCh)
+	delete(w.informerStopChannels, resourceName)
+	delete(w.informers, resourceName)
+
+	// The type went away; trigger a config reload so its targets are dropped.
+	notify(notifyEvents)
+}
+
+// crdObjectName extracts the CustomResourceDefinition name from an informer
+// event object, tolerating the tombstone wrapper delivered on some deletes.
+func crdObjectName(obj interface{}) (string, bool) {
+	switch t := obj.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		return t.Name, true
+	case cache.DeletedFinalStateUnknown:
+		if crd, ok := t.Obj.(*apiextensionsv1.CustomResourceDefinition); ok {
+			return crd.Name, true
+		}
+	}
+	return "", false
+}
+
+// watchCRDs starts a CustomResourceDefinition informer that starts/stops the
+// per-type monitoring informers as the ServiceMonitor/PodMonitor CRDs are
+// created or deleted at runtime — no TA restart required. The informer replays
+// existing CRDs on its initial sync, so CRDs present at startup are handled here
+// too (startMonitorInformer is idempotent).
+func (w *PrometheusCRWatcher) watchCRDs(notifyEvents chan struct{}) {
+	factory := apiextensionsinformers.NewSharedInformerFactory(w.crdClient, allocatorconfig.DefaultResyncTime)
+	crdInformer := factory.Apiextensions().V1().CustomResourceDefinitions().Informer()
+	_, _ = crdInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			name, ok := crdObjectName(obj)
+			if !ok {
+				return
+			}
+			resourceName, tracked := crdNameToResource[name]
+			if !tracked {
+				return
+			}
+			if err := w.startMonitorInformer(resourceName, notifyEvents); err != nil {
+				w.logger.Error(err, "prometheus-cr: failed to start informer after CRD became available", "crd", name)
+				return
+			}
+			w.logger.Info("prometheus-cr: CRD available, started informer", "crd", name, "resource", resourceName)
+		},
+		DeleteFunc: func(obj interface{}) {
+			name, ok := crdObjectName(obj)
+			if !ok {
+				return
+			}
+			resourceName, tracked := crdNameToResource[name]
+			if !tracked {
+				return
+			}
+			w.stopMonitorInformer(resourceName, notifyEvents)
+			w.logger.Info("prometheus-cr: CRD removed, stopped informer and dropped targets", "crd", name, "resource", resourceName)
+		},
+	})
+	factory.Start(w.stopChannel)
+}
+
+// notify performs a non-blocking send on the buffered notification channel.
+func notify(notifyEvents chan struct{}) {
+	select {
+	case notifyEvents <- struct{}{}:
+	default:
+	}
+}
+
+// notifyHandler returns event handlers that coalesce ServiceMonitor/PodMonitor
+// changes into the notification channel (non-blocking so rate-limiting upstream
+// is never starved).
+func notifyHandler(notifyEvents chan struct{}) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { notify(notifyEvents) },
+		UpdateFunc: func(oldObj, newObj interface{}) { notify(notifyEvents) },
+		DeleteFunc: func(obj interface{}) { notify(notifyEvents) },
+	}
+}
+
+// Watch starts watching for ServiceMonitor/PodMonitor changes. It is resilient
+// to either CRD being absent: it starts the informer for each CRD that exists
+// now, defers the rest until their CRDs appear (via a CustomResourceDefinition
+// watch), and never fails startup just because a CRD is missing. This means the
+// TA starts and stays healthy regardless of CRD install ordering, and begins
+// (or stops) watching each type automatically as its CRD is created or deleted.
 func (w *PrometheusCRWatcher) Watch(upstreamEvents chan Event, upstreamErrors chan error) error {
-	success := true
 	// this channel needs to be buffered because notifications are asynchronous and neither producers nor consumers wait
 	notifyEvents := make(chan struct{}, 1)
 
-	for name, resource := range w.informers {
-		resource.Start(w.stopChannel)
-
-		if ok := cache.WaitForNamedCacheSync(name, w.stopChannel, resource.HasSynced); !ok {
-			success = false
+	// Start informers for CRDs that already exist. Absent CRDs are simply
+	// skipped here; the CRD watch below starts them if/when they appear.
+	for crdName, resourceName := range crdNameToResource {
+		exists, err := w.crdExists(context.Background(), crdName)
+		if err != nil {
+			// Surface the error but keep going — a transient API error must not
+			// take down the allocator. The CRD watch will recover the informer.
+			w.logger.Error(err, "prometheus-cr: failed to check for CRD, deferring to CRD watch", "crd", crdName)
+			continue
 		}
+		if !exists {
+			w.logger.Info("prometheus-cr: CRD not present at startup, deferring informer until it is created", "crd", crdName)
+			continue
+		}
+		if startErr := w.startMonitorInformer(resourceName, notifyEvents); startErr != nil {
+			w.logger.Error(startErr, "prometheus-cr: failed to start informer for present CRD, deferring to CRD watch", "crd", crdName)
+			continue
+		}
+		w.logger.Info("prometheus-cr: started informer for present CRD", "crd", crdName, "resource", resourceName)
+	}
 
-		// only send an event notification if there isn't one already
-		resource.AddEventHandler(cache.ResourceEventHandlerFuncs{
-			// these functions only write to the notification channel if it's empty to avoid blocking
-			// if scrape config updates are being rate-limited
-			AddFunc: func(obj interface{}) {
-				select {
-				case notifyEvents <- struct{}{}:
-				default:
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				select {
-				case notifyEvents <- struct{}{}:
-				default:
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				select {
-				case notifyEvents <- struct{}{}:
-				default:
-				}
-			},
-		})
-	}
-	if !success {
-		return fmt.Errorf("failed to sync cache")
-	}
+	// React to CRDs being created/deleted at runtime with no restart.
+	w.watchCRDs(notifyEvents)
 
 	// limit the rate of outgoing events
 	w.rateLimitedEventSender(upstreamEvents, notifyEvents)
@@ -219,32 +384,54 @@ func (w *PrometheusCRWatcher) rateLimitedEventSender(upstreamEvents chan Event, 
 }
 
 func (w *PrometheusCRWatcher) Close() error {
+	// Stop any per-type monitoring informers (each has its own stop channel).
+	w.informersMtx.Lock()
+	for name, stopCh := range w.informerStopChannels {
+		close(stopCh)
+		delete(w.informerStopChannels, name)
+		delete(w.informers, name)
+	}
+	w.informersMtx.Unlock()
+
+	// Stop the CRD watch and release Watch's blocking read.
 	close(w.stopChannel)
 	return nil
 }
 
 func (w *PrometheusCRWatcher) LoadConfig(ctx context.Context) (*promconfig.Config, error) {
+	// Snapshot the currently-running informers. Either may be absent if its CRD
+	// is not (yet) installed; in that case its monitors are simply skipped and
+	// no scrape jobs are generated for that type.
+	w.informersMtx.RLock()
+	smInformer := w.informers[monitoringv1.ServiceMonitorName]
+	pmInformer := w.informers[monitoringv1.PodMonitorName]
+	w.informersMtx.RUnlock()
+
 	store := assets.NewStoreBuilder(w.k8sClient.CoreV1(), w.k8sClient.CoreV1())
 	serviceMonitorInstances := make(map[string]*monitoringv1.ServiceMonitor)
-	smRetrieveErr := w.informers[monitoringv1.ServiceMonitorName].ListAll(w.serviceMonitorSelector, func(sm interface{}) {
-		monitor := sm.(*monitoringv1.ServiceMonitor)
-		key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(monitor)
-		w.addStoreAssetsForServiceMonitor(ctx, monitor.Name, monitor.Namespace, monitor.Spec.Endpoints, store)
-		serviceMonitorInstances[key] = monitor
-	})
-	if smRetrieveErr != nil {
-		return nil, smRetrieveErr
+	if smInformer != nil {
+		smRetrieveErr := smInformer.ListAll(w.serviceMonitorSelector, func(sm interface{}) {
+			monitor := sm.(*monitoringv1.ServiceMonitor)
+			key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(monitor)
+			w.addStoreAssetsForServiceMonitor(ctx, monitor.Name, monitor.Namespace, monitor.Spec.Endpoints, store)
+			serviceMonitorInstances[key] = monitor
+		})
+		if smRetrieveErr != nil {
+			return nil, smRetrieveErr
+		}
 	}
 
 	podMonitorInstances := make(map[string]*monitoringv1.PodMonitor)
-	pmRetrieveErr := w.informers[monitoringv1.PodMonitorName].ListAll(w.podMonitorSelector, func(pm interface{}) {
-		monitor := pm.(*monitoringv1.PodMonitor)
-		key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(monitor)
-		w.addStoreAssetsForPodMonitor(ctx, monitor.Name, monitor.Namespace, monitor.Spec.PodMetricsEndpoints, store)
-		podMonitorInstances[key] = monitor
-	})
-	if pmRetrieveErr != nil {
-		return nil, pmRetrieveErr
+	if pmInformer != nil {
+		pmRetrieveErr := pmInformer.ListAll(w.podMonitorSelector, func(pm interface{}) {
+			monitor := pm.(*monitoringv1.PodMonitor)
+			key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(monitor)
+			w.addStoreAssetsForPodMonitor(ctx, monitor.Name, monitor.Namespace, monitor.Spec.PodMetricsEndpoints, store)
+			podMonitorInstances[key] = monitor
+		})
+		if pmRetrieveErr != nil {
+			return nil, pmRetrieveErr
+		}
 	}
 
 	generatedConfig, err := w.configGenerator.GenerateServerConfiguration(

--- a/cmd/amazon-cloudwatch-agent-target-allocator/watcher/promOperator.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/watcher/promOperator.go
@@ -21,6 +21,7 @@ import (
 	kubeDiscovery "github.com/prometheus/prometheus/discovery/kubernetes"
 	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -49,11 +50,25 @@ func NewPrometheusCRWatcher(logger logr.Logger, cfg allocatorconfig.Config) (*Pr
 	}
 
 	// TODO: We should make these durations configurable
+	// The prometheus-operator config generator calls store.ForNamespace(prom.Namespace)
+	// which panics on an empty namespace, so the synthetic Prometheus must carry the
+	// allocator's own namespace (injected by the operator as OTELCOL_NAMESPACE).
+	namespace := os.Getenv("OTELCOL_NAMESPACE")
+	if namespace == "" {
+		namespace = "amazon-cloudwatch"
+	}
 	prom := &monitoringv1.Prometheus{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+		},
 		Spec: monitoringv1.PrometheusSpec{
 			CommonPrometheusFields: monitoringv1.CommonPrometheusFields{
 				ScrapeInterval: monitoringv1.Duration(cfg.PrometheusCR.ScrapeInterval.String()),
 			},
+			// The config generator unconditionally emits evaluation_interval; an empty
+			// value makes the downstream Prometheus config parser fail with
+			// "empty duration string", so give it the scrape interval as a sane default.
+			EvaluationInterval: monitoringv1.Duration(cfg.PrometheusCR.ScrapeInterval.String()),
 		},
 	}
 

--- a/cmd/amazon-cloudwatch-agent-target-allocator/watcher/promOperator_test.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/watcher/promOperator_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	fakemonitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
 	"github.com/prometheus-operator/prometheus-operator/pkg/informers"
@@ -21,7 +22,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
@@ -252,17 +256,12 @@ func TestLoadConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			w := getTestPrometheusCRWatcher(t, tt.serviceMonitor, tt.podMonitor)
-			for _, informer := range w.informers {
-				// Start informers in order to populate cache.
-				informer.Start(w.stopChannel)
-			}
+			defer func() { _ = w.Close() }()
 
-			// Wait for informers to sync.
-			for _, informer := range w.informers {
-				for !informer.HasSynced() {
-					time.Sleep(50 * time.Millisecond)
-				}
-			}
+			// Start both informers via the per-type lifecycle (both CRDs present).
+			notifyEvents := make(chan struct{}, 1)
+			require.NoError(t, w.startMonitorInformer(monitoringv1.ServiceMonitorName, notifyEvents))
+			require.NoError(t, w.startMonitorInformer(monitoringv1.PodMonitorName, notifyEvents))
 
 			got, err := w.LoadConfig(context.Background())
 			require.NoError(t, err)
@@ -305,11 +304,15 @@ func TestRateLimit(t *testing.T) {
 	_, err = w.kubeMonitoringClient.MonitoringV1().ServiceMonitors("test").Create(context.Background(), serviceMonitor, metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// wait for cache sync first
-	for _, informer := range w.informers {
-		success := cache.WaitForCacheSync(w.stopChannel, informer.HasSynced)
-		require.True(t, success)
-	}
+	// wait for the watcher to start the ServiceMonitor informer and finish its
+	// startup loop (both CRDs present => both informers running) so the
+	// rate-limited event sender is active before we measure event timing.
+	require.Eventually(t, func() bool {
+		w.informersMtx.RLock()
+		defer w.informersMtx.RUnlock()
+		sm, ok := w.informers[monitoringv1.ServiceMonitorName]
+		return ok && sm.HasSynced() && len(w.informers) == 2
+	}, 5*time.Second, 10*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		_, createErr := w.kubeMonitoringClient.MonitoringV1().ServiceMonitors("test").Update(context.Background(), serviceMonitor, metav1.UpdateOptions{})
@@ -353,9 +356,26 @@ func TestRateLimit(t *testing.T) {
 
 }
 
-// getTestPrometheuCRWatcher creates a test instance of PrometheusCRWatcher with fake clients
-// and test secrets.
+// getTestPrometheusCRWatcher creates a test instance of PrometheusCRWatcher with
+// fake clients and test secrets. Both the ServiceMonitor and PodMonitor CRDs are
+// registered in the fake apiextensions client, so the watcher behaves as if both
+// CRDs are present. Use getTestPrometheusCRWatcherWithCRDs to control CRD presence.
 func getTestPrometheusCRWatcher(t *testing.T, sm *monitoringv1.ServiceMonitor, pm *monitoringv1.PodMonitor) *PrometheusCRWatcher {
+	return getTestPrometheusCRWatcherWithCRDs(t, sm, pm, true, true)
+}
+
+// crdFor builds a minimal CustomResourceDefinition object for the given
+// monitoring resource (e.g. "servicemonitors"), matching the names the watcher
+// keys on.
+func crdFor(resourceName string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resourceName + "." + monitoringv1.SchemeGroupVersion.Group,
+		},
+	}
+}
+
+func getTestPrometheusCRWatcherWithCRDs(t *testing.T, sm *monitoringv1.ServiceMonitor, pm *monitoringv1.PodMonitor, smCRD, pmCRD bool) *PrometheusCRWatcher {
 	mClient := fakemonitoringclient.NewSimpleClientset() //nolint:staticcheck // NewClientset causes structured merge diff schema errors in tests
 	if sm != nil {
 		_, err := mClient.MonitoringV1().ServiceMonitors("test").Create(context.Background(), sm, metav1.CreateOptions{})
@@ -369,6 +389,15 @@ func getTestPrometheusCRWatcher(t *testing.T, sm *monitoringv1.ServiceMonitor, p
 			t.Fatal(t, err)
 		}
 	}
+
+	var crdObjects []runtime.Object
+	if smCRD {
+		crdObjects = append(crdObjects, crdFor(monitoringv1.ServiceMonitorName))
+	}
+	if pmCRD {
+		crdObjects = append(crdObjects, crdFor(monitoringv1.PodMonitorName))
+	}
+	crdClient := apiextensionsfake.NewSimpleClientset(crdObjects...)
 
 	k8sClient := fake.NewSimpleClientset()
 	_, err := k8sClient.CoreV1().Secrets("test").Create(context.Background(), &v1.Secret{
@@ -392,12 +421,6 @@ func getTestPrometheusCRWatcher(t *testing.T, sm *monitoringv1.ServiceMonitor, p
 		t.Fatal(t, err)
 	}
 
-	factory := informers.NewMonitoringInformerFactories(map[string]struct{}{v1.NamespaceAll: {}}, map[string]struct{}{}, mClient, 0, nil)
-	informers, err := getInformers(factory)
-	if err != nil {
-		t.Fatal(t, err)
-	}
-
 	prom := &monitoringv1.Prometheus{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -417,9 +440,12 @@ func getTestPrometheusCRWatcher(t *testing.T, sm *monitoringv1.ServiceMonitor, p
 	}
 
 	return &PrometheusCRWatcher{
+		logger:                 logr.Discard(),
 		kubeMonitoringClient:   mClient,
 		k8sClient:              k8sClient,
-		informers:              informers,
+		crdClient:              crdClient,
+		informers:              map[string]*informers.ForResource{},
+		informerStopChannels:   map[string]chan struct{}{},
 		configGenerator:        generator,
 		prom:                   prom,
 		serviceMonitorSelector: getSelector(nil),
@@ -444,4 +470,140 @@ func sanitizeScrapeConfigsForTest(scs []*promconfig.ScrapeConfig) {
 		sc.MetricNameEscapingScheme = ""
 		sc.ExtraScrapeMetrics = nil
 	}
+}
+
+// runningInformers returns the set of monitoring resource names whose informers
+// are currently active.
+func runningInformers(w *PrometheusCRWatcher) map[string]bool {
+	w.informersMtx.RLock()
+	defer w.informersMtx.RUnlock()
+	out := map[string]bool{}
+	for name := range w.informers {
+		out[name] = true
+	}
+	return out
+}
+
+// TestWatchStartsHealthyWithoutCRDs verifies the TA does not error when neither
+// the ServiceMonitor nor PodMonitor CRD exists: Watch returns no error, no
+// informers are started, and LoadConfig yields a config with no scrape jobs.
+func TestWatchStartsHealthyWithoutCRDs(t *testing.T) {
+	w := getTestPrometheusCRWatcherWithCRDs(t, nil, nil, false, false)
+	w.eventInterval = 5 * time.Millisecond
+	defer func() { _ = w.Close() }()
+
+	watchDone := make(chan error, 1)
+	go func() { watchDone <- w.Watch(make(chan Event, 1), make(chan error, 1)) }()
+
+	// Give the CRD watch time to sync and (not) start anything.
+	require.Never(t, func() bool {
+		return len(runningInformers(w)) > 0
+	}, 200*time.Millisecond, 20*time.Millisecond)
+
+	cfg, err := w.LoadConfig(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, cfg.ScrapeConfigs)
+
+	// Watch must still be running (resilient), not have returned an error.
+	select {
+	case err := <-watchDone:
+		t.Fatalf("Watch exited unexpectedly with: %v", err)
+	default:
+	}
+}
+
+// TestWatchPerTypeIndependence verifies that with only the ServiceMonitor CRD
+// present, the SM informer starts and the PM informer does not.
+func TestWatchPerTypeIndependence(t *testing.T) {
+	w := getTestPrometheusCRWatcherWithCRDs(t, nil, nil, true, false)
+	w.eventInterval = 5 * time.Millisecond
+	defer func() { _ = w.Close() }()
+
+	go func() { _ = w.Watch(make(chan Event, 1), make(chan error, 1)) }()
+
+	require.Eventually(t, func() bool {
+		return runningInformers(w)[monitoringv1.ServiceMonitorName]
+	}, 5*time.Second, 10*time.Millisecond)
+
+	// PodMonitor CRD is absent, so its informer must never start.
+	require.Never(t, func() bool {
+		return runningInformers(w)[monitoringv1.PodMonitorName]
+	}, 200*time.Millisecond, 20*time.Millisecond)
+}
+
+// TestWatchStartsInformerWhenCRDCreated verifies the TA begins watching a type
+// when its CRD is created at runtime — no restart required.
+func TestWatchStartsInformerWhenCRDCreated(t *testing.T) {
+	w := getTestPrometheusCRWatcherWithCRDs(t, nil, nil, false, false)
+	w.eventInterval = 5 * time.Millisecond
+	defer func() { _ = w.Close() }()
+
+	go func() { _ = w.Watch(make(chan Event, 1), make(chan error, 1)) }()
+
+	// Nothing running initially.
+	require.Never(t, func() bool {
+		return len(runningInformers(w)) > 0
+	}, 200*time.Millisecond, 20*time.Millisecond)
+
+	// Create the ServiceMonitor CRD after startup.
+	_, err := w.crdClient.ApiextensionsV1().CustomResourceDefinitions().Create(
+		context.Background(), crdFor(monitoringv1.ServiceMonitorName), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return runningInformers(w)[monitoringv1.ServiceMonitorName]
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+// TestStopMonitorInformerDropsType verifies the stop path used when a CRD is
+// removed at runtime: the informer is stopped, dropped from the active set (so
+// LoadConfig no longer emits its targets), and a reload is signalled. This is
+// the logic invoked by the CRD watch's DeleteFunc; it is exercised directly so
+// the assertion does not depend on fake-clientset delete-watch delivery.
+func TestStopMonitorInformerDropsType(t *testing.T) {
+	w := getTestPrometheusCRWatcherWithCRDs(t, nil, nil, true, false)
+	defer func() { _ = w.Close() }()
+
+	notifyEvents := make(chan struct{}, 1)
+	require.NoError(t, w.startMonitorInformer(monitoringv1.ServiceMonitorName, notifyEvents))
+	require.True(t, runningInformers(w)[monitoringv1.ServiceMonitorName])
+	// drain the start notification
+	select {
+	case <-notifyEvents:
+	default:
+	}
+
+	w.stopMonitorInformer(monitoringv1.ServiceMonitorName, notifyEvents)
+
+	assert.False(t, runningInformers(w)[monitoringv1.ServiceMonitorName], "informer should be stopped and dropped")
+	// a reload must be signalled so the dropped type's targets are removed
+	select {
+	case <-notifyEvents:
+	default:
+		t.Fatal("expected a reload notification after stopping the informer")
+	}
+
+	// LoadConfig must succeed and emit no scrape jobs once the type is dropped.
+	cfg, err := w.LoadConfig(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, cfg.ScrapeConfigs)
+}
+
+// TestCRDObjectName verifies the CRD-name extraction used by the CRD watch,
+// including the delete tombstone wrapper.
+func TestCRDObjectName(t *testing.T) {
+	crd := crdFor(monitoringv1.ServiceMonitorName)
+	name, ok := crdObjectName(crd)
+	require.True(t, ok)
+	assert.Equal(t, "servicemonitors.monitoring.coreos.com", name)
+	if _, tracked := crdNameToResource[name]; !tracked {
+		t.Fatalf("CRD name %q is not mapped to a monitoring resource", name)
+	}
+
+	name, ok = crdObjectName(cache.DeletedFinalStateUnknown{Key: "k", Obj: crd})
+	require.True(t, ok)
+	assert.Equal(t, "servicemonitors.monitoring.coreos.com", name)
+
+	_, ok = crdObjectName("not-a-crd")
+	assert.False(t, ok)
 }

--- a/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -6405,9 +6405,10 @@ spec:
                   allocationStrategy:
                     description: |-
                       AllocationStrategy determines which strategy the target allocator should use for allocation.
-                      The current option is consistent-hashing.
+                      The options are consistent-hashing and per-node.
                     enum:
                     - consistent-hashing
+                    - per-node
                     type: string
                   enabled:
                     description: Enabled indicates whether to use a target allocation

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.4
+	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 	k8s.io/component-base v0.35.4
@@ -245,7 +246,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/manifests/targetallocator/configmap.go
+++ b/internal/manifests/targetallocator/configmap.go
@@ -51,7 +51,18 @@ func ConfigMap(params manifests.Params) (*corev1.ConfigMap, error) {
 		taConfig["config"] = prometheusConfig
 	}
 
-	taConfig["allocation_strategy"] = v1alpha1.AmazonCloudWatchAgentTargetAllocatorAllocationStrategyConsistentHashing
+	// Use the strategy from the CR if set, defaulting to consistent-hashing to
+	// preserve prior behavior. When per-node is selected, configure a
+	// consistent-hashing fallback so targets without a resolvable node (e.g.
+	// non-pod ServiceMonitor endpoints) are still allocated rather than dropped.
+	allocationStrategy := params.OtelCol.Spec.TargetAllocator.AllocationStrategy
+	if allocationStrategy == "" {
+		allocationStrategy = v1alpha1.AmazonCloudWatchAgentTargetAllocatorAllocationStrategyConsistentHashing
+	}
+	taConfig["allocation_strategy"] = allocationStrategy
+	if allocationStrategy == v1alpha1.AmazonCloudWatchAgentTargetAllocatorAllocationStrategyPerNode {
+		taConfig["allocation_fallback_strategy"] = v1alpha1.AmazonCloudWatchAgentTargetAllocatorAllocationStrategyConsistentHashing
+	}
 
 	if len(params.OtelCol.Spec.TargetAllocator.FilterStrategy) > 0 {
 		taConfig["filter_strategy"] = params.OtelCol.Spec.TargetAllocator.FilterStrategy

--- a/internal/manifests/targetallocator/configmap_test.go
+++ b/internal/manifests/targetallocator/configmap_test.go
@@ -145,5 +145,42 @@ prometheus_cr:
 		assert.Equal(t, expectedData, actual.Data)
 
 	})
+	t.Run("should emit per-node strategy with consistent-hashing fallback", func(t *testing.T) {
+		expectedLables["app.kubernetes.io/component"] = "amazon-cloudwatch-agent-target-allocator"
+		expectedLables["app.kubernetes.io/name"] = "my-instance-target-allocator"
+
+		expectedData := map[string]string{
+			"targetallocator.yaml": `allocation_fallback_strategy: consistent-hashing
+allocation_strategy: per-node
+config:
+  scrape_configs:
+  - job_name: otel-collector
+    scrape_interval: 10s
+    static_configs:
+    - targets:
+      - 0.0.0.0:8888
+      - 0.0.0.0:9999
+label_selector:
+  app.kubernetes.io/component: amazon-cloudwatch-agent
+  app.kubernetes.io/instance: default.my-instance
+  app.kubernetes.io/managed-by: amazon-cloudwatch-agent-operator
+  app.kubernetes.io/part-of: amazon-cloudwatch-agent
+`,
+		}
+		instance := collectorInstance()
+		instance.Spec.TargetAllocator.AllocationStrategy = "per-node"
+		cfg := config.New()
+		params := manifests.Params{
+			OtelCol: instance,
+			Config:  cfg,
+			Log:     logr.Discard(),
+		}
+		actual, err := ConfigMap(params)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "my-instance-target-allocator", actual.Name)
+		assert.Equal(t, expectedLables, actual.Labels)
+		assert.Equal(t, expectedData, actual.Data)
+	})
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds per-node target allocation to the Target Allocator (TA) and makes the TA resilient to ServiceMonitor/PodMonitor CRD install ordering, so the SM/PM scraping path works zero-step and node-locally on a DaemonSet agent deployment.

The TA previously built SM/PM informers once at startup and blocked on cache sync; a missing CRD failed the sync and required a restart to pick the CRD up later.
Now the TA watches CustomResourceDefinition objects and lazily starts each monitor informer when its CRD appears 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
