### PR TITLE
fix: use FQDN for CloudWatch agent auto-instrumentation endpoint (#392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ metadata:
   namespace: default # use a namespace with pods you'd like to inject
 spec:
   exporter:
-    endpoint: http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics
+    endpoint: http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics
   propagators:
     - tracecontext
     - baggage
@@ -147,7 +147,7 @@ spec:
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
         value: "http/protobuf"
       - name: OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT
-        value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"
+        value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"
 EOF
 ```
 

--- a/pkg/instrumentation/defaultinstrumentation.go
+++ b/pkg/instrumentation/defaultinstrumentation.go
@@ -68,11 +68,11 @@ func getDefaultInstrumentation(agentConfig *adapters.CwaConfig, additionalEnvs m
 		return nil, errors.New("unable to determine nodejs instrumentation image")
 	}
 
-	cloudwatchAgentServiceEndpoint := "cloudwatch-agent.amazon-cloudwatch"
+	cloudwatchAgentServiceEndpoint := cloudwatchAgentStandardEndpoint
 	if isWindowsPod {
 		// Windows pods use the headless service endpoint due to limitations with the agent on host network mode
 		// https://kubernetes.io/docs/concepts/services-networking/windows-networking/#limitations
-		cloudwatchAgentServiceEndpoint = "cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local"
+		cloudwatchAgentServiceEndpoint = cloudwatchAgentWindowsEndpoint
 	}
 
 	// set protocol by checking cloudwatch agent config for tls setting

--- a/pkg/instrumentation/defaultinstrumentation_test.go
+++ b/pkg/instrumentation/defaultinstrumentation_test.go
@@ -66,15 +66,15 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 					{Name: "OTEL_AWS_APP_SIGNALS_ENABLED", Value: "true"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
-					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
-					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
-					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -92,20 +92,20 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APP_SIGNALS_ENABLED", Value: "true"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_PYTHON_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
-					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
-					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
-					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -123,12 +123,12 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
-					{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_DOTNET_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_DOTNET_CONFIGURATOR", Value: "aws_configurator"},
@@ -150,16 +150,16 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Image: defaultNodeJSInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
-					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
-					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
-					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -198,15 +198,15 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 					{Name: "OTEL_AWS_APP_SIGNALS_ENABLED", Value: "true"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
-					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
-					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
-					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -224,20 +224,20 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APP_SIGNALS_ENABLED", Value: "true"}, //TODO: remove in favor of new name once safe
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APP_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"}, //TODO: remove in favor of new name once safe
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_PYTHON_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_PYTHON_CONFIGURATOR", Value: "aws_configurator"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
-					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
-					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
-					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -255,12 +255,12 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
-					{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_DOTNET_DISTRO", Value: "aws_distro"},
 					{Name: "OTEL_DOTNET_CONFIGURATOR", Value: "aws_configurator"},
@@ -282,16 +282,16 @@ func Test_getDefaultInstrumentationLinux(t *testing.T) {
 				Image: defaultNodeJSInstrumentationImage,
 				Env: []corev1.EnvVar{
 					{Name: "OTEL_AWS_APPLICATION_SIGNALS_ENABLED", Value: "true"},
-					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_TRACES_SAMPLER_ARG", Value: "endpoint=http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 					{Name: "OTEL_TRACES_SAMPLER", Value: "xray"},
 					{Name: "OTEL_EXPORTER_OTLP_PROTOCOL", Value: "http/protobuf"},
-					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/traces"},
-					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
+					{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/traces"},
+					{Name: "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
-					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/logs"},
-					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch:4316/v1/metrics"},
-					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"},
+					{Name: "OTEL_AWS_OTLP_LOGS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/logs"},
+					{Name: "OTEL_AWS_OTLP_METRICS_ENDPOINT", Value: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316/v1/metrics"},
+					{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"},
 				},
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -837,7 +837,7 @@ func Test_getDefaultInstrumentationLinuxWithApplicationSignalsDisabled(t *testin
 					{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 					{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 					{Name: "OTEL_TRACES_EXPORTER", Value: "none"},
-					{Name: "OTEL_AWS_JMX_EXPORTER_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4314/v1/metrics"},
+					{Name: "OTEL_AWS_JMX_EXPORTER_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4314/v1/metrics"},
 					{Name: "OTEL_JMX_TARGET_SYSTEM", Value: "jvm"},
 				},
 				Resources: corev1.ResourceRequirements{
@@ -1010,7 +1010,7 @@ func Test_getServiceEventsEnvs(t *testing.T) {
 
 func Test_getDynamicInstrumentationEnvs(t *testing.T) {
 	// The API URL is always emitted; the ENABLED toggle is emit-when-set.
-	apiURLEnv := corev1.EnvVar{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch:2000"}
+	apiURLEnv := corev1.EnvVar{Name: "OTEL_AWS_DYNAMIC_INSTRUMENTATION_API_URL", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:2000"}
 	tests := []struct {
 		name string
 		// env maps the AUTO_INSTRUMENTATION_JAVA_* suffix to its value; absent keys stay unset.
@@ -1038,7 +1038,7 @@ func Test_getDynamicInstrumentationEnvs(t *testing.T) {
 			for suffix, v := range tt.env {
 				t.Setenv("AUTO_INSTRUMENTATION_JAVA_"+suffix, v)
 			}
-			got := getDynamicInstrumentationEnvs(java, "cloudwatch-agent.amazon-cloudwatch")
+			got := getDynamicInstrumentationEnvs(java, "cloudwatch-agent.amazon-cloudwatch.svc.cluster.local")
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getDynamicInstrumentationEnvs() got = %v, want %v", got, tt.want)
 			}

--- a/pkg/instrumentation/helper.go
+++ b/pkg/instrumentation/helper.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// CloudWatch agent service endpoints
-	cloudwatchAgentStandardEndpoint = "cloudwatch-agent.amazon-cloudwatch"
+	cloudwatchAgentStandardEndpoint = "cloudwatch-agent.amazon-cloudwatch.svc.cluster.local"
 	cloudwatchAgentWindowsEndpoint  = "cloudwatch-agent-windows-headless.amazon-cloudwatch.svc.cluster.local"
 )
 

--- a/pkg/instrumentation/helper_test.go
+++ b/pkg/instrumentation/helper_test.go
@@ -238,17 +238,17 @@ func TestContainsCloudWatchAgent(t *testing.T) {
 	}{
 		{
 			name:     "Valid: Standard CloudWatch agent endpoint",
-			endpoint: "http://cloudwatch-agent.amazon-cloudwatch:4316",
+			endpoint: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316",
 			expected: true,
 		},
 		{
 			name:     "Valid: grpc protocol",
-			endpoint: "grpc://cloudwatch-agent.amazon-cloudwatch:4316",
+			endpoint: "grpc://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316",
 			expected: true,
 		},
 		{
 			name:     "Valid: https protocol",
-			endpoint: "https://cloudwatch-agent.amazon-cloudwatch:4316",
+			endpoint: "https://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316",
 			expected: true,
 		},
 		{
@@ -258,7 +258,7 @@ func TestContainsCloudWatchAgent(t *testing.T) {
 		},
 		{
 			name:     "Valid: Custom port",
-			endpoint: "http://cloudwatch-agent.amazon-cloudwatch:8080",
+			endpoint: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:8080",
 			expected: true,
 		},
 		{
@@ -268,7 +268,7 @@ func TestContainsCloudWatchAgent(t *testing.T) {
 		},
 		{
 			name:     "Invalid: Prefix before hostname",
-			endpoint: "http://my-cloudwatch-agent.amazon-cloudwatch:4316",
+			endpoint: "http://my-cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316",
 			expected: false,
 		},
 		{
@@ -278,7 +278,7 @@ func TestContainsCloudWatchAgent(t *testing.T) {
 		},
 		{
 			name:     "Invalid: No protocol separator",
-			endpoint: "cloudwatch-agent.amazon-cloudwatch:4316",
+			endpoint: "cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316",
 			expected: false,
 		},
 	}
@@ -516,7 +516,7 @@ func TestShouldInjectADOTSDK(t *testing.T) {
 		{
 			name: "CloudWatch endpoint: Inject",
 			envs: []corev1.EnvVar{
-				{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316"},
+				{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316"},
 			},
 			pod:       corev1.Pod{},
 			container: &corev1.Container{},
@@ -526,7 +526,7 @@ func TestShouldInjectADOTSDK(t *testing.T) {
 			name: "Custom traces endpoint + CloudWatch metrics: Skip",
 			envs: []corev1.EnvVar{
 				{Name: "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", Value: "http://custom:4318"},
-				{Name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4316"},
+				{Name: "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4316"},
 			},
 			pod:       corev1.Pod{},
 			container: &corev1.Container{},

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -87,7 +87,7 @@ func TestGetInstrumentationInstanceJMX(t *testing.T) {
 				{Name: "OTEL_METRICS_EXPORTER", Value: "none"},
 				{Name: "OTEL_LOGS_EXPORTER", Value: "none"},
 				{Name: "OTEL_TRACES_EXPORTER", Value: "none"},
-				{Name: "OTEL_AWS_JMX_EXPORTER_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch:4314/v1/metrics"},
+				{Name: "OTEL_AWS_JMX_EXPORTER_METRICS_ENDPOINT", Value: "http://cloudwatch-agent.amazon-cloudwatch.svc.cluster.local:4314/v1/metrics"},
 				{Name: "OTEL_JMX_TARGET_SYSTEM", Value: "jvm,tomcat"},
 			},
 		},
@@ -2752,7 +2752,7 @@ func TestMutatePod(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "otel/apache-httpd:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,


### PR DESCRIPTION
## Closes #392.

  The auto-instrumentation defaults injected by the operator's admission webhook pointed at the CloudWatch agent service using a short, 2-label hostname (cloudwatch-agent.amazon-cloudwatch) instead of a fully-qualified domain name. Because the value only
  has one dot, resolving it depended entirely on the pod's DNS search list, which:

##  Changes

  - pkg/instrumentation/helper.go: updated the cloudwatchAgentStandardEndpoint constant to the FQDN (cloudwatch-agent.amazon-cloudwatch.svc.cluster.local), matching the existing cloudwatchAgentWindowsEndpoint pattern.
  - pkg/instrumentation/defaultinstrumentation.go: getDefaultInstrumentation() now references cloudwatchAgentStandardEndpoint/cloudwatchAgentWindowsEndpoint from helper.go instead of duplicating the hostname as a separate literal, so there's a single
  source of truth for both.
  - pkg/instrumentation/defaultinstrumentation_test.go, helper_test.go, podmutator_test.go: updated hardcoded expected env var values to the new FQDN. TestContainsCloudWatchAgent's negative/edge-case assertions (path-embedded host, prefix-mismatch host,
  no-protocol-separator) were preserved with their original intent against the new FQDN boundary.
  - README.md: updated the two example Instrumentation CR snippets to use the FQDN.

##  Testing

  - go build ./... — pass
  - go vet ./... — pass
  - make test (full suite, envtest-backed) — all packages pass, including pkg/instrumentation
  - Manually verified containsCloudWatchAgent() still correctly accepts/rejects each case in TestContainsCloudWatchAgent after the constant change (substring matching against the FQDN, including the windows-headless and negative cases)

##  Behavior change

  None for existing clusters at default ndots — the FQDN resolves identically today. This unblocks operators who want to set ndots: 1 and removes the NXDOMAIN log noise from Route53 Resolver query logging.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
