### PR TITLE
Bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
-        go-version: "~1.26.4"
+        go-version: "~1.26.5"
 
     - name: Cache tools
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM --platform=$BUILDPLATFORM golang:1.26.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5 AS builder
 
 # Set build arguments early
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-cloudwatch-agent-operator
 
-go 1.26.4
+go 1.26.5
 
 retract v1.51.0
 


### PR DESCRIPTION
Bumps the Go toolchain from 1.26.4 to 1.26.5 (go.mod, Dockerfile builder image, and CI Go pin) to pick up the latest patch-level standard library fixes. No source or API changes; unit tests pass with identical results before and after the bump.