### PR TITLE
fix: Accept jmx config as object or array

### DIFF
--- a/internal/manifests/collector/adapters/config_from.go
+++ b/internal/manifests/collector/adapters/config_from.go
@@ -7,6 +7,7 @@ package adapters
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v2"
 )
@@ -101,7 +102,25 @@ type AppSignals struct {
 type emf struct {
 }
 
+// jmx marks the presence of the jmx section in the agent configuration. The
+// CloudWatch agent accepts this section as either a single object or an array
+// of objects (one entry per JMX target), so unmarshalling must tolerate both.
+// The operator only cares about presence, not contents.
 type jmx struct{}
+
+// UnmarshalJSON accepts both the object and array forms of the jmx section.
+func (j *jmx) UnmarshalJSON(data []byte) error {
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	switch value.(type) {
+	case map[string]any, []any:
+		return nil
+	default:
+		return fmt.Errorf("invalid jmx configuration: expected object or array, got %T", value)
+	}
+}
 
 type kubernetes struct {
 	EnhancedContainerInsights bool `json:"enhanced_container_insights,omitempty"`

--- a/internal/manifests/collector/adapters/config_from_test.go
+++ b/internal/manifests/collector/adapters/config_from_test.go
@@ -26,3 +26,20 @@ func TestEmptyString(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, res, 0)
 }
+
+func TestConfigStructFromJSONStringJMXObject(t *testing.T) {
+	config, err := adapters.ConfigStructFromJSONString(`{"metrics":{"metrics_collected":{"jmx":{"jvm":{"measurement":["jvm.memory.heap.used"]}}}}}`)
+	assert.NoError(t, err)
+	assert.NotNil(t, config.Metrics.MetricsCollected.JMX)
+}
+
+func TestConfigStructFromJSONStringJMXArray(t *testing.T) {
+	config, err := adapters.ConfigStructFromJSONString(`{"metrics":{"metrics_collected":{"jmx":[{"endpoint":"localhost:9999","jvm":{}},{"endpoint":"localhost:9998","kafka-consumer":{}}]}}}`)
+	assert.NoError(t, err)
+	assert.NotNil(t, config.Metrics.MetricsCollected.JMX)
+}
+
+func TestConfigStructFromJSONStringJMXInvalidType(t *testing.T) {
+	_, err := adapters.ConfigStructFromJSONString(`{"metrics":{"metrics_collected":{"jmx":"invalid"}}}`)
+	assert.Error(t, err)
+}

--- a/internal/manifests/collector/adapters/config_from_test.go
+++ b/internal/manifests/collector/adapters/config_from_test.go
@@ -34,7 +34,7 @@ func TestConfigStructFromJSONStringJMXObject(t *testing.T) {
 }
 
 func TestConfigStructFromJSONStringJMXArray(t *testing.T) {
-	config, err := adapters.ConfigStructFromJSONString(`{"metrics":{"metrics_collected":{"jmx":[{"endpoint":"localhost:9999","jvm":{}},{"endpoint":"localhost:9998","kafka-consumer":{}}]}}}`)
+	config, err := adapters.ConfigStructFromJSONString(`{"metrics":{"metrics_collected":{"jmx":[{"jvm":{}},{"kafka-consumer":{}}]}}}`)
 	assert.NoError(t, err)
 	assert.NotNil(t, config.Metrics.MetricsCollected.JMX)
 }

--- a/internal/manifests/collector/ports_test.go
+++ b/internal/manifests/collector/ports_test.go
@@ -532,6 +532,15 @@ func TestJMXGetContainerPorts(t *testing.T) {
 	assert.Equal(t, corev1.ProtocolTCP, containerPorts[JmxHttp].Protocol)
 }
 
+func TestJMXArrayGetContainerPorts(t *testing.T) {
+	cfg := getJSONStringFromFile("./test-resources/jmxAgentArrayConfig.json")
+	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})
+	assert.Equal(t, 1, len(containerPorts))
+	assert.Equal(t, int32(4314), containerPorts[JmxHttp].ContainerPort)
+	assert.Equal(t, JmxHttp, containerPorts[JmxHttp].Name)
+	assert.Equal(t, corev1.ProtocolTCP, containerPorts[JmxHttp].Protocol)
+}
+
 func TestJMXContainerInsightsGetContainerPorts(t *testing.T) {
 	cfg := getJSONStringFromFile("./test-resources/jmxContainerInsightsConfig.json")
 	containerPorts := getContainerPorts(logger, cfg, "", []corev1.ServicePort{})

--- a/internal/manifests/collector/test-resources/jmxAgentArrayConfig.json
+++ b/internal/manifests/collector/test-resources/jmxAgentArrayConfig.json
@@ -3,7 +3,6 @@
     "metrics_collected": {
       "jmx": [
         {
-          "endpoint": "localhost:9999",
           "jvm": {
             "measurement": [
               "jvm.memory.heap.used"
@@ -11,7 +10,6 @@
           }
         },
         {
-          "endpoint": "localhost:9998",
           "kafka-consumer": {
             "measurement": [
               "kafka.consumer.fetch-rate"

--- a/internal/manifests/collector/test-resources/jmxAgentArrayConfig.json
+++ b/internal/manifests/collector/test-resources/jmxAgentArrayConfig.json
@@ -1,0 +1,24 @@
+{
+  "metrics": {
+    "metrics_collected": {
+      "jmx": [
+        {
+          "endpoint": "localhost:9999",
+          "jvm": {
+            "measurement": [
+              "jvm.memory.heap.used"
+            ]
+          }
+        },
+        {
+          "endpoint": "localhost:9998",
+          "kafka-consumer": {
+            "measurement": [
+              "kafka.consumer.fetch-rate"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:* Added a custom UnmarshalJSON on the jmx marker struct in `internal/manifests/collector/adapters/config_from.go` that accepts both  a single object or an array and returns an error for any other type.
The field remains a `*jmx` pointer, so all existing presence checks (e.g. in `ports.go` and `controllers/common.go`) work unchanged; no call sites needed modification. 

*Testing*: 
- Added unit testing `TestConfigStructFromJSONString`.
- Manual E2E test on EKS cluster:
   - Built the operator image from this branch and deployed it via `make deploy`
   - Applied an AmazonCloudWatchAgent CR (daemonset mode) with jmx configured as a two-element array
   - Verified: cloudwatch-agent and cloudwatch-agent-headless Services are created with port 4314/TCP, persist across   reconciles, and no config-parsing errors appear in the operator logs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
