### PR TITLE
Fix injected annotation removal check

### DIFF
--- a/pkg/instrumentation/annotationmutator.go
+++ b/pkg/instrumentation/annotationmutator.go
@@ -35,7 +35,7 @@ func NewInsertAnnotationMutation(annotations map[string]string) AnnotationMutati
 }
 
 type removeAnnotationMutation struct {
-	remove []string
+	remove map[string]string
 }
 
 func (m *removeAnnotationMutation) Mutate(annotations map[string]string) map[string]string {
@@ -43,7 +43,7 @@ func (m *removeAnnotationMutation) Mutate(annotations map[string]string) map[str
 	if !m.shouldMutate(annotations) {
 		return mutatedAnnotations
 	}
-	for _, key := range m.remove {
+	for key := range m.remove {
 		if value, ok := annotations[key]; ok {
 			delete(annotations, key)
 			mutatedAnnotations[key] = value
@@ -52,18 +52,22 @@ func (m *removeAnnotationMutation) Mutate(annotations map[string]string) map[str
 	return mutatedAnnotations
 }
 
+// shouldMutate reports whether every managed key is present AND still carries the value the operator
+// injected. A key present with a different value (e.g. an explicit "false" opt-out set by the user) means
+// the annotation is not operator-owned, so the mutation must not remove it.
 func (m *removeAnnotationMutation) shouldMutate(annotations map[string]string) bool {
-	for _, key := range m.remove {
-		if _, ok := annotations[key]; !ok {
+	for key, managedValue := range m.remove {
+		if value, ok := annotations[key]; !ok || value != managedValue {
 			return false
 		}
 	}
 	return true
 }
 
-// NewRemoveAnnotationMutation creates a new mutation that removes annotations. All provided annotation keys
-// must be present for it to attempt to remove them.
-func NewRemoveAnnotationMutation(annotations []string) AnnotationMutation {
+// NewRemoveAnnotationMutation creates a new mutation that removes annotations. It only removes the provided
+// keys when all of them are present and each still carries the value it maps to (the value the operator
+// injected), so user-authored values are never destroyed.
+func NewRemoveAnnotationMutation(annotations map[string]string) AnnotationMutation {
 	return &removeAnnotationMutation{remove: annotations}
 }
 

--- a/pkg/instrumentation/annotationmutator_test.go
+++ b/pkg/instrumentation/annotationmutator_test.go
@@ -79,9 +79,9 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyB": "2",
 			},
 			mutations: []AnnotationMutation{
-				NewRemoveAnnotationMutation([]string{
-					"keyA",
-					"keyC",
+				NewRemoveAnnotationMutation(map[string]string{
+					"keyA": "1",
+					"keyC": "4",
 				}),
 			},
 			wantAnnotations: map[string]string{
@@ -96,9 +96,9 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyB": "2",
 			},
 			mutations: []AnnotationMutation{
-				NewRemoveAnnotationMutation([]string{
-					"keyA",
-					"keyB",
+				NewRemoveAnnotationMutation(map[string]string{
+					"keyA": "1",
+					"keyB": "2",
 				}),
 			},
 			wantAnnotations: map[string]string{},
@@ -113,11 +113,11 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyB": "2",
 			},
 			mutations: []AnnotationMutation{
-				NewRemoveAnnotationMutation([]string{
-					"keyA",
+				NewRemoveAnnotationMutation(map[string]string{
+					"keyA": "1",
 				}),
-				NewRemoveAnnotationMutation([]string{
-					"keyB",
+				NewRemoveAnnotationMutation(map[string]string{
+					"keyB": "2",
 				}),
 			},
 			wantAnnotations: map[string]string{},
@@ -126,14 +126,33 @@ func TestMutateAnnotations(t *testing.T) {
 				"keyB": "2",
 			},
 		},
+		"TestRemove/PreservesUserValue": {
+			// A managed key present with a value other than the one the operator injected
+			// (e.g. an explicit "false" opt-out) must not be removed.
+			annotations: map[string]string{
+				"keyA": "false",
+				"keyB": "2",
+			},
+			mutations: []AnnotationMutation{
+				NewRemoveAnnotationMutation(map[string]string{
+					"keyA": "true",
+					"keyB": "2",
+				}),
+			},
+			wantAnnotations: map[string]string{
+				"keyA": "false",
+				"keyB": "2",
+			},
+			wantMutatedAnnotations: map[string]string{},
+		},
 		"TestBoth": {
 			annotations: map[string]string{
 				"keyA": "1",
 				"keyB": "2",
 			},
 			mutations: []AnnotationMutation{
-				NewRemoveAnnotationMutation([]string{
-					"keyA",
+				NewRemoveAnnotationMutation(map[string]string{
+					"keyA": "1",
 				}),
 				NewInsertAnnotationMutation(map[string]string{
 					"keyA": "3",

--- a/pkg/instrumentation/auto/annotation.go
+++ b/pkg/instrumentation/auto/annotation.go
@@ -231,7 +231,7 @@ func newMutatorBuilder(typeSet instrumentation.TypeSet) *mutatorBuilder {
 func buildMutations(instType instrumentation.Type) (instrumentation.AnnotationMutation, instrumentation.AnnotationMutation) {
 	annotations := buildAnnotations(instType)
 	return instrumentation.NewInsertAnnotationMutation(annotations),
-		instrumentation.NewRemoveAnnotationMutation(maps.Keys(annotations))
+		instrumentation.NewRemoveAnnotationMutation(annotations)
 }
 
 // buildAnnotations creates an annotation map of the inject and auto-annotate keys.


### PR DESCRIPTION
### Description of the issue
The operator's auto-annotation flow can delete explicit opt-out annotations and then re-enable instrumentation that had previously been explicitly disabled.

For each instrumentation type, the operator pairs an insert mutation (adds the managed annotation keys with the value set to "true" when missing) with a remove mutation (deletes the same keys). Both are built from the same key/value pairs
```
  - instrumentation.opentelemetry.io/inject-{java,python,dotnet,nodejs}: "true"
  - cloudwatch.aws.amazon.com/auto-annotate-{java,python,dotnet,nodejs}: "true"
```
but the remove mutation only matches the keys when determining whether they should be deleted.

So if a pod has both managed keys and sets them to "false" to opt out, the remove mutation still sees them as operator owned and will remove them. Once removed, the opt-out is gone and the keys get repopulated with "true" on the next update re-enabling injection.

### Description of change
Updated the remove mutation so it only removes annotations the operator actually added by checking the values as well as the keys. It removes the managed annotation pair only when the current values still match the injected values, so an explicit "false" opt-out is preserved.

### Testing
Added a test case to the existing unit tests to assert that a value set to "false" survives when the managed value is "true".

Built the image and installed it on an EKS cluster using the `amazon-cloudwatch-observability` helm chart with `autoMonitor.monitorAllServices: true`. Used a test Deployment with a pod template that set `instrumentation.opentelemetry.io/inject-java: "false"` and `cloudwatch.aws.amazon.com/auto-annotate-java: "false"`.

Reproduced the issue using the current operator `3.7.0`. On create, the webhook deleted both of the "false" opt-outs. After adding a Service that points to the workload and triggering an update, the managed keys for all 4 supported languages get added including the Java ones.

With the fixed operator, the java opt-outs are preserved on create and after the update (only the 3 other language managed annotations got added). Verified that removing the Service still resulted in all the operator's managed keys (the other 3 languages) getting removed and leaving the opt-outs.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
