### PR TITLE
Derive ports from the opentelemetry config section

### DIFF
--- a/cmd/amazon-cloudwatch-agent-target-allocator/config/config_test.go
+++ b/cmd/amazon-cloudwatch-agent-target-allocator/config/config_test.go
@@ -19,16 +19,16 @@ func TestLoad(t *testing.T) {
 		file string
 	}
 	tests := []struct {
-		name           string
-		args           args
-		wantErr        assert.ErrorAssertionFunc
-		wantHTTPS      HTTPSServerConfig
-		wantLabels     map[string]string
-		wantPromCR     PrometheusCRConfig
-		wantAlloc      *string
-		wantPodMonSel  map[string]string
-		wantSvcMonSel  map[string]string
-		wantJobNames   []string
+		name          string
+		args          args
+		wantErr       assert.ErrorAssertionFunc
+		wantHTTPS     HTTPSServerConfig
+		wantLabels    map[string]string
+		wantPromCR    PrometheusCRConfig
+		wantAlloc     *string
+		wantPodMonSel map[string]string
+		wantSvcMonSel map[string]string
+		wantJobNames  []string
 	}{
 		{
 			name: "file sd load",
@@ -58,8 +58,8 @@ func TestLoad(t *testing.T) {
 			args: args{
 				file: "./testdata/no_config.yaml",
 			},
-			wantErr:   assert.NoError,
-			wantHTTPS: CreateDefaultConfig().HTTPS,
+			wantErr:    assert.NoError,
+			wantHTTPS:  CreateDefaultConfig().HTTPS,
 			wantLabels: nil,
 			wantPromCR: CreateDefaultConfig().PrometheusCR,
 			wantAlloc:  CreateDefaultConfig().AllocationStrategy,

--- a/internal/manifests/collector/adapters/config_from.go
+++ b/internal/manifests/collector/adapters/config_from.go
@@ -38,9 +38,10 @@ func ConfigFromJSONString(configStr string) (map[string]interface{}, error) {
 }
 
 type CwaConfig struct {
-	Metrics *Metrics `json:"metrics,omitempty"`
-	Logs    *Logs    `json:"logs,omitempty"`
-	Traces  *Traces  `json:"traces,omitempty"`
+	Metrics       *Metrics       `json:"metrics,omitempty"`
+	Logs          *Logs          `json:"logs,omitempty"`
+	Traces        *Traces        `json:"traces,omitempty"`
+	Opentelemetry *Opentelemetry `json:"opentelemetry,omitempty"`
 }
 
 type Metrics struct {
@@ -53,6 +54,14 @@ type Logs struct {
 
 type Traces struct {
 	TracesCollected *TracesCollected `json:"traces_collected,omitempty"`
+}
+
+type Opentelemetry struct {
+	Collect *OpentelemetryCollect `json:"collect,omitempty"`
+}
+
+type OpentelemetryCollect struct {
+	OTLP *otlp `json:"otlp,omitempty"`
 }
 
 type MetricsCollected struct {

--- a/internal/manifests/collector/adapters/config_from.go
+++ b/internal/manifests/collector/adapters/config_from.go
@@ -41,7 +41,7 @@ type CwaConfig struct {
 	Metrics       *Metrics       `json:"metrics,omitempty"`
 	Logs          *Logs          `json:"logs,omitempty"`
 	Traces        *Traces        `json:"traces,omitempty"`
-	Opentelemetry *Opentelemetry `json:"opentelemetry,omitempty"`
+	OpenTelemetry *OpenTelemetry `json:"opentelemetry,omitempty"`
 }
 
 type Metrics struct {
@@ -56,7 +56,7 @@ type Traces struct {
 	TracesCollected *TracesCollected `json:"traces_collected,omitempty"`
 }
 
-type Opentelemetry struct {
+type OpenTelemetry struct {
 	Collect *OpentelemetryCollect `json:"collect,omitempty"`
 }
 

--- a/internal/manifests/collector/podmonitor.go
+++ b/internal/manifests/collector/podmonitor.go
@@ -70,4 +70,3 @@ func metricsEndpointsFromConfig(logger logr.Logger, otelcol v1alpha1.AmazonCloud
 	metricsEndpoints := []monitoringv1.PodMetricsEndpoint{}
 	return metricsEndpoints
 }
-

--- a/internal/manifests/collector/ports.go
+++ b/internal/manifests/collector/ports.go
@@ -130,6 +130,7 @@ func getServicePortsFromCWAgentConfig(logger logr.Logger, config *adapters.CwaCo
 	getMetricsReceiversServicePorts(logger, config, servicePortsMap)
 	getLogsReceiversServicePorts(logger, config, servicePortsMap)
 	getTracesReceiversServicePorts(logger, config, servicePortsMap)
+	getOpentelemetryReceiversServicePorts(logger, config, servicePortsMap)
 
 	return PortMapToServicePortList(servicePortsMap)
 }
@@ -272,7 +273,6 @@ func getTracesReceiversServicePorts(logger logr.Logger, config *adapters.CwaConf
 		getReceiverServicePort(logger, config.Traces.TracesCollected.OTLP.GRPCEndpoint, OtlpGrpc, corev1.ProtocolTCP, servicePortsMap)
 		//HTTP
 		getReceiverServicePort(logger, config.Traces.TracesCollected.OTLP.HTTPEndpoint, OtlpHttp, corev1.ProtocolTCP, servicePortsMap)
-
 	}
 	//Xray
 	if config.Traces.TracesCollected.XRay != nil {
@@ -284,6 +284,20 @@ func getTracesReceiversServicePorts(logger logr.Logger, config *adapters.CwaConf
 		getReceiverServicePort(logger, serviceAddress, XrayProxy, corev1.ProtocolTCP, servicePortsMap)
 	}
 	return tracesPorts
+}
+
+func getOpentelemetryReceiversServicePorts(logger logr.Logger, config *adapters.CwaConfig, servicePortsMap map[int32][]corev1.ServicePort) {
+	if config.Opentelemetry == nil || config.Opentelemetry.Collect == nil {
+		return
+	}
+
+	//OTLP
+	if config.Opentelemetry.Collect.OTLP != nil {
+		//GRPC
+		getReceiverServicePort(logger, config.Opentelemetry.Collect.OTLP.GRPCEndpoint, OtlpGrpc, corev1.ProtocolTCP, servicePortsMap)
+		//HTTP
+		getReceiverServicePort(logger, config.Opentelemetry.Collect.OTLP.HTTPEndpoint, OtlpHttp, corev1.ProtocolTCP, servicePortsMap)
+	}
 }
 
 func getApplicationSignalsReceiversServicePorts(logger logr.Logger, config *adapters.CwaConfig, servicePortsMap map[int32][]corev1.ServicePort) {

--- a/internal/manifests/collector/ports.go
+++ b/internal/manifests/collector/ports.go
@@ -287,16 +287,16 @@ func getTracesReceiversServicePorts(logger logr.Logger, config *adapters.CwaConf
 }
 
 func getOpentelemetryReceiversServicePorts(logger logr.Logger, config *adapters.CwaConfig, servicePortsMap map[int32][]corev1.ServicePort) {
-	if config.Opentelemetry == nil || config.Opentelemetry.Collect == nil {
+	if config.OpenTelemetry == nil || config.OpenTelemetry.Collect == nil {
 		return
 	}
 
 	//OTLP
-	if config.Opentelemetry.Collect.OTLP != nil {
+	if config.OpenTelemetry.Collect.OTLP != nil {
 		//GRPC
-		getReceiverServicePort(logger, config.Opentelemetry.Collect.OTLP.GRPCEndpoint, OtlpGrpc, corev1.ProtocolTCP, servicePortsMap)
+		getReceiverServicePort(logger, config.OpenTelemetry.Collect.OTLP.GRPCEndpoint, OtlpGrpc, corev1.ProtocolTCP, servicePortsMap)
 		//HTTP
-		getReceiverServicePort(logger, config.Opentelemetry.Collect.OTLP.HTTPEndpoint, OtlpHttp, corev1.ProtocolTCP, servicePortsMap)
+		getReceiverServicePort(logger, config.OpenTelemetry.Collect.OTLP.HTTPEndpoint, OtlpHttp, corev1.ProtocolTCP, servicePortsMap)
 	}
 }
 

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/aws/amazon-cloudwatch-agent-operator/internal/manifests/collector/adapters"
 )
 
 func TestStatsDGetContainerPorts(t *testing.T) {
@@ -398,6 +400,51 @@ func TestValidOTLPLogsAndMetricsPort(t *testing.T) {
 	}
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
 	checkPorts(t, wantPorts, containerPorts)
+}
+
+func TestOpentelemetryOtlpGetContainerPorts(t *testing.T) {
+	cfg := getStringFromFile("./test-resources/opentelemetryOtlp.json")
+	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          OtlpGrpc + "-1234",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(1234),
+		},
+		{
+			Name:          OtlpHttp + "-2345",
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(2345),
+		},
+	}
+	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
+	checkPorts(t, wantPorts, containerPorts)
+}
+
+func TestOpentelemetryOtlpDefaultGetContainerPorts(t *testing.T) {
+	cfg := getStringFromFile("./test-resources/opentelemetryOtlpDefault.json")
+	wantPorts := []corev1.ContainerPort{
+		{
+			Name:          OtlpGrpc,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4317),
+		},
+		{
+			Name:          OtlpHttp,
+			Protocol:      corev1.ProtocolTCP,
+			ContainerPort: int32(4318),
+		},
+	}
+	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
+	checkPorts(t, wantPorts, containerPorts)
+}
+
+// None of the other opentelemetry.collect sources listen on a port.
+func TestOpentelemetryNoOtlpGetContainerPorts(t *testing.T) {
+	cfg := getStringFromFile("./test-resources/opentelemetryNoOtlp.json")
+	config, err := adapters.ConfigStructFromJSONString(cfg)
+	assert.NoError(t, err)
+	assert.Nil(t, config.Opentelemetry.Collect.OTLP)
+	assert.Empty(t, getContainerPorts(logger, cfg, "", []corev1.ServicePort{}))
 }
 
 func TestValidJSONAndValidOtelConfig(t *testing.T) {

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -443,7 +443,7 @@ func TestOpentelemetryNoOtlpGetContainerPorts(t *testing.T) {
 	cfg := getStringFromFile("./test-resources/opentelemetryNoOtlp.json")
 	config, err := adapters.ConfigStructFromJSONString(cfg)
 	assert.NoError(t, err)
-	assert.Nil(t, config.Opentelemetry.Collect.OTLP)
+	assert.Nil(t, config.OpenTelemetry.Collect.OTLP)
 	assert.Empty(t, getContainerPorts(logger, cfg, "", []corev1.ServicePort{}))
 }
 

--- a/internal/manifests/collector/test-resources/opentelemetryNoOtlp.json
+++ b/internal/manifests/collector/test-resources/opentelemetryNoOtlp.json
@@ -1,0 +1,10 @@
+{
+  "opentelemetry": {
+    "collect": {
+      "container_insights": {},
+      "prometheus": {
+        "config_path": "/etc/prometheus/prometheus.yaml"
+      }
+    }
+  }
+}

--- a/internal/manifests/collector/test-resources/opentelemetryOtlp.json
+++ b/internal/manifests/collector/test-resources/opentelemetryOtlp.json
@@ -1,0 +1,10 @@
+{
+  "opentelemetry": {
+    "collect": {
+      "otlp": {
+        "grpc_endpoint": "0.0.0.0:1234",
+        "http_endpoint": "0.0.0.0:2345"
+      }
+    }
+  }
+}

--- a/internal/manifests/collector/test-resources/opentelemetryOtlpDefault.json
+++ b/internal/manifests/collector/test-resources/opentelemetryOtlpDefault.json
@@ -1,0 +1,10 @@
+{
+  "opentelemetry": {
+    "collect": {
+      "container_insights": {},
+      "otlp": {
+        "span_metrics_enabled": true
+      }
+    }
+  }
+}

--- a/pkg/instrumentation/apachehttpd_test.go
+++ b/pkg/instrumentation/apachehttpd_test.go
@@ -69,7 +69,7 @@ func TestInjectApacheHttpdagent(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "foo/bar:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,
@@ -161,7 +161,7 @@ func TestInjectApacheHttpdagent(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "foo/bar:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/opt/customPath"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/opt/customPath"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,
@@ -254,7 +254,7 @@ func TestInjectApacheHttpdagent(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "foo/bar:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,
@@ -352,7 +352,7 @@ func TestInjectApacheHttpdagent(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "foo/bar:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,
@@ -462,7 +462,7 @@ func TestInjectApacheHttpdagentUnknownNamespace(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "foo/bar:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,
@@ -570,7 +570,6 @@ func TestApacheInitContainerMissing(t *testing.T) {
 		})
 	}
 }
-
 
 // TestApacheHttpd_ConfigPath_PositionalArg_NoSplice exercises the P431312609
 // hardening: the user-controlled ApacheHttpd.ConfigPath value must reach the

--- a/pkg/instrumentation/nginx_test.go
+++ b/pkg/instrumentation/nginx_test.go
@@ -625,7 +625,6 @@ func TestNginxInitContainerMissing(t *testing.T) {
 	}
 }
 
-
 // TestNginx_ConfigFile_PositionalArg_NoSplice exercises the P431312609
 // hardening: the user-controlled Nginx.ConfigFile value must reach BOTH the
 // clone and attach init containers only as a positional argument ($1), never

--- a/pkg/instrumentation/podmutator_test.go
+++ b/pkg/instrumentation/podmutator_test.go
@@ -2752,7 +2752,7 @@ func TestMutatePod(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "otel/apache-httpd:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,

--- a/pkg/instrumentation/sdk_test.go
+++ b/pkg/instrumentation/sdk_test.go
@@ -1657,7 +1657,7 @@ func TestInjectApacheHttpd(t *testing.T) {
 							Name:    apacheAgentInitContainerName,
 							Image:   "img:1",
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
+							Args:    []string{apacheHttpdAgentScript, "--", "/usr/local/apache2/conf"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  apacheAttributesEnvVar,


### PR DESCRIPTION
### Description
An agent that is configured with `opentelemetry.collect.otlp` gets no container ports or service ports, so nothing can send it telemetry.

Updates the configuration parsing to understand the `opentelemetry` section. Currently, `otlp` is the only source under `opentelemetry.collect` that binds ports.

### Testing
Added unit tests to verify that the ports can be derived.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
