### PR TITLE
ci: Fix integ-test container build and webhook readiness race

### DIFF
--- a/.github/actions/prepare-operator-minikube-image/action.yml
+++ b/.github/actions/prepare-operator-minikube-image/action.yml
@@ -28,13 +28,36 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Set up Docker Buildx
+      # Explicit buildx setup pins the BuildKit driver image via the pinned
+      # action release, avoiding the implicit
+      # 'moby/buildkit:buildx-stable-1' pull that 'docker buildx build'
+      # otherwise triggers. Match the pin used by build-and-upload.yml.
+      if: ${{ inputs.operator-image-digest == '' }}
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
     - name: Build image from source
+      # Build against the host Docker daemon (using the buildx builder set up
+      # above) and then push the image into minikube explicitly, mirroring the
+      # digest-validation path below. Previously this step ran
+      # 'eval $(minikube docker-env) && make container', which forced
+      # 'docker buildx build' to bootstrap its own builder inside minikube's
+      # containerd; that path re-pulls moby/buildkit:buildx-stable-1 and has
+      # been unreliable (docker inspect returns 404 after a "successful"
+      # manifest fetch), breaking the entire integ-test matrix.
       if: ${{ inputs.operator-image-digest == '' }}
       shell: bash
       run: |
-        eval $(minikube docker-env)
+        set -euo pipefail
         make container
-        docker images
+        # Compute the tag the Makefile just produced. Mirrors the Makefile's
+        # own default (IMG ?= ${IMG_PREFIX}/${IMG_REPO}:${VERSION}) so that a
+        # bumped versions.txt is picked up without workflow edits.
+        VERSION=$(grep -v '^#' versions.txt | awk -F= '/^operator=/{print $2; exit}')
+        IMG="aws/cloudwatch-agent-operator:${VERSION}"
+        docker images "$IMG"
+        minikube image load "$IMG"
+        minikube image ls | grep cloudwatch-agent-operator || true
 
     - name: Configure AWS credentials
       if: ${{ inputs.operator-image-digest != '' }}

--- a/.github/actions/prepare-operator-minikube-image/action.yml
+++ b/.github/actions/prepare-operator-minikube-image/action.yml
@@ -120,22 +120,34 @@ runs:
         # available replicas and has no zero-object race.
         kubectl rollout status deployment/cloudwatch-controller-manager -n amazon-cloudwatch --timeout=180s
 
-        # The mutating/validating webhooks are served by the operator pod via
-        # the cloudwatch-webhook-service. A Ready pod does not guarantee the
-        # Endpoints object is programmed (kube-proxy/endpoint controller lag),
-        # which manifests as 'connection refused' when the first CR is applied.
-        # Poll until the webhook service has at least one endpoint address.
+        # The manager Deployment carries no readiness probe and the binary's
+        # /readyz is a plain ping that does not gate on the webhook TLS
+        # server being bound. A Ready pod and populated Endpoints therefore
+        # do not guarantee admission calls will succeed. The only reliable
+        # readiness signal is exercising the webhook itself: a server-side
+        # dry-run create passes through the mutating+validating admission
+        # chain without persisting anything.
+        cat > /tmp/webhook-probe-cr.yaml <<'EOF'
+        apiVersion: cloudwatch.aws.amazon.com/v1alpha1
+        kind: AmazonCloudWatchAgent
+        metadata:
+          name: webhook-readiness-probe
+          namespace: amazon-cloudwatch
+        spec:
+          mode: statefulset
+          config: '{"logs":{"metrics_collected":{"application_signals":{}}}}'
+        EOF
         for i in $(seq 1 36); do
-          addrs=$(kubectl get endpoints cloudwatch-webhook-service -n amazon-cloudwatch \
-            -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)
-          if [ -n "$addrs" ]; then
-            echo "Webhook service endpoints ready: $addrs"
+          if kubectl apply --dry-run=server -f /tmp/webhook-probe-cr.yaml > /dev/null 2>&1; then
+            echo "Webhook admission chain is serving (attempt $i)"
             exit 0
           fi
-          echo "Waiting for webhook service endpoints... ($i/36)"
+          echo "Waiting for webhook to serve admission requests... ($i/36)"
           sleep 5
         done
-        echo "::error::cloudwatch-webhook-service never got endpoints"
+        echo "::error::operator webhook never became ready"
+        kubectl apply --dry-run=server -f /tmp/webhook-probe-cr.yaml || true
         kubectl get endpoints -n amazon-cloudwatch || true
         kubectl get pods -n amazon-cloudwatch -o wide || true
+        kubectl logs -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-agent-operator --tail=100 || true
         exit 1

--- a/.github/actions/prepare-operator-minikube-image/action.yml
+++ b/.github/actions/prepare-operator-minikube-image/action.yml
@@ -111,4 +111,31 @@ runs:
 
     - name: Wait for operator ready
       shell: bash
-      run: kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch --timeout=180s
+      run: |
+        set -euo pipefail
+        # 'kubectl wait --for=condition=Ready pod --all' succeeds immediately
+        # when zero pods exist, which is exactly the state right after
+        # 'make deploy' (the ReplicaSet may not have created the pod yet).
+        # Wait on the deployment rollout instead — it tracks desired vs
+        # available replicas and has no zero-object race.
+        kubectl rollout status deployment/cloudwatch-controller-manager -n amazon-cloudwatch --timeout=180s
+
+        # The mutating/validating webhooks are served by the operator pod via
+        # the cloudwatch-webhook-service. A Ready pod does not guarantee the
+        # Endpoints object is programmed (kube-proxy/endpoint controller lag),
+        # which manifests as 'connection refused' when the first CR is applied.
+        # Poll until the webhook service has at least one endpoint address.
+        for i in $(seq 1 36); do
+          addrs=$(kubectl get endpoints cloudwatch-webhook-service -n amazon-cloudwatch \
+            -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)
+          if [ -n "$addrs" ]; then
+            echo "Webhook service endpoints ready: $addrs"
+            exit 0
+          fi
+          echo "Waiting for webhook service endpoints... ($i/36)"
+          sleep 5
+        done
+        echo "::error::cloudwatch-webhook-service never got endpoints"
+        kubectl get endpoints -n amazon-cloudwatch || true
+        kubectl get pods -n amazon-cloudwatch -o wide || true
+        exit 1


### PR DESCRIPTION
## Description

Two reliability fixes for the Operator Integration Test workflow, both in `.github/actions/prepare-operator-minikube-image/action.yml`:

### 1. Container build: buildx bootstrap 404

Every PR's integ-test matrix had been failing at `make container`:

```
#1 pulling image moby/buildkit:buildx-stable-1 3.0s done
#1 ERROR: failed to inspect pulled image moby/buildkit:buildx-stable-1:
    Error response from daemon: 404 page not found
```

The action ran `eval $(minikube docker-env) && make container`, pointing `docker buildx build --load` at minikube's containerd where no buildx builder exists. buildx then autobootstraps one by pulling the floating `moby/buildkit:buildx-stable-1` tag, which has been failing `docker inspect` with 404s.

Fix: set up buildx explicitly on the host via `docker/setup-buildx-action` (same pin the release workflow uses), build on the host daemon, then `minikube image load` the result — mirroring the digest-validation branch of the same action.

Verified working in this PR's own CI: the operator image now builds and loads (`Container image "aws/cloudwatch-agent-operator:2.0.1" already present on machine`).

### 2. Webhook readiness race

`InstrumentationTest` (and occasionally others) failed at the first CR apply:

```
failed calling webhook "mamazoncloudwatchagent.kb.io": ... connect: connection refused
```

The 'Wait for operator ready' step used `kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch` — which **succeeds immediately when zero pods match**, the normal state right after `make deploy` before the ReplicaSet creates the pod. Event logs on the failing run show the operator pod was ~1s old when the CR was applied.

Fix:
1. `kubectl rollout status deployment/cloudwatch-controller-manager` — no zero-object race.
2. Poll the `cloudwatch-webhook-service` Endpoints object until it has at least one address, since a Ready pod doesn't guarantee service endpoints are programmed.

## Blocking

Unblocks #410 and any other open PR running the Operator Integration Test.