### PR TITLE
Regenerate CRDs with generateEmbeddedObjectMeta flag

### DIFF
--- a/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
+++ b/config/crd/bases/cloudwatch.aws.amazon.com_amazoncloudwatchagents.yaml
@@ -7694,6 +7694,23 @@ spec:
                       description: |-
                         Standard object's metadata.
                         More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        name:
+                          type: string
+                        namespace:
+                          type: string
                       type: object
                     spec:
                       description: |-
@@ -8627,6 +8644,23 @@ spec:
                                 May contain labels and annotations that will be copied into the PVC
                                 when creating it. No other fields are allowed and will be rejected during
                                 validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: |-

--- a/config/crd/bases/cloudwatch.aws.amazon.com_dcgmexporters.yaml
+++ b/config/crd/bases/cloudwatch.aws.amazon.com_dcgmexporters.yaml
@@ -2085,6 +2085,23 @@ spec:
                                 May contain labels and annotations that will be copied into the PVC
                                 when creating it. No other fields are allowed and will be rejected during
                                 validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: |-

--- a/config/crd/bases/cloudwatch.aws.amazon.com_neuronmonitors.yaml
+++ b/config/crd/bases/cloudwatch.aws.amazon.com_neuronmonitors.yaml
@@ -2097,6 +2097,23 @@ spec:
                                 May contain labels and annotations that will be copied into the PVC
                                 when creating it. No other fields are allowed and will be rejected during
                                 validation.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
                               type: object
                             spec:
                               description: |-


### PR DESCRIPTION
## Description

PR #395 (prometheus/k8s dependency bump) included regenerated CRDs that were produced without the Makefile's `CRD_OPTIONS="crd:generateEmbeddedObjectMeta=true"`, which stripped the embedded ObjectMeta schema (`labels`, `annotations`, `finalizers`, `name`, `namespace`) from PVC template `metadata` in the AmazonCloudWatchAgent, DcgmExporter, and NeuronMonitor CRDs.

Because those metadata schemas became bare `type: object` with no properties and no `x-kubernetes-preserve-unknown-fields`, structural schema pruning would silently strip labels/annotations that users set on `volumeClaimTemplates` / ephemeral volume claim template metadata in their CRs.

This PR restores the schema by regenerating via `make manifests` (which applies the flag). Pure additions: 3 files, +68 lines, four restored ObjectMeta blocks. No other generated manifests changed.

## Verification
- `make manifests` output is now stable (re-running produces no diff)
- YAML validated; restored blocks confirmed under the correct PVC template metadata parents
- Instrumentation CRD unaffected (it has no embedded PVC metadata)